### PR TITLE
feat(server): add configurable TOON results

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -295,6 +295,7 @@ dependencies = [
  "tokio",
  "tokio-util",
  "toml",
+ "toon-format",
  "tracing",
  "tracing-subscriber",
  "uuid",
@@ -2417,6 +2418,7 @@ version = "1.0.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
 dependencies = [
+ "indexmap",
  "itoa",
  "memchr",
  "serde",
@@ -2805,6 +2807,18 @@ name = "toml_writer"
 version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d56353a2a665ad0f41a421187180aab746c8c325620617ad883a99a1cbe66d2"
+
+[[package]]
+name = "toon-format"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f89570c1a68d73941f728cca32a4345b2ffca36667ad921af336c60309a3e7e"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_json",
+ "thiserror",
+]
 
 [[package]]
 name = "tracing"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,7 @@ schemars = "1"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 sha2 = "0.10"
+toon-format = { version = "0.5", default-features = false }
 toml = "0.9"
 uuid = { version = "1", features = ["serde", "v7"] }
 

--- a/README.md
+++ b/README.md
@@ -39,6 +39,11 @@ All invocation data remains in the configured local cache. `clean`, `run`, and
 `shutdown` are denied by default, shell evaluation is never used, and server-
 owned BEP/output-root flags cannot be overridden by a request.
 
+Tool-result encoding is configured with `result_encoding`. The default, `text`,
+returns compact JSON in one MCP text block. Set it to `toon` for a token-oriented
+TOON text block, `structured` for MCP structured content, or `both` for
+structured content plus backwards-compatible JSON text.
+
 ## Development
 
 ```sh

--- a/crates/bazel-mcp-server/Cargo.toml
+++ b/crates/bazel-mcp-server/Cargo.toml
@@ -30,6 +30,7 @@ serde.workspace = true
 serde_json.workspace = true
 tokio.workspace = true
 tokio-util.workspace = true
+toon-format.workspace = true
 toml.workspace = true
 tracing.workspace = true
 tracing-subscriber.workspace = true

--- a/crates/bazel-mcp-server/src/config.rs
+++ b/crates/bazel-mcp-server/src/config.rs
@@ -13,6 +13,7 @@ use serde::{Deserialize, Serialize};
 pub enum ResultEncoding {
     #[default]
     Text,
+    Toon,
     Structured,
     Both,
 }
@@ -310,5 +311,27 @@ mod tests {
         .unwrap();
 
         assert!(ServerConfig::load(&cli(path)).is_err());
+    }
+
+    #[test]
+    fn loads_each_configured_result_encoding() {
+        let root = tempdir().unwrap();
+        let workspace = root.path().join("workspace");
+        fs::create_dir(&workspace).unwrap();
+
+        for (name, expected) in [
+            ("text", ResultEncoding::Text),
+            ("toon", ResultEncoding::Toon),
+            ("structured", ResultEncoding::Structured),
+            ("both", ResultEncoding::Both),
+        ] {
+            let path = write_config(
+                root.path(),
+                &workspace,
+                &format!("result_encoding = {name:?}\n"),
+            );
+            let config = ServerConfig::load(&cli(path)).unwrap();
+            assert_eq!(config.result_encoding, expected);
+        }
     }
 }

--- a/crates/bazel-mcp-server/src/handler.rs
+++ b/crates/bazel-mcp-server/src/handler.rs
@@ -283,33 +283,53 @@ impl BazelMcpServer {
             "query_results" => InspectView::QueryResults,
             other => return Err(format!("unsupported inspection view: {other}")),
         };
-        let result = self
-            .runner
-            .inspect(InspectRequest {
-                invocation_id: Some(id),
-                workspace: None,
-                view,
-                cursor: params.cursor,
-                filter: params.filter,
-                limit: params.limit.unwrap_or(20).clamp(1, 100),
-                max_bytes: self.single_representation_budget(8 * 1024),
-            })
-            .await
-            .map_err(|error| error.to_string())?;
-        let value = serde_json::to_value(result).map_err(|error| error.to_string())?;
-        let bytes = self.model_visible_bytes(&value)?;
-        if let Err(error) = self
-            .runner
-            .record_model_visible_result(id, bytes, true)
-            .await
-        {
-            tracing::warn!(
-                invocation_id = %id,
-                %error,
-                "could not persist model-visible inspection metrics"
-            );
+        let visible_budget = 8 * 1024;
+        let mut representation_budget = self.single_representation_budget(visible_budget);
+        loop {
+            let result = self
+                .runner
+                .inspect(InspectRequest {
+                    invocation_id: Some(id),
+                    workspace: None,
+                    view,
+                    cursor: params.cursor.clone(),
+                    filter: params.filter.clone(),
+                    limit: params.limit.unwrap_or(20).clamp(1, 100),
+                    max_bytes: representation_budget,
+                })
+                .await
+                .map_err(|error| error.to_string())?;
+            let value = serde_json::to_value(result).map_err(|error| error.to_string())?;
+            let bytes = self.model_visible_bytes(&value)?;
+            if bytes > visible_budget {
+                let proportional_budget = representation_budget
+                    .saturating_mul(visible_budget)
+                    .checked_div(bytes)
+                    .unwrap_or_default();
+                let headroom = (proportional_budget / 20).max(1);
+                representation_budget = proportional_budget
+                    .saturating_sub(headroom)
+                    .min(representation_budget.saturating_sub(1));
+                if representation_budget == 0 {
+                    return Err(
+                        "bounded bazel.inspect response could not fit its hard byte limit".into(),
+                    );
+                }
+                continue;
+            }
+            if let Err(error) = self
+                .runner
+                .record_model_visible_result(id, bytes, true)
+                .await
+            {
+                tracing::warn!(
+                    invocation_id = %id,
+                    %error,
+                    "could not persist model-visible inspection metrics"
+                );
+            }
+            return self.encode(value);
         }
-        self.encode(value)
     }
 
     #[tool(
@@ -333,25 +353,32 @@ impl BazelMcpServer {
 impl BazelMcpServer {
     fn single_representation_budget(&self, visible_budget: usize) -> usize {
         match self.result_encoding {
-            ResultEncoding::Text | ResultEncoding::Structured => visible_budget,
+            ResultEncoding::Text | ResultEncoding::Toon | ResultEncoding::Structured => {
+                visible_budget
+            }
             ResultEncoding::Both => visible_budget / 2,
         }
     }
 
     fn model_visible_bytes(&self, value: &serde_json::Value) -> Result<usize, String> {
-        let bytes = serde_json::to_vec(value)
-            .map_err(|error| error.to_string())?
-            .len();
-        Ok(match self.result_encoding {
-            ResultEncoding::Text | ResultEncoding::Structured => bytes,
-            ResultEncoding::Both => bytes.saturating_mul(2),
-        })
+        match self.result_encoding {
+            ResultEncoding::Text | ResultEncoding::Structured => serde_json::to_vec(value)
+                .map(|bytes| bytes.len())
+                .map_err(|error| error.to_string()),
+            ResultEncoding::Toon => Self::encode_toon(value).map(|text| text.len()),
+            ResultEncoding::Both => serde_json::to_vec(value)
+                .map(|bytes| bytes.len().saturating_mul(2))
+                .map_err(|error| error.to_string()),
+        }
     }
 
     fn encode(&self, value: serde_json::Value) -> Result<CallToolResult, String> {
         Ok(match self.result_encoding {
             ResultEncoding::Text => {
                 CallToolResult::success(vec![ContentBlock::text(value.to_string())])
+            }
+            ResultEncoding::Toon => {
+                CallToolResult::success(vec![ContentBlock::text(Self::encode_toon(&value)?)])
             }
             ResultEncoding::Structured => {
                 let mut result = CallToolResult::default();
@@ -361,6 +388,10 @@ impl BazelMcpServer {
             }
             ResultEncoding::Both => CallToolResult::structured(value),
         })
+    }
+
+    fn encode_toon(value: &serde_json::Value) -> Result<String, String> {
+        toon_format::encode_default(value).map_err(|error| format!("encode TOON result: {error}"))
     }
 }
 
@@ -386,7 +417,7 @@ mod tests {
     use super::*;
 
     #[tokio::test]
-    async fn both_encoding_charges_and_budgets_both_visible_representations() {
+    async fn result_encodings_charge_their_model_visible_representations() {
         let root = tempdir().unwrap();
         let runner = InvocationService::new(
             Store::open(root.path()).await.unwrap(),
@@ -399,6 +430,20 @@ mod tests {
         let text = BazelMcpServer::new(runner.clone(), ResultEncoding::Text);
         assert_eq!(text.model_visible_bytes(&value).unwrap(), one);
         assert_eq!(text.single_representation_budget(8_192), 8_192);
+
+        let toon = BazelMcpServer::new(runner.clone(), ResultEncoding::Toon);
+        let toon_text = BazelMcpServer::encode_toon(&value).unwrap();
+        assert_eq!(toon.model_visible_bytes(&value).unwrap(), toon_text.len());
+        assert_eq!(toon.single_representation_budget(8_192), 8_192);
+        let decoded: serde_json::Value = toon_format::decode_default(&toon_text).unwrap();
+        assert_eq!(decoded, value);
+        let result = toon.encode(value.clone()).unwrap();
+        assert_eq!(result.structured_content, None);
+        assert_eq!(result.content.len(), 1);
+        let Some(ContentBlock::Text(content)) = result.content.first() else {
+            panic!("TOON result did not contain one text block");
+        };
+        assert_eq!(content.text, toon_text);
 
         let both = BazelMcpServer::new(runner, ResultEncoding::Both);
         assert_eq!(both.model_visible_bytes(&value).unwrap(), one * 2);

--- a/examples/config.toml
+++ b/examples/config.toml
@@ -9,4 +9,5 @@ progress_interval_seconds = 60
 redaction_patterns = ["(?i)token=[^\\s]+"]
 retention_days = 7
 maximum_storage_bytes = 10737418240
+# Model-visible tool results: "text" (compact JSON), "toon", "structured", or "both".
 result_encoding = "text"

--- a/specs/001-product-requirements.md
+++ b/specs/001-product-requirements.md
@@ -349,17 +349,18 @@ workspace or the invocation store.
 
 ### 8.5 Result encoding
 
-The server supports three deployment-level result encodings:
+The server supports four deployment-level result encodings:
 
 - `text`: one compact JSON `TextContent` block and no duplicate
   `structuredContent`; this is the default.
+- `toon`: one TOON-encoded `TextContent` block and no duplicate
+  `structuredContent`.
 - `structured`: structured content for hosts proven to handle it without placing
   a duplicate representation in model context.
 - `both`: structured content plus the backwards-compatible text representation.
 
 The encoding is server configuration, not a per-call argument. The benchmark
-MUST use the encoding intended for the production MCP host. TOON is not included
-in the MVP.
+MUST use the encoding intended for the production MCP host.
 
 ## 9. Workspace and Bazel discovery
 


### PR DESCRIPTION
## Summary

- add `toon` as a deployment-level `result_encoding` alongside `text`, `structured`, and `both`
- encode model-visible results with `toon-format` while preserving a single MCP text representation
- account for actual TOON bytes and re-bound inspection responses to preserve hard output limits
- document the configuration and cover every encoding with tests

## Why

JSON text remains the backwards-compatible default, but deployments can now select TOON when a token-oriented representation is preferable. The setting remains server-wide rather than per-call, so tool schemas stay unchanged.

## Validation

- `make build`
- `make test`
- `make check`
- `make mcp-conformance`
