### PR TITLE
perf(bep): adopt Buffa zero-copy views

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -212,11 +212,13 @@ name = "bazel-mcp-benchmark"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "bazel-mcp-bep",
  "bazel-mcp-reducer",
  "clap",
  "criterion",
  "serde",
  "serde_json",
+ "sha2",
  "tiktoken-rs",
  "tokio",
  "toml",
@@ -226,9 +228,9 @@ dependencies = [
 name = "bazel-mcp-bep"
 version = "0.1.0"
 dependencies = [
+ "buffa",
+ "buffa-build",
  "proptest",
- "prost",
- "prost-build",
  "protoc-bin-vendored",
  "thiserror",
 ]
@@ -251,7 +253,6 @@ version = "0.1.0"
 dependencies = [
  "bazel-mcp-bep",
  "bazel-mcp-types",
- "prost",
  "quick-xml",
  "serde",
  "thiserror",
@@ -421,6 +422,61 @@ dependencies = [
  "memchr",
  "regex-automata",
  "serde_core",
+]
+
+[[package]]
+name = "buffa"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33f29a40702df4b86ccd84211bfde8cee0bce6d0811450ade4a86a7d0958a23a"
+dependencies = [
+ "bytes",
+ "foldhash",
+ "hashbrown 0.15.5",
+ "once_cell",
+ "rustversion",
+ "serde",
+ "serde_json",
+ "smoothutf8",
+ "thiserror",
+]
+
+[[package]]
+name = "buffa-build"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef33217cabddfad99c0a54d42ddb7ca5b73fa492f7b16ddb621132ef51107556"
+dependencies = [
+ "buffa",
+ "buffa-codegen",
+ "tempfile",
+]
+
+[[package]]
+name = "buffa-codegen"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6681b562b18ea719622d0d12684e88ecbdca600d517557dc7bcef7704631e28"
+dependencies = [
+ "buffa",
+ "buffa-descriptor",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "thiserror",
+]
+
+[[package]]
+name = "buffa-descriptor"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57ed423c4ecec86d1500879ce42e7e5f6def01bc632985ac756c1fd723fa21fc"
+dependencies = [
+ "buffa",
+ "rustversion",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -886,12 +942,6 @@ name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
-
-[[package]]
-name = "fixedbitset"
-version = "0.5.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
 
 [[package]]
 name = "fnv"
@@ -1569,12 +1619,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "multimap"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
-
-[[package]]
 name = "nix"
 version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1718,17 +1762,6 @@ name = "pastey"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2ee67f1008b1ba2321834326597b8e186293b049a023cdef258527550b9935b4"
-
-[[package]]
-name = "petgraph"
-version = "0.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8701b58ea97060d5e5b155d383a69952a60943f0e6dfe30b04c287beb0b27455"
-dependencies = [
- "fixedbitset",
- "hashbrown 0.15.5",
- "indexmap",
-]
 
 [[package]]
 name = "pin-project-lite"
@@ -1879,25 +1912,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "prost-build"
-version = "0.14.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03da047801ff44bb6a4d407d4860c05fd70bb81714e6b2f3812603d5b145b042"
-dependencies = [
- "heck",
- "itertools 0.14.0",
- "log",
- "multimap",
- "petgraph",
- "prettyplease",
- "prost",
- "prost-types",
- "regex",
- "syn",
- "tempfile",
-]
-
-[[package]]
 name = "prost-derive"
 version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1908,15 +1922,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
-]
-
-[[package]]
-name = "prost-types"
-version = "0.14.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f94967dc7688f3054c7fac87473ffae4cc4c3904800e2d9f5b857246d8963b0a"
-dependencies = [
- "prost",
 ]
 
 [[package]]
@@ -2504,6 +2509,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "simdutf8"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
+
+[[package]]
 name = "simsimd"
 version = "6.5.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2529,6 +2540,15 @@ name = "smallvec"
 version = "1.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
+
+[[package]]
+name = "smoothutf8"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36358427d32ecdb1624616deed99eccfef0a167fe5bf40ddb51efe6980bc1ec8"
+dependencies = [
+ "simdutf8",
+]
 
 [[package]]
 name = "softaes"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,8 +47,8 @@ toml = "0.9"
 uuid = { version = "1", features = ["serde", "v7"] }
 
 # BEP and reduction
-prost = "0.14"
-prost-build = "0.14"
+buffa = "=0.8.1"
+buffa-build = "=0.8.1"
 protoc-bin-vendored = "3"
 quick-xml = { version = "0.41", features = ["serialize"] }
 

--- a/crates/bazel-mcp-benchmark/Cargo.toml
+++ b/crates/bazel-mcp-benchmark/Cargo.toml
@@ -10,10 +10,12 @@ publish = false
 
 [dependencies]
 anyhow.workspace = true
+bazel-mcp-bep.workspace = true
 bazel-mcp-reducer.workspace = true
 clap.workspace = true
 serde.workspace = true
 serde_json.workspace = true
+sha2.workspace = true
 tiktoken-rs.workspace = true
 tokio.workspace = true
 toml.workspace = true

--- a/crates/bazel-mcp-benchmark/src/bin/bep-spike.rs
+++ b/crates/bazel-mcp-benchmark/src/bin/bep-spike.rs
@@ -1,0 +1,359 @@
+use std::{
+    env,
+    hint::black_box,
+    io::Cursor,
+    time::{Duration, Instant},
+};
+
+use bazel_mcp_bep::proto::{
+    Aborted, ActionExecuted, BuildEvent, BuildEventId, File, NamedSetOfFiles, OptionsParsed,
+    OutputGroup, Progress, TargetComplete, TestResult, TestSummary, build_event, build_event_id,
+    file,
+};
+use bazel_mcp_bep::{DEFAULT_MAX_FRAME_BYTES, decode_stream, encode_event_id, encode_frame};
+use bazel_mcp_reducer::{
+    Budget, ReductionInput, extract_canonical_arguments, reduce_artifacts, reduce_invocation,
+};
+use serde::Serialize;
+use sha2::{Digest, Sha256};
+
+const IMPLEMENTATION: &str = "buffa-owned-view";
+
+#[derive(Clone, Copy, Debug)]
+enum Mode {
+    Decode,
+    Full,
+    Hold,
+}
+
+impl Mode {
+    fn parse(value: &str) -> Result<Self, String> {
+        match value {
+            "decode" => Ok(Self::Decode),
+            "full" => Ok(Self::Full),
+            "hold" => Ok(Self::Hold),
+            _ => Err(format!(
+                "unknown mode {value:?}; expected decode, full, or hold"
+            )),
+        }
+    }
+
+    const fn as_str(self) -> &'static str {
+        match self {
+            Self::Decode => "decode",
+            Self::Full => "full",
+            Self::Hold => "hold",
+        }
+    }
+}
+
+#[derive(Debug)]
+struct Config {
+    mode: Mode,
+    events: usize,
+    iterations: usize,
+    warmup: usize,
+}
+
+impl Default for Config {
+    fn default() -> Self {
+        Self {
+            mode: Mode::Full,
+            events: 16_000,
+            iterations: 30,
+            warmup: 3,
+        }
+    }
+}
+
+#[derive(Serialize)]
+struct Report {
+    implementation: &'static str,
+    mode: &'static str,
+    events: usize,
+    iterations: usize,
+    warmup: usize,
+    stream_bytes: usize,
+    stream_sha256: String,
+    elapsed_seconds: f64,
+    checksum: usize,
+}
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let config = parse_args()?;
+    let stream = make_stream(config.events);
+    let digest = format!("{:x}", Sha256::digest(&stream));
+
+    for _ in 0..config.warmup {
+        black_box(run_once(config.mode, &stream)?);
+    }
+
+    let started = Instant::now();
+    let mut checksum = 0_usize;
+    let iterations = if matches!(config.mode, Mode::Hold) {
+        1
+    } else {
+        config.iterations
+    };
+    for _ in 0..iterations {
+        checksum = checksum.wrapping_add(run_once(config.mode, &stream)?);
+    }
+    let elapsed = started.elapsed();
+
+    let report = Report {
+        implementation: IMPLEMENTATION,
+        mode: config.mode.as_str(),
+        events: config.events,
+        iterations,
+        warmup: config.warmup,
+        stream_bytes: stream.len(),
+        stream_sha256: digest,
+        elapsed_seconds: duration_seconds(elapsed),
+        checksum,
+    };
+    println!("{}", serde_json::to_string(&report)?);
+    Ok(())
+}
+
+fn parse_args() -> Result<Config, String> {
+    let mut config = Config::default();
+    let mut args = env::args().skip(1);
+    while let Some(flag) = args.next() {
+        let value = args
+            .next()
+            .ok_or_else(|| format!("missing value for {flag}"))?;
+        match flag.as_str() {
+            "--mode" => config.mode = Mode::parse(&value)?,
+            "--events" => config.events = parse_positive(&flag, &value)?,
+            "--iterations" => config.iterations = parse_positive(&flag, &value)?,
+            "--warmup" => {
+                config.warmup = value
+                    .parse()
+                    .map_err(|_| format!("invalid value for {flag}: {value}"))?;
+            }
+            _ => return Err(format!("unknown argument {flag}")),
+        }
+    }
+    Ok(config)
+}
+
+fn parse_positive(flag: &str, value: &str) -> Result<usize, String> {
+    let parsed = value
+        .parse::<usize>()
+        .map_err(|_| format!("invalid value for {flag}: {value}"))?;
+    if parsed == 0 {
+        Err(format!("{flag} must be greater than zero"))
+    } else {
+        Ok(parsed)
+    }
+}
+
+fn run_once(mode: Mode, stream: &[u8]) -> Result<usize, Box<dyn std::error::Error>> {
+    let events = decode_stream(Cursor::new(stream), DEFAULT_MAX_FRAME_BYTES)?;
+    if matches!(mode, Mode::Decode | Mode::Hold) {
+        let checksum = events.iter().fold(events.len(), |sum, event| {
+            sum.wrapping_add(event.view().id.len())
+        });
+        black_box(&events);
+        return Ok(checksum);
+    }
+
+    let arguments = extract_canonical_arguments(&events).unwrap_or_default();
+    let artifacts = reduce_artifacts(&events);
+    let summary = reduce_invocation(ReductionInput {
+        events: &events,
+        stdout: b"",
+        stderr: b"synthetic.cc:7: error: benchmark fallback",
+        exit_code: Some(1),
+        elapsed_ms: 1,
+        budget: Budget::result_default(),
+    });
+    let checksum = events
+        .len()
+        .wrapping_add(arguments.len())
+        .wrapping_add(artifacts.len())
+        .wrapping_add(summary.diagnostics.len())
+        .wrapping_add(summary.tests.len())
+        .wrapping_add(summary.targets.len());
+    black_box((events, arguments, artifacts, summary));
+    Ok(checksum)
+}
+
+fn make_stream(event_count: usize) -> Vec<u8> {
+    let mut stream = Vec::with_capacity(event_count.saturating_mul(256));
+    for index in 0..event_count {
+        stream.extend_from_slice(&encode_frame(&make_event(index)));
+    }
+    stream
+}
+
+fn make_event(index: usize) -> BuildEvent {
+    let group = index / 8;
+    let label = format!("//synthetic/package_{:03}:target_{group}", group % 128);
+    let set_id = format!("set-{group}");
+    let (id, payload) = match index % 8 {
+        0 => (
+            Vec::new(),
+            build_event::Payload::OptionsParsed(Box::new(OptionsParsed {
+                startup_options: vec!["--host_jvm_args=-Xmx2g".into()],
+                explicit_startup_options: vec!["--max_idle_secs=60".into()],
+                cmd_line: vec!["--compilation_mode=fastbuild".into(), label.clone()],
+                explicit_cmd_line: vec!["--keep_going".into()],
+                invocation_policy: vec![0x08, 0x01],
+                tool_tag: "bazel-mcp-buffa-spike".into(),
+            })),
+        ),
+        1 => (
+            Vec::new(),
+            build_event::Payload::Progress(Box::new(Progress {
+                stdout: format!(
+                    "[{group}] compiling synthetic target with reusable progress text\n"
+                ),
+                stderr: String::new(),
+            })),
+        ),
+        2 => (
+            encode_id(build_event_id::Id::NamedSet(Box::new(
+                build_event_id::NamedSetOfFilesId { id: set_id.clone() },
+            ))),
+            build_event::Payload::NamedSetOfFiles(Box::new(NamedSetOfFiles {
+                files: (0..4)
+                    .map(|file_index| {
+                        output_file(
+                            &format!("artifact-{group}-{file_index}.a"),
+                            &format!("file:///tmp/bazel-out/{group}/artifact-{file_index}.a"),
+                        )
+                    })
+                    .collect(),
+                file_sets: Vec::new(),
+            })),
+        ),
+        3 => (
+            encode_id(build_event_id::Id::TargetCompleted(Box::new(
+                build_event_id::TargetCompletedId {
+                    label: label.clone(),
+                    aspect: String::new(),
+                    ..Default::default()
+                },
+            ))),
+            build_event::Payload::Completed(Box::new(TargetComplete {
+                success: group.is_multiple_of(3),
+                output_group: vec![OutputGroup {
+                    name: "default".into(),
+                    file_sets: vec![build_event_id::NamedSetOfFilesId { id: set_id }],
+                    incomplete: false,
+                    inline_files: vec![output_file(
+                        &format!("inline-{group}.txt"),
+                        &format!("file:///tmp/bazel-out/{group}/inline.txt"),
+                    )],
+                }],
+                tag: vec!["manual".into(), "synthetic".into()],
+                important_output: Vec::new(),
+                target_kind: "cc_library rule".into(),
+                directory_output: Vec::new(),
+                failure_detail: vec![0x08, 0x02],
+            })),
+        ),
+        4 => (
+            encode_id(build_event_id::Id::ActionCompleted(Box::new(
+                build_event_id::ActionCompletedId {
+                    primary_output: format!("bazel-out/{group}/failed.o"),
+                    label: label.clone(),
+                    ..Default::default()
+                },
+            ))),
+            build_event::Payload::Action(Box::new(ActionExecuted {
+                success: false,
+                exit_code: 1,
+                label: label.clone(),
+                primary_output: output_file(
+                    &format!("failed-{group}.o"),
+                    &format!("file:///tmp/bazel-out/{group}/failed.o"),
+                )
+                .into(),
+                r#type: "CppCompile".into(),
+                command_line: vec!["clang++".into(), "-c".into(), format!("input-{group}.cc")],
+                failure_detail: vec![0x08, 0x03],
+                ..Default::default()
+            })),
+        ),
+        5 => (
+            encode_id(build_event_id::Id::TestResult(Box::new(
+                build_event_id::TestResultId {
+                    label: label.clone(),
+                    run: 1,
+                    shard: 0,
+                    attempt: 1,
+                    ..Default::default()
+                },
+            ))),
+            build_event::Payload::TestResult(Box::new(TestResult {
+                test_action_output: vec![output_file(
+                    "test.log",
+                    &format!("file:///tmp/bazel-testlogs/{group}/test.log"),
+                )],
+                test_attempt_duration_millis: 37,
+                cached_locally: group.is_multiple_of(2),
+                status: 4,
+                test_attempt_start_millis_epoch: 1_700_000_000_000,
+                warning: vec!["synthetic test warning".into()],
+                execution_info: vec![0x0a, 0x01, 0x78],
+                status_details: "assertion failed".into(),
+            })),
+        ),
+        6 => (
+            encode_id(build_event_id::Id::TestSummary(Box::new(
+                build_event_id::TestSummaryId {
+                    label,
+                    ..Default::default()
+                },
+            ))),
+            build_event::Payload::TestSummary(Box::new(TestSummary {
+                total_run_count: 1,
+                failed: vec![output_file(
+                    "test.log",
+                    &format!("file:///tmp/bazel-testlogs/{group}/test.log"),
+                )],
+                overall_status: 4,
+                first_start_time_millis: 1_700_000_000_000,
+                last_stop_time_millis: 1_700_000_000_037,
+                total_run_duration_millis: 37,
+                run_count: 1,
+                shard_count: 1,
+                attempt_count: 1,
+                ..Default::default()
+            })),
+        ),
+        _ => (
+            Vec::new(),
+            build_event::Payload::Aborted(Box::new(Aborted {
+                reason: 6,
+                description: format!("synthetic analysis failure for group {group}"),
+            })),
+        ),
+    };
+    BuildEvent {
+        id,
+        children: Vec::new(),
+        last_message: index + 1 == usize::MAX,
+        payload: Some(payload),
+    }
+}
+
+fn encode_id(id: build_event_id::Id) -> Vec<u8> {
+    encode_event_id(&BuildEventId { id: Some(id) })
+}
+
+fn output_file(name: &str, uri: &str) -> File {
+    File {
+        path_prefix: vec!["bazel-out".into(), "synthetic".into()],
+        name: name.into(),
+        file: Some(file::File::Uri(uri.into())),
+        digest: "0123456789abcdef".into(),
+        length: 4_096,
+    }
+}
+
+fn duration_seconds(duration: Duration) -> f64 {
+    duration.as_secs_f64()
+}

--- a/crates/bazel-mcp-bep/Cargo.toml
+++ b/crates/bazel-mcp-bep/Cargo.toml
@@ -10,11 +10,11 @@ publish = false
 build = "build.rs"
 
 [dependencies]
-prost.workspace = true
+buffa.workspace = true
 thiserror.workspace = true
 
 [build-dependencies]
-prost-build.workspace = true
+buffa-build.workspace = true
 protoc-bin-vendored.workspace = true
 
 [dev-dependencies]

--- a/crates/bazel-mcp-bep/build.rs
+++ b/crates/bazel-mcp-bep/build.rs
@@ -1,13 +1,40 @@
+use std::{env, ffi::OsString, path::PathBuf, process::Command};
+
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let protoc = protoc_bin_vendored::protoc_bin_path()?;
-    let mut config = prost_build::Config::new();
-    config.protoc_executable(protoc);
-    config.enum_attribute(
-        "bazel_mcp.bep.BuildEvent.payload",
-        "#[allow(clippy::large_enum_variant)]",
-    );
-    config.compile_protos(&["proto/build_event_stream_subset.proto"], &["proto"])?;
+    let out_dir = PathBuf::from(env::var_os("OUT_DIR").ok_or("OUT_DIR is not set")?);
+    let descriptor = out_dir.join("bazel-mcp-bep-descriptor.bin");
+    generate_descriptor(protoc.into_os_string(), &descriptor)?;
+
+    buffa_build::Config::new()
+        .files(&["build_event_stream_subset.proto"])
+        .descriptor_set(descriptor)
+        .generate_views(true)
+        .preserve_unknown_fields(false)
+        .compile()?;
     println!("cargo:rerun-if-changed=proto/build_event_stream_subset.proto");
     println!("cargo:rerun-if-changed=proto/PROVENANCE.md");
     Ok(())
+}
+
+fn generate_descriptor(
+    protoc: OsString,
+    descriptor: &std::path::Path,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let output = Command::new(protoc)
+        .arg("--include_imports")
+        .arg("--include_source_info")
+        .arg(format!("--descriptor_set_out={}", descriptor.display()))
+        .arg("--proto_path=proto")
+        .arg("proto/build_event_stream_subset.proto")
+        .output()?;
+    if output.status.success() {
+        Ok(())
+    } else {
+        Err(format!(
+            "vendored protoc failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        )
+        .into())
+    }
 }

--- a/crates/bazel-mcp-bep/src/framing.rs
+++ b/crates/bazel-mcp-bep/src/framing.rs
@@ -1,9 +1,11 @@
 use std::io::{self, Read};
 
-use prost::Message;
+use buffa::{Message, MessageView, bytes::Bytes};
 use thiserror::Error;
 
-use crate::proto::BuildEvent;
+use crate::proto::{
+    BuildEvent, BuildEventId, BuildEventIdView, BuildEventOwnedView, BuildEventView,
+};
 
 pub const DEFAULT_MAX_FRAME_BYTES: usize = 64 * 1024 * 1024;
 pub const DEFAULT_MAX_STREAM_BYTES: usize = 128 * 1024 * 1024;
@@ -24,12 +26,52 @@ pub enum FrameError {
     #[error(transparent)]
     Io(#[from] io::Error),
     #[error(transparent)]
-    Decode(#[from] prost::DecodeError),
+    Decode(#[from] buffa::DecodeError),
+}
+
+/// A self-contained decoded BEP event whose generated view borrows from its
+/// retained protobuf frame without copying strings or byte fields.
+#[derive(Clone, Debug)]
+pub struct BepEvent {
+    inner: BuildEventOwnedView,
+}
+
+impl BepEvent {
+    /// Decode and retain an already-owned protobuf frame without copying it.
+    pub fn decode(frame: Vec<u8>) -> Result<Self, buffa::DecodeError> {
+        Ok(Self {
+            inner: BuildEventOwnedView::decode(Bytes::from(frame))?,
+        })
+    }
+
+    /// Decode a borrowed frame by copying only the frame backing allocation.
+    pub fn decode_slice(frame: &[u8]) -> Result<Self, buffa::DecodeError> {
+        Ok(Self {
+            inner: BuildEventOwnedView::decode(Bytes::copy_from_slice(frame))?,
+        })
+    }
+
+    /// Encode an owned generated message and decode it as a retained view.
+    pub fn from_owned(event: &BuildEvent) -> Result<Self, buffa::DecodeError> {
+        Ok(Self {
+            inner: BuildEventOwnedView::from_owned(event)?,
+        })
+    }
+
+    #[must_use]
+    pub fn view(&self) -> &BuildEventView<'_> {
+        self.inner.view()
+    }
+
+    #[must_use]
+    pub fn frame_bytes(&self) -> &[u8] {
+        self.inner.bytes()
+    }
 }
 
 #[derive(Debug)]
 pub struct PartialStream {
-    pub events: Vec<BuildEvent>,
+    pub events: Vec<BepEvent>,
     pub terminal_error: Option<FrameError>,
 }
 
@@ -61,7 +103,7 @@ pub fn read_frame<R: Read>(
     Ok(Some(frame))
 }
 
-pub fn decode_stream<R: Read>(reader: R, max_bytes: usize) -> Result<Vec<BuildEvent>, FrameError> {
+pub fn decode_stream<R: Read>(reader: R, max_bytes: usize) -> Result<Vec<BepEvent>, FrameError> {
     let partial = decode_stream_partial_bounded(
         reader,
         max_bytes,
@@ -116,7 +158,7 @@ pub fn decode_stream_partial_bounded<R: Read>(
                     };
                 }
                 stream_bytes = next_bytes;
-                match BuildEvent::decode(frame.as_slice()) {
+                match BepEvent::decode(frame) {
                     Ok(event) => events.push(event),
                     Err(error) => {
                         return PartialStream {
@@ -149,6 +191,22 @@ pub fn encode_frame<M: Message>(message: &M) -> Vec<u8> {
     write_varint(body.len() as u64, &mut framed);
     framed.extend_from_slice(&body);
     framed
+}
+
+/// Decode a single borrowed frame into a retained zero-copy event handle.
+pub fn decode_event(frame: &[u8]) -> Result<BepEvent, buffa::DecodeError> {
+    BepEvent::decode_slice(frame)
+}
+
+/// Decode an event-id submessage as a borrowed view into its parent event.
+pub fn decode_event_id(input: &[u8]) -> Result<BuildEventIdView<'_>, buffa::DecodeError> {
+    BuildEventIdView::decode_view(input)
+}
+
+/// Encode an owned event-id submessage for fixtures and benchmarks.
+#[must_use]
+pub fn encode_event_id(id: &BuildEventId) -> Vec<u8> {
+    id.encode_to_vec()
 }
 
 fn read_varint<R: Read>(reader: &mut R) -> Result<Option<u64>, FrameError> {
@@ -195,16 +253,23 @@ mod tests {
 
     proptest! {
         #[test]
-        fn frame_round_trips(stdout in ".{0,1024}") {
+    fn frame_round_trips(stdout in ".{0,1024}") {
             let event = BuildEvent {
                 payload: Some(crate::proto::build_event::Payload::Progress(
-                    crate::proto::Progress { stdout, stderr: String::new() }
+                    Box::new(crate::proto::Progress { stdout, stderr: String::new() })
                 )),
                 ..Default::default()
             };
             let framed = encode_frame(&event);
             let decoded = decode_stream(Cursor::new(framed), DEFAULT_MAX_FRAME_BYTES).unwrap();
-            prop_assert_eq!(decoded, vec![event]);
+            prop_assert_eq!(decoded.len(), 1);
+            let Some(crate::view::build_event::Payload::Progress(progress)) =
+                decoded[0].view().payload.as_ref()
+            else {
+                prop_assert!(false, "missing progress payload");
+                return Ok(());
+            };
+            prop_assert_eq!(progress.stdout, event_progress_stdout(&event));
         }
     }
 
@@ -229,12 +294,12 @@ mod tests {
     #[test]
     fn retains_partial_events_when_the_stream_budget_is_exhausted() {
         let event = BuildEvent {
-            payload: Some(crate::proto::build_event::Payload::Progress(
+            payload: Some(crate::proto::build_event::Payload::Progress(Box::new(
                 crate::proto::Progress {
                     stdout: "output".into(),
                     stderr: String::new(),
                 },
-            )),
+            ))),
             ..Default::default()
         };
         let frame = encode_frame(&event);
@@ -243,7 +308,7 @@ mod tests {
         let partial = decode_stream_partial_bounded(
             input.as_slice(),
             DEFAULT_MAX_FRAME_BYTES,
-            event.encoded_len().saturating_sub(1),
+            event.encoded_len().saturating_sub(1) as usize,
             10,
         );
         assert!(partial.events.is_empty());
@@ -258,10 +323,37 @@ mod tests {
             DEFAULT_MAX_STREAM_BYTES,
             1,
         );
-        assert_eq!(partial.events, vec![event]);
+        assert_eq!(partial.events.len(), 1);
+        let Some(crate::view::build_event::Payload::Progress(progress)) =
+            partial.events[0].view().payload.as_ref()
+        else {
+            panic!("missing progress payload");
+        };
+        assert_eq!(progress.stdout, "output");
         assert!(matches!(
             partial.terminal_error,
             Some(FrameError::TooManyEvents { .. })
         ));
+    }
+
+    #[test]
+    fn ignores_unknown_fields_without_rejecting_the_event() {
+        let event = BuildEvent::default();
+        let mut body = event.encode_to_vec();
+        body.extend_from_slice(&[0xf8, 0x07, 0x01]);
+        let mut framed = Vec::new();
+        write_varint(body.len() as u64, &mut framed);
+        framed.extend_from_slice(&body);
+
+        let decoded = decode_stream(framed.as_slice(), DEFAULT_MAX_FRAME_BYTES).unwrap();
+        assert_eq!(decoded.len(), 1);
+    }
+
+    fn event_progress_stdout(event: &BuildEvent) -> &str {
+        let Some(crate::proto::build_event::Payload::Progress(progress)) = event.payload.as_ref()
+        else {
+            panic!("missing progress payload");
+        };
+        &progress.stdout
     }
 }

--- a/crates/bazel-mcp-bep/src/lib.rs
+++ b/crates/bazel-mcp-bep/src/lib.rs
@@ -3,11 +3,30 @@
 mod framing;
 
 pub mod proto {
-    include!(concat!(env!("OUT_DIR"), "/bazel_mcp.bep.rs"));
+    #![allow(clippy::match_single_binding)]
+
+    buffa::include_proto!("bazel_mcp.bep");
+}
+
+/// Stable re-exports of the generated borrowed BEP model used by reducers.
+pub mod view {
+    pub use crate::proto::{BuildEventIdView, BuildEventView, FileView, NamedSetOfFilesView};
+
+    pub mod build_event {
+        pub use crate::proto::build_event::PayloadView as Payload;
+    }
+
+    pub mod build_event_id {
+        pub use crate::proto::build_event_id::{IdView as Id, NamedSetOfFilesIdView};
+    }
+
+    pub mod file {
+        pub use crate::proto::file::FileView as File;
+    }
 }
 
 pub use framing::{
-    DEFAULT_MAX_FRAME_BYTES, DEFAULT_MAX_STREAM_BYTES, DEFAULT_MAX_STREAM_EVENTS, FrameError,
-    PartialStream, decode_stream, decode_stream_partial, decode_stream_partial_bounded,
-    encode_frame, read_frame,
+    BepEvent, DEFAULT_MAX_FRAME_BYTES, DEFAULT_MAX_STREAM_BYTES, DEFAULT_MAX_STREAM_EVENTS,
+    FrameError, PartialStream, decode_event, decode_event_id, decode_stream, decode_stream_partial,
+    decode_stream_partial_bounded, encode_event_id, encode_frame, read_frame,
 };

--- a/crates/bazel-mcp-reducer/Cargo.toml
+++ b/crates/bazel-mcp-reducer/Cargo.toml
@@ -11,7 +11,6 @@ publish = false
 [dependencies]
 bazel-mcp-bep.workspace = true
 bazel-mcp-types.workspace = true
-prost.workspace = true
 quick-xml.workspace = true
 serde.workspace = true
 thiserror.workspace = true

--- a/crates/bazel-mcp-reducer/src/build.rs
+++ b/crates/bazel-mcp-reducer/src/build.rs
@@ -1,15 +1,17 @@
-use bazel_mcp_bep::proto::{BuildEvent, BuildEventId, build_event, build_event_id};
+use bazel_mcp_bep::{
+    BepEvent, decode_event_id,
+    view::{BuildEventIdView, FileView, NamedSetOfFilesView, build_event, build_event_id, file},
+};
 use bazel_mcp_types::{
     Artifact, ArtifactKind, Diagnostic, DiagnosticCategory, InvocationSummary, Severity,
     TargetCounts, TargetResult, TestCounts, TestResult, TestStatus,
 };
-use prost::Message;
 use std::collections::{BTreeMap, BTreeSet};
 
 use crate::{Budget, deduplicate_lines, normalize_terminal_text};
 
 pub struct ReductionInput<'a> {
-    pub events: &'a [BuildEvent],
+    pub events: &'a [BepEvent],
     pub stdout: &'a [u8],
     pub stderr: &'a [u8],
     pub exit_code: Option<i32>,
@@ -25,12 +27,13 @@ pub fn reduce_invocation(input: ReductionInput<'_>) -> InvocationSummary {
     let mut tests = Vec::new();
 
     for event in input.events {
-        let id = BuildEventId::decode(event.id.as_slice()).ok();
-        match &event.payload {
+        let event = event.view();
+        let id = decode_event_id(event.id).ok();
+        match event.payload.as_ref() {
             Some(build_event::Payload::Aborted(aborted)) => diagnostics.push(Diagnostic {
                 severity: Severity::Error,
                 category: abort_category(aborted.reason),
-                message: aborted.description.clone(),
+                message: aborted.description.to_owned(),
                 location: None,
                 target: label_from_id(id.as_ref()),
                 action: None,
@@ -45,13 +48,13 @@ pub fn reduce_invocation(input: ReductionInput<'_>) -> InvocationSummary {
                         if action.r#type.is_empty() {
                             "Bazel".to_owned()
                         } else {
-                            action.r#type.clone()
+                            action.r#type.to_owned()
                         },
                         action.exit_code
                     ),
                     location: None,
-                    target: label_from_id(id.as_ref()).or_else(|| nonempty(&action.label)),
-                    action: nonempty(&action.r#type),
+                    target: label_from_id(id.as_ref()).or_else(|| nonempty(action.label)),
+                    action: nonempty(action.r#type),
                     repetition_count: 1,
                 });
             }
@@ -166,39 +169,31 @@ fn deduplicate_diagnostics(diagnostics: Vec<Diagnostic>) -> Vec<Diagnostic> {
 }
 
 #[must_use]
-pub fn reduce_artifacts(events: &[BuildEvent]) -> Vec<Artifact> {
-    let mut sets = BTreeMap::<
-        String,
-        (
-            &[bazel_mcp_bep::proto::File],
-            &[build_event_id::NamedSetOfFilesId],
-        ),
-    >::new();
-    let mut roots = Vec::new();
-    let mut direct = Vec::<&bazel_mcp_bep::proto::File>::new();
+pub fn reduce_artifacts<'a>(events: &'a [BepEvent]) -> Vec<Artifact> {
+    let mut sets = BTreeMap::<&'a str, &'a NamedSetOfFilesView<'a>>::new();
+    let mut roots = Vec::<&'a str>::new();
+    let mut direct = Vec::<&'a FileView<'a>>::new();
     for event in events {
-        let id = BuildEventId::decode(event.id.as_slice()).ok();
-        match &event.payload {
+        let event = event.view();
+        let id = decode_event_id(event.id).ok();
+        match event.payload.as_ref() {
             Some(build_event::Payload::NamedSetOfFiles(set)) => {
                 if let Some(build_event_id::Id::NamedSet(named_set)) =
                     id.as_ref().and_then(|id| id.id.as_ref())
                 {
-                    sets.insert(
-                        named_set.id.clone(),
-                        (set.files.as_slice(), set.file_sets.as_slice()),
-                    );
+                    sets.insert(named_set.id, set);
                 }
             }
             Some(build_event::Payload::Completed(completed)) => {
                 for group in &completed.output_group {
-                    roots.extend(group.file_sets.iter().map(|set| set.id.clone()));
+                    roots.extend(group.file_sets.iter().map(|set| set.id));
                     direct.extend(group.inline_files.iter());
                 }
                 direct.extend(completed.important_output.iter());
                 direct.extend(completed.directory_output.iter());
             }
             Some(build_event::Payload::Action(action)) if !action.success => {
-                if let Some(output) = &action.primary_output {
+                if let Some(output) = action.primary_output.as_option() {
                     direct.push(output);
                 }
             }
@@ -208,15 +203,15 @@ pub fn reduce_artifacts(events: &[BuildEvent]) -> Vec<Artifact> {
             _ => {}
         }
     }
-    let mut visited = BTreeSet::new();
+    let mut visited = BTreeSet::<&str>::new();
     let mut pending = roots;
     while let Some(id) = pending.pop() {
-        if !visited.insert(id.clone()) {
+        if !visited.insert(id) {
             continue;
         }
-        if let Some((files, children)) = sets.get(&id) {
-            direct.extend(files.iter());
-            pending.extend(children.iter().map(|set| set.id.clone()));
+        if let Some(set) = sets.get(id) {
+            direct.extend(set.files.iter());
+            pending.extend(set.file_sets.iter().map(|set| set.id));
         }
     }
     let mut seen = BTreeSet::new();
@@ -228,31 +223,37 @@ pub fn reduce_artifacts(events: &[BuildEvent]) -> Vec<Artifact> {
 }
 
 #[must_use]
-pub fn extract_canonical_arguments(events: &[BuildEvent]) -> Option<Vec<String>> {
-    events.iter().find_map(|event| match &event.payload {
-        Some(build_event::Payload::OptionsParsed(options)) => {
-            let mut arguments = options.startup_options.clone();
-            arguments.extend(options.cmd_line.iter().cloned());
-            Some(arguments)
-        }
-        _ => None,
-    })
+pub fn extract_canonical_arguments(events: &[BepEvent]) -> Option<Vec<String>> {
+    events
+        .iter()
+        .find_map(|event| match event.view().payload.as_ref() {
+            Some(build_event::Payload::OptionsParsed(options)) => {
+                let mut arguments = options
+                    .startup_options
+                    .iter()
+                    .map(|value| (*value).to_owned())
+                    .collect::<Vec<_>>();
+                arguments.extend(options.cmd_line.iter().map(|value| (*value).to_owned()));
+                Some(arguments)
+            }
+            _ => None,
+        })
 }
 
-fn file_artifact(file: &bazel_mcp_bep::proto::File) -> Option<Artifact> {
+fn file_artifact(file: &FileView<'_>) -> Option<Artifact> {
     let name = bounded_text(
         &file
             .path_prefix
             .iter()
             .chain(std::iter::once(&file.name))
             .filter(|part| !part.is_empty())
-            .cloned()
+            .copied()
             .collect::<Vec<_>>()
             .join("/"),
         1_000,
     );
     let (uri, kind, locally_available) = match &file.file {
-        Some(bazel_mcp_bep::proto::file::File::Uri(uri)) => {
+        Some(file::File::Uri(uri)) => {
             let kind = if file.name == "test.log" || file.name == "test.xml" {
                 ArtifactKind::TestLog
             } else if file.name.contains("coverage") || file.name.ends_with(".dat") {
@@ -264,12 +265,10 @@ fn file_artifact(file: &bazel_mcp_bep::proto::File) -> Option<Artifact> {
             };
             (bounded_text(uri, 1_000), kind, uri.starts_with("file:"))
         }
-        Some(bazel_mcp_bep::proto::file::File::SymlinkTargetPath(target)) => {
+        Some(file::File::SymlinkTargetPath(target)) => {
             (bounded_text(target, 1_000), ArtifactKind::File, true)
         }
-        Some(bazel_mcp_bep::proto::file::File::Contents(_)) => {
-            ("inline://redacted".to_owned(), ArtifactKind::File, true)
-        }
+        Some(file::File::Contents(_)) => ("inline://redacted".to_owned(), ArtifactKind::File, true),
         None => return None,
     };
     Some(Artifact {
@@ -357,14 +356,14 @@ fn abort_category(reason: i32) -> DiagnosticCategory {
     }
 }
 
-fn label_from_id(id: Option<&BuildEventId>) -> Option<String> {
+fn label_from_id(id: Option<&BuildEventIdView<'_>>) -> Option<String> {
     match id.and_then(|value| value.id.as_ref()) {
-        Some(build_event_id::Id::TargetCompleted(value)) => nonempty(&value.label),
-        Some(build_event_id::Id::ActionCompleted(value)) => nonempty(&value.label),
-        Some(build_event_id::Id::TestSummary(value)) => nonempty(&value.label),
-        Some(build_event_id::Id::TestResult(value)) => nonempty(&value.label),
-        Some(build_event_id::Id::UnconfiguredLabel(value)) => nonempty(&value.label),
-        Some(build_event_id::Id::ConfiguredLabel(value)) => nonempty(&value.label),
+        Some(build_event_id::Id::TargetCompleted(value)) => nonempty(value.label),
+        Some(build_event_id::Id::ActionCompleted(value)) => nonempty(value.label),
+        Some(build_event_id::Id::TestSummary(value)) => nonempty(value.label),
+        Some(build_event_id::Id::TestResult(value)) => nonempty(value.label),
+        Some(build_event_id::Id::UnconfiguredLabel(value)) => nonempty(value.label),
+        Some(build_event_id::Id::ConfiguredLabel(value)) => nonempty(value.label),
         _ => None,
     }
 }
@@ -385,9 +384,9 @@ fn test_status(value: i32) -> TestStatus {
     }
 }
 
-fn file_uri(file: &bazel_mcp_bep::proto::File) -> Option<String> {
+fn file_uri(file: &FileView<'_>) -> Option<String> {
     match &file.file {
-        Some(bazel_mcp_bep::proto::file::File::Uri(uri)) => Some(uri.clone()),
+        Some(file::File::Uri(uri)) => Some((*uri).to_owned()),
         _ => None,
     }
 }
@@ -395,22 +394,30 @@ fn file_uri(file: &bazel_mcp_bep::proto::File) -> Option<String> {
 #[cfg(test)]
 mod tests {
     use bazel_mcp_bep::proto::{
-        ActionExecuted, BuildEventId, File, NamedSetOfFiles, build_event, build_event_id, file,
+        ActionExecuted, BuildEvent, BuildEventId, File, FileOwnedView, NamedSetOfFiles,
     };
+    use bazel_mcp_bep::proto::{
+        build_event as owned_build_event, build_event_id as owned_build_event_id,
+        file as owned_file,
+    };
+    use bazel_mcp_bep::{BepEvent, encode_event_id};
 
     use super::*;
 
     #[test]
     fn reduces_noisy_failure_to_root_cause() {
         let event = BuildEvent {
-            payload: Some(build_event::Payload::Action(ActionExecuted {
-                success: false,
-                exit_code: 1,
-                r#type: "CppCompile".into(),
-                ..Default::default()
-            })),
+            payload: Some(owned_build_event::Payload::Action(Box::new(
+                ActionExecuted {
+                    success: false,
+                    exit_code: 1,
+                    r#type: "CppCompile".into(),
+                    ..Default::default()
+                },
+            ))),
             ..Default::default()
         };
+        let event = BepEvent::from_owned(&event).unwrap();
         let stderr = b"warning: duplicate\nwarning: duplicate\nfile.cc:7: error: bad type\n";
         let summary = reduce_invocation(ReductionInput {
             events: &[event],
@@ -474,51 +481,61 @@ mod tests {
     #[test]
     fn resolves_nested_named_sets_once_even_when_cyclic() {
         fn event_id(id: &str) -> Vec<u8> {
-            BuildEventId {
-                id: Some(build_event_id::Id::NamedSet(
-                    build_event_id::NamedSetOfFilesId { id: id.into() },
-                )),
-            }
-            .encode_to_vec()
+            encode_event_id(&BuildEventId {
+                id: Some(owned_build_event_id::Id::NamedSet(Box::new(
+                    bazel_mcp_bep::proto::build_event_id::NamedSetOfFilesId { id: id.into() },
+                ))),
+            })
         }
         let first = BuildEvent {
             id: event_id("first"),
-            payload: Some(build_event::Payload::NamedSetOfFiles(NamedSetOfFiles {
-                files: vec![File {
-                    name: "local.out".into(),
-                    file: Some(file::File::Uri("file:///tmp/local.out".into())),
-                    ..Default::default()
-                }],
-                file_sets: vec![build_event_id::NamedSetOfFilesId {
-                    id: "second".into(),
-                }],
-            })),
+            payload: Some(owned_build_event::Payload::NamedSetOfFiles(Box::new(
+                NamedSetOfFiles {
+                    files: vec![File {
+                        name: "local.out".into(),
+                        file: Some(owned_file::File::Uri("file:///tmp/local.out".into())),
+                        ..Default::default()
+                    }],
+                    file_sets: vec![bazel_mcp_bep::proto::build_event_id::NamedSetOfFilesId {
+                        id: "second".into(),
+                    }],
+                },
+            ))),
             ..Default::default()
         };
         let second = BuildEvent {
             id: event_id("second"),
-            payload: Some(build_event::Payload::NamedSetOfFiles(NamedSetOfFiles {
-                files: vec![File {
-                    name: "remote.out".into(),
-                    file: Some(file::File::Uri("bytestream://cache/digest".into())),
-                    ..Default::default()
-                }],
-                file_sets: vec![build_event_id::NamedSetOfFilesId { id: "first".into() }],
-            })),
+            payload: Some(owned_build_event::Payload::NamedSetOfFiles(Box::new(
+                NamedSetOfFiles {
+                    files: vec![File {
+                        name: "remote.out".into(),
+                        file: Some(owned_file::File::Uri("bytestream://cache/digest".into())),
+                        ..Default::default()
+                    }],
+                    file_sets: vec![bazel_mcp_bep::proto::build_event_id::NamedSetOfFilesId {
+                        id: "first".into(),
+                    }],
+                },
+            ))),
             ..Default::default()
         };
         let completed = BuildEvent {
-            payload: Some(build_event::Payload::Completed(
+            payload: Some(owned_build_event::Payload::Completed(Box::new(
                 bazel_mcp_bep::proto::TargetComplete {
                     output_group: vec![bazel_mcp_bep::proto::OutputGroup {
-                        file_sets: vec![build_event_id::NamedSetOfFilesId { id: "first".into() }],
+                        file_sets: vec![bazel_mcp_bep::proto::build_event_id::NamedSetOfFilesId {
+                            id: "first".into(),
+                        }],
                         ..Default::default()
                     }],
                     ..Default::default()
                 },
-            )),
+            ))),
             ..Default::default()
         };
+        let completed = BepEvent::from_owned(&completed).unwrap();
+        let second = BepEvent::from_owned(&second).unwrap();
+        let first = BepEvent::from_owned(&first).unwrap();
         let artifacts = reduce_artifacts(&[completed, second, first]);
         assert_eq!(artifacts.len(), 2);
         assert!(artifacts.iter().any(|artifact| {
@@ -540,10 +557,11 @@ mod tests {
     fn bounds_symlink_artifact_paths() {
         let file = File {
             name: "artifact".into(),
-            file: Some(file::File::SymlinkTargetPath("x".repeat(2_000))),
+            file: Some(owned_file::File::SymlinkTargetPath("x".repeat(2_000))),
             ..Default::default()
         };
-        let artifact = file_artifact(&file).unwrap();
+        let file = FileOwnedView::from_owned(&file).unwrap();
+        let artifact = file_artifact(file.view()).unwrap();
         assert!(artifact.uri.len() <= 1_003);
         assert!(artifact.uri.ends_with('…'));
     }

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -153,8 +153,8 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 name = "bazel-mcp-bep"
 version = "0.1.0"
 dependencies = [
- "prost",
- "prost-build",
+ "buffa",
+ "buffa-build",
  "protoc-bin-vendored",
  "thiserror",
 ]
@@ -170,7 +170,6 @@ dependencies = [
  "bazel-mcp-store",
  "bazel-mcp-types",
  "libfuzzer-sys",
- "prost",
 ]
 
 [[package]]
@@ -190,7 +189,6 @@ version = "0.1.0"
 dependencies = [
  "bazel-mcp-bep",
  "bazel-mcp-types",
- "prost",
  "quick-xml",
  "serde",
  "thiserror",
@@ -289,6 +287,61 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e426eb5cc1900033930ec955317b302e68f19f326cc7bb0c8a86865a826cdf0c"
 dependencies = [
  "rustc_version",
+]
+
+[[package]]
+name = "buffa"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33f29a40702df4b86ccd84211bfde8cee0bce6d0811450ade4a86a7d0958a23a"
+dependencies = [
+ "bytes",
+ "foldhash",
+ "hashbrown",
+ "once_cell",
+ "rustversion",
+ "serde",
+ "serde_json",
+ "smoothutf8",
+ "thiserror",
+]
+
+[[package]]
+name = "buffa-build"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef33217cabddfad99c0a54d42ddb7ca5b73fa492f7b16ddb621132ef51107556"
+dependencies = [
+ "buffa",
+ "buffa-codegen",
+ "tempfile",
+]
+
+[[package]]
+name = "buffa-codegen"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6681b562b18ea719622d0d12684e88ecbdca600d517557dc7bcef7704631e28"
+dependencies = [
+ "buffa",
+ "buffa-descriptor",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "thiserror",
+]
+
+[[package]]
+name = "buffa-descriptor"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57ed423c4ecec86d1500879ce42e7e5f6def01bc632985ac756c1fd723fa21fc"
+dependencies = [
+ "buffa",
+ "rustversion",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -544,12 +597,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "equivalent"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
-
-[[package]]
 name = "errno"
 version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -587,12 +634,6 @@ name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
-
-[[package]]
-name = "fixedbitset"
-version = "0.5.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
 
 [[package]]
 name = "foldhash"
@@ -728,12 +769,6 @@ checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
  "foldhash",
 ]
-
-[[package]]
-name = "hashbrown"
-version = "0.17.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
 name = "heck"
@@ -928,16 +963,6 @@ dependencies = [
  "zerofrom",
  "zerotrie",
  "zerovec",
-]
-
-[[package]]
-name = "indexmap"
-version = "2.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
-dependencies = [
- "equivalent",
- "hashbrown 0.17.1",
 ]
 
 [[package]]
@@ -1188,12 +1213,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "multimap"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
-
-[[package]]
 name = "nom"
 version = "7.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1303,17 +1322,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2ee67f1008b1ba2321834326597b8e186293b049a023cdef258527550b9935b4"
 
 [[package]]
-name = "petgraph"
-version = "0.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8701b58ea97060d5e5b155d383a69952a60943f0e6dfe30b04c287beb0b27455"
-dependencies = [
- "fixedbitset",
- "hashbrown 0.15.5",
- "indexmap",
-]
-
-[[package]]
 name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1401,25 +1409,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "prost-build"
-version = "0.14.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03da047801ff44bb6a4d407d4860c05fd70bb81714e6b2f3812603d5b145b042"
-dependencies = [
- "heck",
- "itertools 0.14.0",
- "log",
- "multimap",
- "petgraph",
- "prettyplease",
- "prost",
- "prost-types",
- "regex",
- "syn",
- "tempfile",
-]
-
-[[package]]
 name = "prost-derive"
 version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1430,15 +1419,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
-]
-
-[[package]]
-name = "prost-types"
-version = "0.14.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f94967dc7688f3054c7fac87473ffae4cc4c3904800e2d9f5b857246d8963b0a"
-dependencies = [
- "prost",
 ]
 
 [[package]]
@@ -1866,6 +1846,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "simdutf8"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
+
+[[package]]
 name = "simsimd"
 version = "6.5.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1891,6 +1877,15 @@ name = "smallvec"
 version = "1.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
+
+[[package]]
+name = "smoothutf8"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36358427d32ecdb1624616deed99eccfef0a167fe5bf40ddb51efe6980bc1ec8"
+dependencies = [
+ "simdutf8",
+]
 
 [[package]]
 name = "softaes"

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -12,7 +12,6 @@ cargo-fuzz = true
 [dependencies]
 arbitrary = { version = "1", features = ["derive"] }
 libfuzzer-sys = "0.4"
-prost = "0.14"
 bazel-mcp-bep = { path = "../crates/bazel-mcp-bep" }
 bazel-mcp-policy = { path = "../crates/bazel-mcp-policy" }
 bazel-mcp-reducer = { path = "../crates/bazel-mcp-reducer" }

--- a/fuzz/fuzz_targets/named_file_sets.rs
+++ b/fuzz/fuzz_targets/named_file_sets.rs
@@ -1,10 +1,8 @@
 #![no_main]
-use bazel_mcp_bep::proto::BuildEvent;
 use libfuzzer_sys::fuzz_target;
-use prost::Message;
 
 fuzz_target!(|data: &[u8]| {
-    if let Ok(event) = BuildEvent::decode(data) {
+    if let Ok(event) = bazel_mcp_bep::decode_event(data) {
         let _ = bazel_mcp_reducer::reduce_artifacts(&[event]);
     }
 });

--- a/specs/001-product-requirements.md
+++ b/specs/001-product-requirements.md
@@ -555,7 +555,10 @@ It MUST reap every child and MUST NOT leave an untracked Bazel client running.
 
 - Bazel BEP `.proto` files and required imports are vendored at a pinned Bazel
   release tag.
-- Rust types are generated with `prost-build`.
+- Rust owned messages and borrowed views are generated with `buffa-build`.
+- Decoded events retain their protobuf frame and expose Buffa views so string,
+  byte, nested-message, and repeated-message fields are not copied into a
+  second owned object graph.
 - The selected protobuf version MUST decode fixtures from every supported Bazel
   major version.
 - Unknown protobuf fields are ignored, and missing optional fields are handled
@@ -1036,7 +1039,7 @@ Expected foundational dependencies include:
 
 - `rmcp`
 - `tokio` and `tokio-util`
-- `prost` and `prost-build`
+- `buffa` and `buffa-build`
 - `serde`, `serde_json`, and `schemars`
 - `uuid`
 - `turso` in embedded local mode

--- a/specs/002-project-architecture.md
+++ b/specs/002-project-architecture.md
@@ -195,13 +195,15 @@ byte slices.
 
 Responsibilities:
 
-- Generated `prost` types for the pinned Bazel BEP schema.
+- Generated Buffa owned messages and borrowed views for the pinned Bazel BEP
+  schema.
 - Varint frame decoding with explicit incomplete-frame outcomes.
 - Event identity, announcement, and reference tracking.
 - `NamedSetOfFiles` graph resolution without quadratic expansion.
 - Compatibility metadata for the Bazel version used to vendor the protos.
-- Conversion from generated protobufs into small BEP-oriented Rust views used by
-  reducers.
+- A self-contained event handle that retains the raw protobuf frame while
+  reducers borrow generated views from it without copying protobuf strings,
+  bytes, nested messages, or repeated messages.
 
 Suggested layout:
 
@@ -230,10 +232,12 @@ crates/bazel-mcp-bep/
         └── bazel-9/
 ```
 
-`build.rs` uses `prost-build` and a vendored `protoc` binary so ordinary Cargo
-builds do not depend on a system protobuf installation. It declares
-`rerun-if-changed` for the vendored proto tree. Generated Rust is written to
-`OUT_DIR` and included from `generated.rs`; generated files are not committed.
+`build.rs` invokes a vendored `protoc` binary directly to create a descriptor
+set, then uses `buffa-build` to generate owned messages and borrowed views.
+Ordinary Cargo builds therefore do not depend on a system protobuf
+installation. The script declares `rerun-if-changed` for the vendored proto
+tree. Generated Rust is written to `OUT_DIR` and included from `lib.rs`;
+generated files are not committed.
 
 The proto `README.md` records the upstream Bazel tag, source paths, update
 procedure, and checksums. The Apache-2.0 license accompanying vendored Bazel
@@ -662,7 +666,7 @@ set includes:
 | --- | --- |
 | MCP and async | `rmcp`, `tokio`, `tokio-util`, `futures` |
 | Serialization and schemas | `serde`, `serde_json`, `schemars`, `uuid` |
-| BEP | `prost`, `prost-types`, `prost-build`, vendored `protoc` support |
+| BEP | `buffa`, `buffa-build`, vendored `protoc` support |
 | Storage | `turso`, `tempfile` |
 | Parsing | a bounded XML parser, LCOV parser or internal LCOV reader, `memchr`, ANSI stripping |
 | Errors and logging | `thiserror`, `anyhow`, `tracing`, `tracing-subscriber` |
@@ -1227,7 +1231,7 @@ feat(server): add MCP task execution
 fix(runner): reap cancelled Bazel clients
 perf(reducer): avoid duplicate diagnostic buffers
 docs(specs): define remote artifact adapter boundary
-chore(deps): update prost
+chore(deps): update buffa
 ```
 
 release-please maintains a draft release PR, updates

--- a/specs/003-buffa-spike.md
+++ b/specs/003-buffa-spike.md
@@ -1,0 +1,182 @@
+# Buffa BEP spike
+
+Status: implemented and recommended
+
+Date: 2026-07-15
+
+Buffa version: `0.8.1` (exactly pinned)
+
+## Decision
+
+Adopt Buffa for Build Event Protocol decoding. The migrated implementation
+reduces the primary machine-independent work metric, retired instructions, by
+55.24% for decoding and by 37.53% for the full reduction pipeline. Retaining a
+large decoded stream uses 29.08% less peak resident memory. It passes the full
+workspace tests, the Bazel 7/8/9 compatibility matrix, and every BEP fuzz-smoke
+target.
+
+Buffa is pre-1.0, so its workspace dependencies are pinned to `=0.8.1`. A
+version update must include the same compatibility, fuzz, and benchmark gates.
+The selected release is Apache-2.0 licensed. Upstream describes generated
+owned/view types as its primary stability surface and reports full binary,
+JSON, and text protobuf conformance; this integration uses only the binary
+generated-type surface.
+
+## Ownership model
+
+The previous decoder materialized a complete Prost-owned object graph. Every
+protobuf string, byte field, nested message, and repeated message became a
+separate owned Rust value.
+
+The new `BepEvent` model owns one immutable encoded frame through Buffa's
+`BuildEventOwnedView`. The framing buffer is transferred into that handle
+without copying. Reducers receive a `BuildEventView` borrowed from the handle
+and use borrowed nested views throughout traversal. In particular:
+
+- event payloads and identifiers are decoded as borrowed views;
+- `NamedSetOfFiles` maps, traversal stacks, and visited sets borrow `&str`
+  identifiers and file views from the retained events;
+- canonical arguments, diagnostics, target results, and artifacts allocate
+  only when producing the final public result;
+- owned generated messages remain available for fixtures and synthetic-event
+  generation, but are not used by the production decode/reduce path.
+
+There is still one allocation per protobuf frame because the decoder consumes
+an arbitrary `Read` and must retain successfully decoded frames for partial
+stream recovery. The allocation becomes the view's backing storage; there is
+no second protobuf object graph. The complete raw BEP remains separately on
+disk as required by the retention policy.
+
+Unknown fields are configured to be ignored, matching the product requirement
+and forward-compatibility behavior of the old decoder. Frame, stream-byte, and
+event-count limits and valid-prefix recovery are unchanged.
+
+## Benchmark design
+
+The benchmark is `bep-spike` in `bazel-mcp-benchmark`. It creates a deterministic
+mixed stream with eight recurring event shapes: options, progress, named file
+sets, target completion, failed actions, test results, test summaries, and
+aborted events. It exercises nested messages, repeated strings and messages,
+byte fields, event-id submessages, artifact graph traversal, and result
+allocation.
+
+Both implementations processed byte-identical input and produced the same
+checksum:
+
+| Workload | Events | Stream size | SHA-256 |
+| --- | ---: | ---: | --- |
+| Decode and full reduction | 16,000 | 3,064,474 bytes | `e0af4cc967e2c5bc11d57cbc958c2c217c7efef7c27bf908b77ef5871e29a453` |
+| Retained-memory run | 200,000 | 39,027,808 bytes | `076e95d78858337305b64d1ffc2a227843fad4e9626fae6dd34846bdb61e1f09` |
+
+The Prost baseline started from commit
+`5d7792da89e05d2053a285fa2c58b2ee2ce4b6a6`; the same benchmark harness was
+added before changing the decoder. The Buffa candidate was built from this
+spike. Both were release builds using Rust 1.94.1 on an Apple M5 Max running
+macOS 26.4.
+
+Because unrelated work was running on the host, elapsed wall time is not used
+for the decision. Each CPU workload has five samples with alternating process
+order. `/usr/bin/time -lp` supplied retired instructions, CPU time, CPU cycles,
+and maximum resident set size. Retired instructions are the primary comparison;
+user-plus-system CPU time and cycles are corroborating measures. The table uses
+sample medians.
+
+## Results
+
+Lower is better. Deltas are `(Buffa / Prost) - 1`.
+
+| Workload and metric | Prost | Buffa | Delta |
+| --- | ---: | ---: | ---: |
+| Decode, retired instructions (400 iterations) | 65,011,554,630 | 29,101,988,579 | **-55.24%** |
+| Decode, CPU seconds | 5.77 | 2.68 | **-53.55%** |
+| Decode, CPU cycles | 13,711,477,687 | 6,917,323,404 | **-49.55%** |
+| Decode + reducers, retired instructions (200 iterations) | 63,498,682,258 | 39,668,463,199 | **-37.53%** |
+| Decode + reducers, CPU seconds | 5.87 | 3.50 | **-40.37%** |
+| Decode + reducers, CPU cycles | 13,971,899,304 | 8,034,345,920 | **-42.50%** |
+| Retain 200,000 decoded events, peak RSS | 280,625,152 bytes | 199,016,448 bytes | **-29.08%** |
+| Release server binary | 15,907,760 bytes | 15,861,536 bytes | **-0.29%** |
+| Release server `__TEXT` segment | 14,991,360 bytes | 14,942,208 bytes | **-0.33%** |
+
+Observed wall time was highly variable: 4.23-18.47 seconds for Prost decode and
+1.93-9.36 seconds for Buffa decode. That spread confirms that wall time is a
+poor primary signal on this host. The independent work counters and CPU-time
+medians all agree on the direction and approximate size of the improvement.
+
+Raw retired-instruction samples:
+
+| Workload | Prost | Buffa |
+| --- | --- | --- |
+| Decode | 64,923,852,434; 65,049,999,361; 64,868,740,959; 65,187,336,956; 65,011,554,630 | 29,101,988,579; 29,111,436,063; 29,052,315,563; 29,066,312,536; 29,159,891,806 |
+| Decode + reducers | 63,498,682,258; 63,328,087,657; 63,252,968,010; 63,627,328,806; 63,511,986,741 | 39,729,582,527; 39,757,301,145; 39,668,463,199; 39,633,554,638; 39,633,058,648 |
+
+Raw peak-RSS samples for the 200,000-event retention run:
+
+| Prost | Buffa |
+| --- | --- |
+| 280,641,536; 280,657,920; 280,608,768; 280,625,152; 280,576,000 | 199,081,984; 199,065,600; 199,016,448; 198,967,296; 198,967,296 |
+
+## Validation
+
+The spike was validated with:
+
+```text
+make build
+make test
+make check
+make test-bazel-matrix
+make fuzz-smoke FUZZ_TARGET=bep_framing
+make fuzz-smoke FUZZ_TARGET=bep_event_stream
+make fuzz-smoke FUZZ_TARGET=named_file_sets
+```
+
+The Bazel matrix passed build success, loading failure, action failure, test
+success, test failure, coverage, query, and timeout fixtures on Bazel 7.6.1,
+8.4.2, and 9.1.0. The matrix uses real BEP output and complements the larger
+deterministic synthetic workload used for repeatable performance measurement.
+
+## Reproduction
+
+Build and run the candidate benchmark with:
+
+```sh
+cargo build --release -p bazel-mcp-benchmark --bin bep-spike
+/usr/bin/time -lp target/release/bep-spike \
+  --mode decode --events 16000 --iterations 400 --warmup 5
+/usr/bin/time -lp target/release/bep-spike \
+  --mode full --events 16000 --iterations 200 --warmup 5
+/usr/bin/time -lp target/release/bep-spike \
+  --mode hold --events 200000 --iterations 1 --warmup 0
+```
+
+For noisy shared hosts, alternate the candidate and baseline processes and use
+at least five samples. Compare retired instructions first, then CPU cycles and
+user-plus-system CPU time. Do not use a single wall-time result.
+
+## Risks and follow-up
+
+- Buffa is pre-1.0 and may make source-breaking releases. Exact pinning and the
+  generated-view compatibility tests contain that risk. Version 0.8.1 is the
+  latest upstream release as of the spike date.
+- Buffa is used only in `bazel-mcp-bep`; reducers consume stable re-exports from
+  that crate rather than importing Buffa directly. The wrapper uses Buffa's
+  public generated re-exports and does not expose generated `__buffa` modules.
+- Prost remains in the final dependency graph through Turso's sync engine, but
+  it is no longer a direct BEP or reducer dependency. The measured release
+  server binary is nevertheless slightly smaller.
+- [Upstream issue #298](https://github.com/anthropics/buffa/issues/298) reports
+  an approximately 10% view-decode regression in 0.8.1 caused by a missing
+  inline annotation. The results above measure the affected release, so a fix
+  may improve Buffa further; it is not needed for the adoption decision.
+- [Upstream issue #301](https://github.com/anthropics/buffa/issues/301) reports
+  repeated-element memory amplification in owned and view decoding. Existing
+  frame, stream, and event limits bound input bytes but not the number of
+  repeated elements inside one frame. The current trust boundary is a local
+  BEP file emitted by the Bazel process started by this server; `decode_event`
+  must not be repurposed for arbitrary remote protobuf input. Track the issue
+  and enable an upstream decoded-element budget when one is available.
+- The open reflection/WKT conformance issue is outside this integration: the
+  BEP subset uses neither Buffa reflection nor its well-known-type adapters.
+- If profiling later shows per-frame allocation overhead to be significant, a
+  bounded shared-buffer decoder can retain Buffa byte slices from larger input
+  slabs. That is independent of this ownership migration and must preserve
+  partial-stream recovery and stream limits.


### PR DESCRIPTION
## Summary

- replace the direct Prost BEP implementation with exactly pinned Buffa 0.8.1 generated owned messages and zero-copy views
- retain each protobuf frame in a self-contained `BepEvent` while reducers borrow strings, bytes, nested messages, event IDs, and named-file-set graphs
- add a deterministic Prost/Buffa benchmark harness and a complete spike report with raw samples and reproduction commands
- update BEP fuzz coverage and architecture/product specifications

## Why

The existing Prost decoder materialized a complete owned object graph. Buffa's owned-view model lets the framing allocation become the backing storage for generated views, avoiding a second copy of protobuf strings, bytes, and nested/repeated messages.

Five alternating samples used retired instructions as the primary metric because the benchmark host had unrelated concurrent work:

| Workload | Buffa vs. Prost |
| --- | ---: |
| Decode retired instructions | -55.24% |
| Full decode + reduction instructions | -37.53% |
| Decode CPU time | -53.55% |
| Full pipeline CPU time | -40.37% |
| Retained-event peak RSS | -29.08% |
| Release server size | -0.29% |

Wall time was deliberately excluded from the decision. The report documents exact input hashes, raw counter/RSS samples, upstream risks, and the remaining per-frame allocation.

## Validation

- `make build`
- `make test`
- `make check`
- `make test-bazel-matrix` on Bazel 7.6.1, 8.4.2, and 9.1.0
- `make fuzz-smoke FUZZ_TARGET=bep_framing`
- `make fuzz-smoke FUZZ_TARGET=bep_event_stream`
- `make fuzz-smoke FUZZ_TARGET=named_file_sets`

## Risk notes

Buffa is pre-1.0, so both runtime and build dependencies are pinned to `=0.8.1`. The report also records the upstream repeated-element amplification issue; the decoder remains scoped to locally emitted Bazel BEP and should not be exposed to arbitrary remote protobuf input.
