### PR TITLE
feat: make server configuration optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ The server exposes exactly three tools:
 - `bazel.inspect` reads a bounded, filtered, paginated retained view.
 - `bazel.cancel` cancels a known queued or running invocation.
 
-## Install and configure
+## Install
 
 Build from source with Rust 1.94.1:
 
@@ -20,20 +20,25 @@ Build from source with Rust 1.94.1:
 cargo build --release -p bazel-mcp-server
 ```
 
-Copy `examples/config.toml`, set at least one `allowed_roots` entry, and register
-the binary as a stdio MCP server in the host. Standard output is reserved for
-MCP protocol frames; logs always go to standard error.
+Register the binary as a stdio MCP server in the host. No configuration file is
+required. Standard output is reserved for MCP protocol frames; logs always go
+to standard error.
 
 ```json
 {
   "mcpServers": {
     "bazel": {
-      "command": "/absolute/path/to/bazel-mcp",
-      "args": ["--config", "/absolute/path/to/config.toml"]
+      "command": "/absolute/path/to/bazel-mcp"
     }
   }
 }
 ```
+
+Built-in defaults allow any Bazel workspace while retaining command,
+environment, timeout, storage, and output limits. To restrict workspace paths or
+customize other settings, copy `examples/config.toml` and pass it with
+`--config`, set `BAZEL_MCP_CONFIG`, or place it in the OS user configuration
+directory.
 
 All invocation data remains in the configured local cache. `clean`, `run`, and
 `shutdown` are denied by default, shell evaluation is never used, and server-

--- a/crates/bazel-mcp-policy/src/workspace.rs
+++ b/crates/bazel-mcp-policy/src/workspace.rs
@@ -12,12 +12,14 @@ pub fn validate_workspace(
         return Err(PolicyError::WorkspaceNotAbsolute(workspace.to_owned()));
     }
     let canonical = workspace.canonicalize()?;
-    let allowed = allowed_roots.iter().any(|root| {
-        root.canonicalize()
-            .is_ok_and(|canonical_root| canonical.starts_with(canonical_root))
-    });
-    if !allowed {
-        return Err(PolicyError::WorkspaceNotAllowed(canonical));
+    if !allowed_roots.is_empty() {
+        let allowed = allowed_roots.iter().any(|root| {
+            root.canonicalize()
+                .is_ok_and(|canonical_root| canonical.starts_with(canonical_root))
+        });
+        if !allowed {
+            return Err(PolicyError::WorkspaceNotAllowed(canonical));
+        }
     }
     if !WORKSPACE_MARKERS
         .iter()
@@ -44,6 +46,19 @@ mod tests {
         fs::write(workspace.join("MODULE.bazel"), "").unwrap();
         assert_eq!(
             validate_workspace(&workspace, &[root.path().to_owned()]).unwrap(),
+            workspace.canonicalize().unwrap()
+        );
+    }
+
+    #[test]
+    fn accepts_a_bazel_workspace_when_roots_are_unrestricted() {
+        let root = tempdir().unwrap();
+        let workspace = root.path().join("repo");
+        fs::create_dir(&workspace).unwrap();
+        fs::write(workspace.join("MODULE.bazel"), "").unwrap();
+
+        assert_eq!(
+            validate_workspace(&workspace, &[]).unwrap(),
             workspace.canonicalize().unwrap()
         );
     }

--- a/crates/bazel-mcp-server/src/config.rs
+++ b/crates/bazel-mcp-server/src/config.rs
@@ -101,11 +101,6 @@ impl ServerConfig {
         if let Some(cache_root) = &cli.cache_root {
             config.cache_root = cache_root.clone();
         }
-        if config.allowed_roots.is_empty() {
-            anyhow::bail!(
-                "no allowed workspace roots configured; set allowed_roots or use --allow-root"
-            );
-        }
         if config.global_concurrency == 0 {
             anyhow::bail!("global concurrency must be greater than zero");
         }
@@ -274,6 +269,21 @@ mod tests {
             "default_timeout_seconds = 0\nmaximum_timeout_seconds = 0\n",
         );
         assert!(ServerConfig::load(&cli(timeout)).is_err());
+    }
+
+    #[test]
+    fn accepts_configuration_without_allowed_roots() {
+        let root = tempdir().unwrap();
+        let path = root.path().join("config.toml");
+        fs::write(
+            &path,
+            format!("cache_root = {:?}\n", root.path().join("cache")),
+        )
+        .unwrap();
+
+        let config = ServerConfig::load(&cli(path)).unwrap();
+
+        assert!(config.allowed_roots.is_empty());
     }
 
     #[cfg(unix)]

--- a/examples/config.toml
+++ b/examples/config.toml
@@ -1,3 +1,5 @@
+# Optional: set one or more roots to restrict which Bazel workspaces may run.
+# Leave the list empty (the built-in default) to allow any Bazel workspace.
 allowed_roots = ["/absolute/path/to/bazel/workspaces"]
 global_concurrency = 4
 default_timeout_seconds = 1800

--- a/specs/001-product-requirements.md
+++ b/specs/001-product-requirements.md
@@ -366,8 +366,8 @@ MUST use the encoding intended for the production MCP host.
 
 ### 9.1 Workspace validation
 
-- `workspace` MUST be absolute, canonicalized, and contained by a configured
-  allowed root.
+- `workspace` MUST be absolute and canonicalized. When allowed roots are
+  configured, it MUST be contained by one of them.
 - The canonical directory MUST contain `MODULE.bazel`, `WORKSPACE.bazel`, or
   `WORKSPACE`.
 - Symlink traversal MUST NOT escape the allowed root.

--- a/specs/002-project-architecture.md
+++ b/specs/002-project-architecture.md
@@ -770,7 +770,8 @@ workspace has its own committed `fuzz/Cargo.lock`.
 ## Server configuration
 
 Configuration is user-level and MUST NOT require modifying a target Bazel
-repository.
+repository. It is optional; when no source is present, the server uses built-in
+defaults and does not restrict workspace roots.
 
 Resolution order:
 


### PR DESCRIPTION
## Summary

- allow the server to start with built-in defaults when no configuration file or allowed roots are provided
- treat an empty `allowed_roots` list as unrestricted while preserving canonical containment and symlink-escape checks when roots are configured
- simplify the README installation example and align the example configuration and specifications

## Why

The README required users to create and reference a `config.toml`, even though most settings already have sensible defaults. Startup also rejected the default empty `allowed_roots`, making the nominal no-config path unusable. This adds unnecessary setup friction for local use.

## Impact

Users can register the `bazel-mcp` binary without any arguments and use the built-in command, environment, timeout, storage, and output limits. Deployments that need workspace isolation can continue configuring `allowed_roots` or passing `--allow-root`; their existing containment checks remain unchanged.

## Validation

- `make check`
- `make test`
- `git diff --check`
