### PR TITLE
docs: rewrite README for open source users

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,107 +1,200 @@
 # bazel-mcp
 
-`bazel-mcp` is a local, token-efficient Model Context Protocol server for Bazel.
-It runs real Bazel commands, persists the raw evidence locally, and returns a
-small actionable result instead of streaming progress, repeated warnings, and
-complete test logs into an LLM context.
+[![CI](https://github.com/ewhauser/bazel-mcp/actions/workflows/ci.yml/badge.svg)](https://github.com/ewhauser/bazel-mcp/actions/workflows/ci.yml)
+[![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
 
-The server exposes exactly three tools:
+Run Bazel from MCP-compatible coding agents without filling their context
+windows with build logs.
 
-- `bazel.run` executes `build`, `test`, `coverage`, `query`, `cquery`, `aquery`,
-  and explicitly allowed informational commands.
-- `bazel.inspect` reads a bounded, filtered, paginated retained view.
-- `bazel.cancel` cancels a known queued or running invocation.
+`bazel-mcp` is a local [Model Context Protocol](https://modelcontextprotocol.io/)
+server. It runs Bazel in your workspace, returns a compact actionable result,
+and keeps the complete invocation evidence available for inspection when an
+agent needs more detail.
 
-## Install
+## Why bazel-mcp?
 
-Build from source with Rust 1.94.1:
+Bazel output can be enormous. Sending complete progress output, repeated
+warnings, and test logs to a coding agent wastes context and can hide the error
+that matters.
+
+`bazel-mcp` gives agents:
+
+- concise summaries of successful and failed invocations;
+- structured diagnostics, test results, coverage, artifacts, and query output;
+- filtered, paginated access to retained evidence;
+- cancellation of queued or running commands.
+
+Bazel still runs locally with your workspace, configured credentials,
+toolchains, and remote execution settings.
+
+## Quick start
+
+### Requirements
+
+- macOS or Linux
+- Bazel 7, 8, or 9, Bazelisk, or an executable workspace-local `tools/bazel`
+- an MCP-compatible client
+- Rust 1.94.1 when building from source
+
+### Install with Homebrew
 
 ```sh
+brew install ewhauser/tap/bazel-mcp
+```
+
+### Install from a release
+
+Download a prebuilt archive from the
+[latest GitHub release](https://github.com/ewhauser/bazel-mcp/releases/latest),
+or run the shell installer on macOS or Linux:
+
+```sh
+curl --proto '=https' --tlsv1.2 -LsSf \
+  https://github.com/ewhauser/bazel-mcp/releases/latest/download/bazel-mcp-installer.sh | sh
+```
+
+### Build from source
+
+Clone the repository and build the server with the pinned Rust toolchain:
+
+```sh
+git clone https://github.com/ewhauser/bazel-mcp.git
+cd bazel-mcp
 cargo build --release -p bazel-mcp-server
 ```
 
-Register the binary as a stdio MCP server in the host. No configuration file is
-required. Standard output is reserved for MCP protocol frames; logs always go
-to standard error.
+The binary is written to `target/release/bazel-mcp`.
+
+### Connect your MCP client
+
+Register the binary as a stdio MCP server. The exact settings location depends
+on your client.
 
 ```json
 {
   "mcpServers": {
     "bazel": {
-      "command": "/absolute/path/to/bazel-mcp"
+      "command": "bazel-mcp"
     }
   }
 }
 ```
 
-Built-in defaults allow any Bazel workspace while retaining command,
-environment, timeout, storage, and output limits. To restrict workspace paths or
-customize other settings, copy `examples/config.toml` and pass it with
-`--config`, set `BAZEL_MCP_CONFIG`, or place it in the OS user configuration
-directory.
+If you built from source without installing the binary, use the absolute path
+to `target/release/bazel-mcp` instead.
 
-All invocation data remains in the configured local cache. `clean`, `run`, and
-`shutdown` are denied by default, shell evaluation is never used, and server-
-owned BEP/output-root flags cannot be overridden by a request.
+Restart the client, open a Bazel workspace, and try prompts such as:
 
-Tool-result encoding is configured with `result_encoding`. The default, `text`,
-returns compact JSON in one MCP text block. Set it to `toon` for a token-oriented
-TOON text block, `structured` for MCP structured content, or `both` for
-structured content plus backwards-compatible JSON text.
+- “Build `//app:server`.”
+- “Run the tests under `//services/...` and explain any failures.”
+- “Which targets depend on `//lib:core`?”
 
-Bazel 7, 8, and 9 are accepted and exercised in the integration matrix.
-Untested major versions fail before an invocation is created unless
-`allow_unsupported_bazel_versions` is explicitly enabled. Workspace-local
-`tools/bazel` wrappers and Bazelisk are supported.
+No configuration file is required. By default, the server can run Bazel in any
+workspace accessible to the current user. See [Security and local data](#security-and-local-data)
+to restrict it to specific roots.
 
-## Benchmarks
+## Tools
 
-Three independent five-sample runs against a pinned Abseil commit show an
-89.73–90.69% reduction in cumulative model context versus a default shell
-agent. The latest run measured 89.73% (95% CI 87.28–91.38%). It reduced
-model-visible bytes by 96.43% (95% CI 95.40–97.09%) while median paired Bazel
-wall-time overhead was 0.00%.
+The server exposes three tools:
 
-| Baseline in latest run | Context reduction | Visible-byte reduction | Median Bazel overhead |
-| --- | ---: | ---: | ---: |
-| Default shell | 89.73% (87.28–91.38%) | 96.43% (95.40–97.09%) | 0.00% |
-| Optimized shell instructions | 94.46% (91.90–95.89%) | 97.54% (96.53–98.15%) | -0.33% |
+| Tool | Purpose |
+| --- | --- |
+| `bazel.run` | Run an allowed Bazel command and return a bounded summary. |
+| `bazel.inspect` | Read filtered diagnostics, tests, coverage, artifacts, query results, or logs from an invocation. |
+| `bazel.cancel` | Cancel a queued or running invocation. |
 
-The corpus is Abseil at commit
-`5650e9cf76d3be4318d5fa3af38ee483ddfd5e4a`, using Bazel 9.1.0 and
-`tiktoken-rs` with `o200k_base`. Every run covers six real build, test, query,
-and failure scenarios under cold and warm cache conditions: 180 paired adapter
-observations per run. Adapter order rotates, every observation gets an isolated
-output root, and confidence intervals use deterministic paired bootstrap
-resampling. The reports retain environment metadata, raw evidence, and
-checksummed transcripts.
+`bazel.run` supports `build`, `test`, `coverage`, `query`, `cquery`, `aquery`,
+and selected informational commands. Successful results are limited to 2 KiB
+and unsuccessful results to 8 KiB. Follow-up `bazel.inspect` calls are also
+bounded and paginated, so an agent only retrieves the evidence it needs.
 
-These are deterministic tokenizer estimates, not provider billing. The
-scheduled token workflow repeats the acceptance run on Linux and macOS and
-uploads the same reviewable artifact format for 30 days. Benchmark reports,
-transcripts, and evidence are intentionally excluded from source control. Run
-`make publish-token-benchmark` to package the latest local run under
-`.cache/published-benchmarks`, or download a bundle from the
-[token integration workflow](https://github.com/ewhauser/bazel-mcp/actions/workflows/token-integration.yml).
-`make bench-token-live` uses the Codex CLI JSON event stream to compare
-provider-reported input, cached-input, output, and total tokens for the same
-three adapters.
+## Security and local data
 
-## Development
+`bazel-mcp` executes Bazel with the permissions of the user who started the MCP
+client. It does not make untrusted repositories safe; use a sandbox or isolated
+account for untrusted source.
+
+The server:
+
+- invokes Bazel directly without shell evaluation or concatenated arguments;
+- denies `clean`, `fetch`, `mobile-install`, `run`, `shutdown`, and `sync` by
+  default;
+- prevents requests from overriding server-owned BEP and output-root flags;
+- filters the child-process environment and supports configurable regex
+  redaction;
+- stores raw output and BEP evidence only in the local cache, using private file
+  permissions.
+
+To restrict the server to one or more workspace roots, add a repeated
+`--allow-root` argument to the MCP configuration:
+
+```json
+{
+  "mcpServers": {
+    "bazel": {
+      "command": "bazel-mcp",
+      "args": ["--allow-root", "/absolute/path/to/workspaces"]
+    }
+  }
+}
+```
+
+See [SECURITY.md](SECURITY.md) for the security policy and threat-model
+guidance.
+
+## Configuration
+
+The built-in defaults cover personal local use. For workspace restrictions,
+retention limits, timeouts, command policy, result encoding, or custom
+redaction, start with [`examples/config.toml`](examples/config.toml).
+
+Pass a configuration explicitly with `--config`, set `BAZEL_MCP_CONFIG`, or
+place it at `$XDG_CONFIG_HOME/bazel-mcp/config.toml` (normally
+`~/.config/bazel-mcp/config.toml`). Command-line options can also add allowed
+roots or override the cache directory.
+
+See the [configuration reference](docs/configuration.md) for all settings and
+their defaults.
+
+## Compatibility
+
+| Component | Supported |
+| --- | --- |
+| Bazel | Major versions 7, 8, and 9 |
+| Platforms | macOS and Linux |
+| Transport | Local MCP over stdio |
+| Bazel discovery | `tools/bazel`, then Bazelisk, then Bazel on `PATH` |
+
+Other Bazel major versions are rejected before an invocation is created unless
+they are explicitly enabled in the configuration.
+
+## Performance
+
+Across three independent five-sample runs against a pinned Abseil corpus,
+`bazel-mcp` reduced cumulative model context by 89.73–90.69% compared with a
+default shell agent. The latest run measured an 89.73% reduction, with 0.00%
+median paired Bazel wall-time overhead.
+
+These results are deterministic tokenizer estimates, not provider billing. See
+the [benchmark methodology](docs/benchmarks.md) for the complete results,
+corpus, acceptance gates, and reproduction commands.
+
+## Contributing
+
+Contributions are welcome. The usual local checks are:
 
 ```sh
 make build
 make test
 make check
-make test-bazel-matrix
-make setup-oss-corpus
-make test-token-integration
 ```
 
-The last command runs the credential-free, commit-pinned Abseil comparison and
-enforces the 75% context/byte savings (including the lower 95% confidence
-bound) and 3% median Bazel overhead gates against both shell baselines. See
-[`specs/001-product-requirements.md`](specs/001-product-requirements.md) and
-[`specs/002-project-architecture.md`](specs/002-project-architecture.md). The
-configurable synchronous and task protocol shapes are specified in
-[`specs/003-configurable-mcp-task-execution.md`](specs/003-configurable-mcp-task-execution.md).
+Runner, BEP, policy, or reducer changes should also run
+`make test-bazel-matrix`. Read [CONTRIBUTING.md](CONTRIBUTING.md) before opening
+a pull request.
+
+Architecture and protocol decisions are recorded under [`specs/`](specs/).
+
+## License
+
+`bazel-mcp` is available under the [MIT License](LICENSE).

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -1,0 +1,90 @@
+# Token benchmark
+
+The token integration benchmark measures how much Bazel-related context an
+agent sees when using `bazel-mcp`, a default shell, or a shell with optimized
+instructions. It also measures Bazel wall-time overhead independently from
+model-visible output.
+
+## Results
+
+Three independent five-sample runs against a pinned Abseil commit measured an
+89.73–90.69% reduction in cumulative model context compared with a default
+shell agent.
+
+The latest recorded run produced these results:
+
+| Baseline | Context reduction | Visible-byte reduction | Median Bazel overhead |
+| --- | ---: | ---: | ---: |
+| Default shell | 89.73% (95% CI 87.28–91.38%) | 96.43% (95% CI 95.40–97.09%) | 0.00% |
+| Optimized shell instructions | 94.46% (95% CI 91.90–95.89%) | 97.54% (95% CI 96.53–98.15%) | -0.33% |
+
+These numbers are deterministic tokenizer estimates, not provider billing.
+
+## Corpus and method
+
+The corpus is
+[`abseil/abseil-cpp`](https://github.com/abseil/abseil-cpp) at commit
+`5650e9cf76d3be4318d5fa3af38ee483ddfd5e4a`, using Bazel 9.1.0 and
+`tiktoken-rs` with the `o200k_base` encoding.
+
+Every run covers six real build, test, query, and failure scenarios under cold
+and warm cache conditions. Five samples produce 180 paired adapter
+observations per run. Adapter order rotates, every observation receives an
+isolated output root, and confidence intervals use deterministic paired
+bootstrap resampling.
+
+The generated reports retain environment metadata, raw evidence, checksummed
+transcripts, and the inputs needed to review a comparison. Reports,
+transcripts, and evidence are excluded from source control because they are
+large and may contain local paths.
+
+## Acceptance gates
+
+The credential-free integration benchmark enforces these gates against both
+shell baselines:
+
+- at least 75% cumulative context reduction;
+- at least 75% model-visible byte reduction;
+- a lower 95% confidence bound of at least 75% for both reductions;
+- no more than 3% median paired Bazel wall-time overhead.
+
+## Reproduce the benchmark
+
+Install the development dependencies described in
+[CONTRIBUTING.md](../CONTRIBUTING.md), then set up the pinned corpus once:
+
+```sh
+make setup-oss-corpus
+```
+
+Run the deterministic acceptance benchmark:
+
+```sh
+make test-token-integration
+```
+
+Package the latest report and its reviewable evidence under
+`.cache/published-benchmarks`:
+
+```sh
+make publish-token-benchmark
+```
+
+The scheduled
+[token integration workflow](https://github.com/ewhauser/bazel-mcp/actions/workflows/token-integration.yml)
+repeats the acceptance run on Linux and macOS and retains its artifact bundle
+for 30 days.
+
+## Live-agent comparison
+
+The live benchmark uses the Codex CLI JSON event stream to compare
+provider-reported input, cached-input, output, and total tokens for the same
+three adapters:
+
+```sh
+make bench-token-live
+```
+
+The live comparison is separate from the deterministic acceptance gate because
+provider behavior and billing metrics can change independently of the local
+tokenizer estimate.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,150 @@
+# Configuration
+
+`bazel-mcp` works without a configuration file. The built-in defaults allow
+any Bazel workspace available to the current user and retain invocation
+evidence in a local cache.
+
+For shared environments or tighter local controls, configure allowed workspace
+roots, command policy, retention, timeouts, environment variables, and
+redaction explicitly.
+
+## Loading configuration
+
+The server looks for configuration in this order:
+
+1. the file passed with `--config`;
+2. the file named by `BAZEL_MCP_CONFIG`;
+3. `$XDG_CONFIG_HOME/bazel-mcp/config.toml`, or
+   `~/.config/bazel-mcp/config.toml` when `XDG_CONFIG_HOME` is not set;
+4. built-in defaults.
+
+The default path is used only when the file already exists. Command-line
+`--allow-root` values are added to roots read from the file, and `--cache-root`
+overrides the configured cache directory.
+
+Start with the repository's [example configuration](../examples/config.toml):
+
+```sh
+mkdir -p ~/.config/bazel-mcp
+cp examples/config.toml ~/.config/bazel-mcp/config.toml
+```
+
+Replace the example workspace path before starting the server.
+
+## Common settings
+
+### Restrict workspace access
+
+An empty `allowed_roots` list permits every workspace available to the current
+user. Production or shared configurations should list one or more absolute
+roots:
+
+```toml
+allowed_roots = ["/work/company", "/work/open-source"]
+```
+
+A requested workspace must be contained by one of these roots. The invocation
+cache cannot be located inside an allowed workspace root.
+
+For a single root, the equivalent CLI option is:
+
+```sh
+bazel-mcp --allow-root /work/company
+```
+
+### Select Bazel
+
+By default, `bazel-mcp` looks for an executable in this order:
+
+1. `tools/bazel` in the requested workspace;
+2. `bazelisk` on `PATH`;
+3. `bazel` on `PATH`.
+
+Set an explicit executable to bypass discovery:
+
+```toml
+bazel_executable = "/usr/local/bin/bazelisk"
+```
+
+### Pass environment variables
+
+Child Bazel processes always receive `HOME`, `PATH`, `TMPDIR`, `TEMP`, `TMP`,
+and `USER` when those variables are present. Add other variable names to the
+allowlist when they are required by credentials, toolchains, or remote
+execution:
+
+```toml
+environment_allowlist = ["GOOGLE_APPLICATION_CREDENTIALS", "JAVA_HOME"]
+```
+
+### Redact sensitive text
+
+Configured regular expressions are replaced with `[REDACTED]` before text is
+written to summaries, database text fields, or telemetry:
+
+```toml
+redaction_patterns = [
+  "(?i)authorization: bearer [^\\s]+",
+  "(?i)token=[^\\s]+",
+]
+```
+
+Raw evidence remains local and should still be treated as sensitive.
+
+### Choose a result encoding
+
+```toml
+result_encoding = "text"
+```
+
+Available values are:
+
+| Value | MCP result |
+| --- | --- |
+| `text` | Compact JSON in one text content block. This is the default. |
+| `toon` | Token-oriented TOON text in one content block. |
+| `structured` | MCP structured content only. |
+| `both` | Structured content plus backwards-compatible JSON text. |
+
+## Reference
+
+| Setting | Default | Description |
+| --- | --- | --- |
+| `allowed_roots` | `[]` | Absolute roots containing workspaces the server may access. An empty list allows any workspace. |
+| `cache_root` | Platform user cache under `bazel-mcp` | Directory for metadata, logs, and BEP evidence. |
+| `bazel_executable` | unset | Explicit Bazel or Bazelisk executable. |
+| `output_user_root` | unset | Isolated Bazel output user root managed by the server. |
+| `allowed_commands` | build, test, coverage, query commands, and selected informational commands | Commands eligible to run. |
+| `denied_commands` | `clean`, `fetch`, `mobile-install`, `run`, `shutdown`, `sync` | Commands rejected even if also present in `allowed_commands`. |
+| `environment_allowlist` | `[]` | Additional environment variables passed to Bazel. |
+| `redaction_patterns` | `[]` | Regular expressions removed from model-visible and persisted text fields. |
+| `global_concurrency` | `4` | Maximum concurrent Bazel invocations. |
+| `maximum_pending_invocations` | `256` | Maximum queued and running invocations. Must be at least `global_concurrency`. |
+| `default_timeout_seconds` | `1800` | Timeout used when a request omits one. |
+| `maximum_timeout_seconds` | `7200` | Maximum timeout accepted from a request. |
+| `cancellation_interrupt_grace_seconds` | `10` | Time allowed after the initial interrupt. |
+| `cancellation_terminate_grace_seconds` | `5` | Additional time allowed after termination. |
+| `progress_initial_seconds` | `30` | Delay before the first MCP progress notification. |
+| `progress_interval_seconds` | `60` | Interval between later progress notifications. |
+| `retention_days` | `7` | Maximum age of retained invocation evidence. |
+| `maximum_storage_bytes` | `10737418240` | Maximum cache size before older evidence is removed. |
+| `retention_cleanup_interval_seconds` | `3600` | Interval between retention sweeps. |
+| `result_encoding` | `text` | Model-visible result representation. |
+| `supported_bazel_major_versions` | `[7, 8, 9]` | Bazel major versions accepted by default. |
+| `allow_unsupported_bazel_versions` | `false` | Allow majors outside `supported_bazel_major_versions`. |
+| `version_check_timeout_seconds` | `30` | Timeout for the pre-invocation Bazel version check. |
+| `isolated_bazel_server_idle_seconds` | `60` | Bazel server idle timeout used with `output_user_root`. |
+
+## CLI options
+
+Run `bazel-mcp --help` for the authoritative command-line reference:
+
+| Option | Description |
+| --- | --- |
+| `--config <PATH>` | Read configuration from a TOML file. |
+| `--allow-root <PATH>` | Add an allowed workspace root. May be repeated. |
+| `--cache-root <PATH>` | Override the invocation cache directory. |
+| `--log <FILTER>` | Set the tracing filter written to stderr. |
+
+Standard output is reserved for MCP protocol frames. Tracing and diagnostics
+are always written to standard error.


### PR DESCRIPTION
## Summary

- rewrite the README around the user journey from value proposition to first Bazel invocation
- document Homebrew, GitHub release, shell-installer, and source-build installation paths
- add focused configuration and benchmark reference pages
- retain security, compatibility, performance, and contributor guidance without overwhelming the quick start

## Why

The previous README presented implementation details and benchmark methodology before helping a new user understand, install, and try the project. This made the project documentation read more like internal design notes than an open source landing page.

## User impact

New users get a shorter path to installation and MCP setup, while maintainers keep the detailed configuration and benchmark material in dedicated documentation.

## Validation

- `make check`
- local Markdown link validation
- trailing-whitespace validation
- `git diff --check`
