### PR TITLE
Add negotiated MCP task execution

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,6 +89,19 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with: { persist-credentials: false }
       - run: make mcp-conformance
+  claude-code-compatibility:
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with: { persist-credentials: false }
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with: { node-version: "22" }
+      - run: npm install --global @anthropic-ai/claude-code@2.1.204
+      - run: make test-claude-code
   fuzz-smoke:
     runs-on: ubuntu-latest
     timeout-minutes: 25

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,8 +100,8 @@ jobs:
         with: { persist-credentials: false }
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with: { node-version: "22" }
-      - run: npm install --global @anthropic-ai/claude-code@2.1.204
-      - run: make test-claude-code
+      - run: npm ci --prefix scripts/compat
+      - run: PATH="$PWD/scripts/compat/node_modules/.bin:$PATH" make test-claude-code
   fuzz-smoke:
     runs-on: ubuntu-latest
     timeout-minutes: 25

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -295,6 +295,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tempfile",
+ "time",
  "tokio",
  "tokio-util",
  "toml",
@@ -316,6 +317,7 @@ dependencies = [
  "tempfile",
  "thiserror",
  "tokio",
+ "tracing",
  "turso",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,7 @@ serde_json = "1"
 sha2 = "0.10"
 toon-format = { version = "0.5", default-features = false }
 toml = "0.9"
+time = { version = "0.3", features = ["formatting"] }
 uuid = { version = "1", features = ["serde", "v7"] }
 
 # BEP and reduction

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 	bench-compare bench-token bench-token-live publish-token-benchmark \
 	generate-bep-goldens fuzz-setup fuzz-list fuzz-smoke \
 	fuzz-run harden-release check-release-security \
-	mcp-conformance generate-sbom
+	mcp-conformance test-claude-code test-claude-code-live generate-sbom
 
 ARGS ?= --help
 FUZZ_TARGET ?= bep_framing
@@ -95,6 +95,14 @@ check-release-security: harden-release
 mcp-conformance:
 	cargo build -p bazel-mcp-server --bin bazel-mcp
 	python3 ./scripts/test-mcp-conformance.py
+
+test-claude-code:
+	cargo build -p bazel-mcp-server --bin bazel-mcp
+	python3 ./scripts/compat/test-claude-code.py
+
+test-claude-code-live:
+	cargo build -p bazel-mcp-server --bin bazel-mcp
+	python3 ./scripts/compat/test-claude-code.py --live
 
 generate-sbom:
 	./scripts/generate-release-sbom.sh

--- a/README.md
+++ b/README.md
@@ -108,6 +108,201 @@ and selected informational commands. Successful results are limited to 2 KiB
 and unsuccessful results to 8 KiB. Follow-up `bazel.inspect` calls are also
 bounded and paginated, so an agent only retrieves the evidence it needs.
 
+Long calls can be returned as durable task handles when the MCP client declares
+task support. With the default `auto` policy, the server discovers the
+negotiated protocol and chooses synchronous execution, MCP `2025-11-25` legacy
+tasks, or the `io.modelcontextprotocol/tasks` extension at runtime. This does
+not add tools: task status, result, and cancellation are protocol methods.
+
+## MCP protocol shape
+
+MCP clients normally produce these messages on an agent's behalf, but the wire
+shape is useful when integrating or debugging a host. `bazel-mcp` uses
+newline-delimited JSON-RPC 2.0 over stdio; the examples below are formatted
+across lines for readability and omit unrelated response fields.
+
+| Flow | Client signal | Initial result | Final result |
+| --- | --- | --- | --- |
+| Synchronous | No task capability, or `sync_only` policy | `CallToolResult` | Same `tools/call` response |
+| Legacy tasks | MCP `2025-11-25` plus `params.task` | Nested `result.task` | Separate `tasks/result` call |
+| Tasks extension | Extension capability in request `_meta` | Flat `resultType: "task"` | Inline in terminal `tasks/get` |
+
+<details>
+<summary>Show representative JSON-RPC messages</summary>
+
+### Synchronous call
+
+A basic call is an ordinary MCP tool request:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 2,
+  "method": "tools/call",
+  "params": {
+    "name": "bazel.run",
+    "arguments": {
+      "workspace": "/src/project",
+      "command": "build",
+      "args": ["//app:server"]
+    }
+  }
+}
+```
+
+Without a compatible task opt-in, the request remains attached and returns a
+normal `CallToolResult`. The default `text` encoding places the bounded logical
+result in one text content block:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 2,
+  "result": {
+    "content": [{
+      "type": "text",
+      "text": "{\"invocation_id\":\"019f...\",\"state\":\"succeeded\",\"command\":\"build\",\"exit_code\":0,\"headline\":\"Build succeeded\",\"more_available\":true}"
+    }],
+    "isError": false
+  }
+}
+```
+
+That `invocation_id` can be passed to `bazel.inspect` or `bazel.cancel`.
+Different result encodings change the content representation, not the logical
+result or its byte budget.
+
+### Legacy MCP tasks
+
+A client negotiating MCP `2025-11-25` sees
+`bazel.run.execution.taskSupport = "optional"`. It opts into detached execution
+by adding `params.task` to the same tool call:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 3,
+  "method": "tools/call",
+  "params": {
+    "name": "bazel.run",
+    "arguments": {
+      "workspace": "/src/project",
+      "command": "test",
+      "args": ["//services/..."]
+    },
+    "task": {}
+  }
+}
+```
+
+The response contains a nested task. Its `taskId` is also the Bazel invocation
+ID, and it is readable as soon as the handle is returned:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 3,
+  "result": {
+    "task": {
+      "taskId": "019f...",
+      "status": "working",
+      "ttl": 86400000,
+      "pollInterval": 2000
+    },
+    "_meta": {
+      "io.modelcontextprotocol/related-task": {
+        "taskId": "019f..."
+      }
+    }
+  }
+}
+```
+
+The client polls `tasks/get`, waits for the original `CallToolResult` with
+`tasks/result`, lists durable handles with `tasks/list`, or requests
+`tasks/cancel`.
+
+### Tasks extension
+
+Modern extension-aware clients can discover the capability with
+`server/discover`:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 4,
+  "method": "server/discover",
+  "params": {}
+}
+```
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 4,
+  "result": {
+    "capabilities": {
+      "extensions": {
+        "io.modelcontextprotocol/tasks": {}
+      }
+    }
+  }
+}
+```
+
+After negotiating the extension's `2026-06-30` base protocol, each participating
+request declares the extension in `_meta`. The initial result is flat rather
+than nested:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 5,
+  "method": "tools/call",
+  "params": {
+    "name": "bazel.run",
+    "arguments": {
+      "workspace": "/src/project",
+      "command": "build",
+      "args": ["//app:server"]
+    },
+    "_meta": {
+      "io.modelcontextprotocol/clientCapabilities": {
+        "extensions": {
+          "io.modelcontextprotocol/tasks": {}
+        }
+      }
+    }
+  }
+}
+```
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 5,
+  "result": {
+    "resultType": "task",
+    "taskId": "019f...",
+    "status": "working",
+    "ttlMs": 86400000,
+    "pollIntervalMs": 2000
+  }
+}
+```
+
+Here the client polls `tasks/get`; once terminal, that response contains the
+original `CallToolResult` inline in its `result` field. The extension has no
+`tasks/result` or `tasks/list` methods. Both task dialects are durable across a
+server restart, while clients that declare neither continue to use the simpler
+synchronous shape.
+
+</details>
+
+See [specification 003](specs/003-configurable-mcp-task-execution.md) for the
+complete negotiation matrix, cancellation semantics, error codes, and pinned
+protocol revisions.
+
 ## Security and local data
 
 `bazel-mcp` executes Bazel with the permissions of the user who started the MCP
@@ -164,9 +359,16 @@ their defaults.
 | Platforms | macOS and Linux |
 | Transport | Local MCP over stdio |
 | Bazel discovery | `tools/bazel`, then Bazelisk, then Bazel on `PATH` |
+| Task execution | Synchronous fallback, MCP `2025-11-25` legacy tasks, and the SEP-2663 Tasks extension |
 
 Other Bazel major versions are rejected before an invocation is created unless
 they are explicitly enabled in the configuration.
+
+Use `mcp_execution_policy = "sync_only"` if a host cannot consume task-shaped
+results. Use `tasks_required` only when detached execution is mandatory; calls
+from clients without compatible capabilities are then rejected before Bazel
+starts. See the [configuration reference](docs/configuration.md#configure-negotiated-task-execution)
+for TTL and polling settings.
 
 ## Performance
 

--- a/crates/bazel-mcp-benchmark/resources/protocol/legacy-tasks.jsonl
+++ b/crates/bazel-mcp-benchmark/resources/protocol/legacy-tasks.jsonl
@@ -1,0 +1,4 @@
+{"sequence":0,"adapter":"legacy_tasks","scenario":"successful_build","kind":"tool_call","role":"assistant","model_visible":true,"content":"bazel.run //:fixture task={}"}
+{"sequence":1,"adapter":"legacy_tasks","scenario":"successful_build","kind":"progress","role":"host","model_visible":false,"content":"{\"method\":\"tasks/get\",\"status\":\"working\"}"}
+{"sequence":2,"adapter":"legacy_tasks","scenario":"successful_build","kind":"progress","role":"host","model_visible":false,"content":"{\"method\":\"tasks/result\"}"}
+{"sequence":3,"adapter":"legacy_tasks","scenario":"successful_build","kind":"tool_result","role":"tool","model_visible":true,"content":"{\"command\":\"build\",\"headline\":\"Build completed successfully\",\"state\":\"succeeded\"}"}

--- a/crates/bazel-mcp-benchmark/resources/protocol/synchronous.jsonl
+++ b/crates/bazel-mcp-benchmark/resources/protocol/synchronous.jsonl
@@ -1,0 +1,2 @@
+{"sequence":0,"adapter":"synchronous","scenario":"successful_build","kind":"tool_call","role":"assistant","model_visible":true,"content":"bazel.run //:fixture"}
+{"sequence":1,"adapter":"synchronous","scenario":"successful_build","kind":"tool_result","role":"tool","model_visible":true,"content":"{\"command\":\"build\",\"headline\":\"Build completed successfully\",\"state\":\"succeeded\"}"}

--- a/crates/bazel-mcp-benchmark/resources/protocol/tasks-extension.jsonl
+++ b/crates/bazel-mcp-benchmark/resources/protocol/tasks-extension.jsonl
@@ -1,0 +1,4 @@
+{"sequence":0,"adapter":"tasks_extension","scenario":"successful_build","kind":"tool_call","role":"assistant","model_visible":true,"content":"bazel.run //:fixture capability=io.modelcontextprotocol/tasks"}
+{"sequence":1,"adapter":"tasks_extension","scenario":"successful_build","kind":"progress","role":"host","model_visible":false,"content":"{\"method\":\"tasks/get\",\"resultType\":\"complete\",\"status\":\"working\"}"}
+{"sequence":2,"adapter":"tasks_extension","scenario":"successful_build","kind":"progress","role":"host","model_visible":false,"content":"{\"method\":\"tasks/get\",\"resultType\":\"complete\",\"status\":\"completed\"}"}
+{"sequence":3,"adapter":"tasks_extension","scenario":"successful_build","kind":"tool_result","role":"tool","model_visible":true,"content":"{\"command\":\"build\",\"headline\":\"Build completed successfully\",\"state\":\"succeeded\"}"}

--- a/crates/bazel-mcp-benchmark/src/transcript.rs
+++ b/crates/bazel-mcp-benchmark/src/transcript.rs
@@ -39,6 +39,8 @@ pub struct TranscriptMetrics {
     pub model_events: u64,
     pub tool_calls: u64,
     pub polling_calls: u64,
+    #[serde(default)]
+    pub protocol_polling_bytes: u64,
 }
 
 impl Transcript {
@@ -60,6 +62,7 @@ impl Transcript {
         let mut model_events = 0_u64;
         let mut tool_calls = 0_u64;
         let mut polling_calls = 0_u64;
+        let mut protocol_polling_bytes = 0_u64;
         for event in &self.events {
             if event.kind == TranscriptKind::ModelEvent {
                 model_events += 1;
@@ -70,6 +73,10 @@ impl Transcript {
             }
             if event.kind == TranscriptKind::Progress {
                 polling_calls += 1;
+                if !event.model_visible {
+                    protocol_polling_bytes =
+                        protocol_polling_bytes.saturating_add(event.content.len() as u64);
+                }
             }
             if event.model_visible {
                 if matches!(
@@ -93,6 +100,7 @@ impl Transcript {
             model_events,
             tool_calls,
             polling_calls,
+            protocol_polling_bytes,
         })
     }
 }
@@ -159,5 +167,41 @@ mod tests {
         let metrics = transcript.measure("o200k_base").unwrap();
         assert_eq!(metrics.model_events, 2);
         assert!(metrics.cumulative_context_tokens > metrics.visible_tool_tokens);
+    }
+
+    #[test]
+    fn negotiated_task_transcripts_preserve_results_and_isolate_polling_bytes() {
+        let transcripts = [
+            include_str!("../resources/protocol/synchronous.jsonl"),
+            include_str!("../resources/protocol/legacy-tasks.jsonl"),
+            include_str!("../resources/protocol/tasks-extension.jsonl"),
+        ];
+        let mut final_results = Vec::new();
+        for source in transcripts {
+            let events = source
+                .lines()
+                .map(|line| serde_json::from_str::<TranscriptEvent>(line).unwrap())
+                .collect::<Vec<_>>();
+            let transcript = Transcript {
+                canonicalization_version: 1,
+                events,
+            };
+            let metrics = transcript.measure("o200k_base").unwrap();
+            let result = transcript
+                .events
+                .iter()
+                .rev()
+                .find(|event| event.kind == TranscriptKind::ToolResult)
+                .unwrap()
+                .content
+                .clone();
+            final_results.push(result);
+            if transcript.events[0].adapter == "synchronous" {
+                assert_eq!(metrics.protocol_polling_bytes, 0);
+            } else {
+                assert!(metrics.protocol_polling_bytes > 0);
+            }
+        }
+        assert!(final_results.windows(2).all(|pair| pair[0] == pair[1]));
     }
 }

--- a/crates/bazel-mcp-runner/src/service.rs
+++ b/crates/bazel-mcp-runner/src/service.rs
@@ -21,16 +21,18 @@ use bazel_mcp_reducer::{
 };
 use bazel_mcp_store::{InvocationPaths, Store, StoreError};
 use bazel_mcp_types::{
-    ArtifactKind, BazelCommand, CommandClass, Diagnostic, DiagnosticCategory, InvocationId,
-    InvocationMetrics, InvocationRecord, InvocationRequest, InvocationState, PageRequest, QueryRow,
-    Severity, Termination, TestStatus,
+    ArtifactKind, BazelCommand, CommandClass, DeferredFailure, DeferredFailureKind,
+    DeferredResultRecord, DeferredResultView, DeferredRetrieval, DeferredTerminalState, Diagnostic,
+    DiagnosticCategory, InvocationId, InvocationMetrics, InvocationRecord, InvocationRequest,
+    InvocationState, Page, PageRequest, QueryRow, ResultDisposition, Severity, Termination,
+    TestStatus,
 };
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 use tokio::{
     io::{AsyncBufReadExt, AsyncReadExt, AsyncSeekExt, BufReader},
     process::Command,
-    sync::{Mutex, Semaphore},
+    sync::{Mutex, OwnedSemaphorePermit, Semaphore},
 };
 use tokio_util::sync::CancellationToken;
 
@@ -103,6 +105,10 @@ pub enum RunnerError {
     InvalidOffset,
     #[error("inspect response cannot fit the requested {0}-byte limit")]
     ResponseTooLarge(usize),
+    #[error("invocation was cancelled before it was accepted")]
+    CancelledBeforeAcceptance,
+    #[error("wait for invocation {0} was cancelled")]
+    WaitCancelled(InvocationId),
     #[error(transparent)]
     Json(#[from] serde_json::Error),
 }
@@ -124,6 +130,16 @@ struct VersionCacheKey {
     executable: PathBuf,
     workspace: PathBuf,
     environment: Vec<(String, String)>,
+}
+
+struct PreparedSubmission {
+    queued: InvocationRecord,
+    paths: InvocationPaths,
+    lock_key: PathBuf,
+    executable: PathBuf,
+    cancellation: CancellationToken,
+    _pending_permit: OwnedSemaphorePermit,
+    deferred: bool,
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]
@@ -260,14 +276,156 @@ impl InvocationService {
 
     pub async fn run_with_cancellation(
         &self,
-        mut request: InvocationRequest,
+        request: InvocationRequest,
         cancellation: CancellationToken,
     ) -> Result<InvocationRecord, RunnerError> {
+        let prepared = self
+            .prepare_submission(request, ResultDisposition::Attached, cancellation)
+            .await?;
+        let id = prepared.queued.request.id;
+        let result = self.run_prepared(prepared).await;
+        self.live.lock().await.remove(&id);
+        result
+    }
+
+    /// Durably accept an invocation and execute it independently of the caller.
+    pub async fn submit(
+        &self,
+        request: InvocationRequest,
+        disposition: ResultDisposition,
+    ) -> Result<InvocationId, RunnerError> {
+        let prepared = self
+            .prepare_submission(request, disposition, CancellationToken::new())
+            .await?;
+        let id = prepared.queued.request.id;
+        let deferred = prepared.deferred;
+        let worker_service = self.clone();
+        let worker = tokio::spawn(async move { worker_service.run_prepared(prepared).await });
+        let supervisor = self.clone();
+        tokio::spawn(async move {
+            let error = match worker.await {
+                Ok(Ok(record)) => {
+                    if deferred {
+                        tracing::info!(
+                            target: "bazel_mcp::metrics",
+                            metric = "deferred_invocations_terminal_total",
+                            increment = 1_u64,
+                            state = ?record.state,
+                            "deferred invocation reached a terminal state"
+                        );
+                    }
+                    None
+                }
+                Ok(Err(error)) => Some(error),
+                Err(error) => Some(RunnerError::Join(error)),
+            };
+            if let Some(error) = error {
+                tracing::warn!(invocation_id = %id, %error, "accepted Bazel invocation worker failed");
+                supervisor
+                    .materialize_worker_failure(id, deferred, &error)
+                    .await;
+                if deferred {
+                    tracing::info!(
+                        target: "bazel_mcp::metrics",
+                        metric = "deferred_invocations_terminal_total",
+                        increment = 1_u64,
+                        state = "accepted_execution_error",
+                        "deferred invocation failure was materialized"
+                    );
+                }
+            }
+            supervisor.live.lock().await.remove(&id);
+        });
+        Ok(id)
+    }
+
+    /// Wait for completion without coupling cancellation of this wait to Bazel.
+    pub async fn wait(
+        &self,
+        id: InvocationId,
+        cancellation: CancellationToken,
+    ) -> Result<InvocationRecord, RunnerError> {
+        loop {
+            let record = self.store.get_invocation(id).await?;
+            if record.state.is_terminal() {
+                return Ok(record);
+            }
+            tokio::select! {
+                () = cancellation.cancelled() => return Err(RunnerError::WaitCancelled(id)),
+                () = tokio::time::sleep(Duration::from_millis(25)) => {}
+            }
+        }
+    }
+
+    pub async fn deferred_result(
+        &self,
+        id: InvocationId,
+        retrieval: DeferredRetrieval,
+    ) -> Result<DeferredResultView, RunnerError> {
+        self.store
+            .get_deferred_result(id, retrieval, bazel_mcp_types::unix_timestamp_ms())
+            .await
+            .map_err(Into::into)
+    }
+
+    pub async fn list_deferred_results(
+        &self,
+        retrieval: DeferredRetrieval,
+        page: PageRequest,
+    ) -> Result<Page<DeferredResultView>, RunnerError> {
+        self.store
+            .list_deferred_results(retrieval, bazel_mcp_types::unix_timestamp_ms(), page)
+            .await
+            .map_err(Into::into)
+    }
+
+    pub async fn record_deferred_cancellation(&self, id: InvocationId) -> Result<(), RunnerError> {
+        self.store
+            .record_deferred_cancellation(id, bazel_mcp_types::unix_timestamp_ms())
+            .await?;
+        Ok(())
+    }
+
+    pub async fn set_deferred_cancelled(&self, id: InvocationId) -> Result<(), RunnerError> {
+        self.store
+            .set_deferred_terminal_override(
+                id,
+                DeferredTerminalState::Cancelled,
+                bazel_mcp_types::unix_timestamp_ms(),
+            )
+            .await?;
+        Ok(())
+    }
+
+    pub async fn extend_deferred_expiry(
+        &self,
+        id: InvocationId,
+        minimum_expires_at_ms: i64,
+    ) -> Result<(), RunnerError> {
+        self.store
+            .extend_deferred_expiry(
+                id,
+                minimum_expires_at_ms,
+                bazel_mcp_types::unix_timestamp_ms(),
+            )
+            .await?;
+        Ok(())
+    }
+
+    async fn prepare_submission(
+        &self,
+        mut request: InvocationRequest,
+        disposition: ResultDisposition,
+        cancellation: CancellationToken,
+    ) -> Result<PreparedSubmission, RunnerError> {
+        if cancellation.is_cancelled() {
+            return Err(RunnerError::CancelledBeforeAcceptance);
+        }
         validate_command(&self.config.policy, &request.command)?;
         validate_arguments(&request.startup_arguments)?;
         validate_arguments(&request.arguments)?;
         validate_query_arguments(&request.command, &request.arguments)?;
-        let _pending_permit = self
+        let pending_permit = self
             .pending
             .clone()
             .try_acquire_owned()
@@ -277,14 +435,60 @@ impl InvocationService {
             .unwrap_or_else(|| workspace.clone());
         let executable = resolve_bazel_executable(&workspace, &self.config.policy)?;
         self.validate_bazel_version(&executable, &workspace).await?;
+        if cancellation.is_cancelled() {
+            return Err(RunnerError::CancelledBeforeAcceptance);
+        }
         request.workspace = workspace.clone();
         let id = request.id;
         let queued = InvocationRecord::queued(request);
         let stored = InvocationRecord::queued(self.redacted_request(&queued.request));
-        let paths = self.store.create_invocation(&stored).await?;
+        let deferred = match disposition {
+            ResultDisposition::Attached => None,
+            ResultDisposition::Deferred {
+                retrieval,
+                expires_at_ms,
+            } => {
+                let now_ms = bazel_mcp_types::unix_timestamp_ms();
+                Some(DeferredResultRecord::new(
+                    id,
+                    retrieval,
+                    now_ms,
+                    expires_at_ms,
+                ))
+            }
+        };
+        let paths = self
+            .store
+            .create_invocation_with_deferred(&stored, deferred.as_ref())
+            .await?;
         self.live.lock().await.insert(id, cancellation.clone());
 
-        let result = async {
+        Ok(PreparedSubmission {
+            queued,
+            paths,
+            lock_key,
+            executable,
+            cancellation,
+            _pending_permit: pending_permit,
+            deferred: deferred.is_some(),
+        })
+    }
+
+    async fn run_prepared(
+        &self,
+        prepared: PreparedSubmission,
+    ) -> Result<InvocationRecord, RunnerError> {
+        let PreparedSubmission {
+            queued,
+            paths,
+            lock_key,
+            executable,
+            cancellation,
+            _pending_permit,
+            deferred: _,
+        } = prepared;
+        let id = queued.request.id;
+        async {
             let workspace_lock = self.workspace_lock(&lock_key).await;
             let workspace_guard = tokio::select! {
                 guard = workspace_lock.lock() => guard,
@@ -352,9 +556,55 @@ impl InvocationService {
             drop(permit);
             result
         }
-        .await;
-        self.live.lock().await.remove(&id);
-        result
+        .await
+    }
+
+    async fn materialize_worker_failure(
+        &self,
+        id: InvocationId,
+        deferred: bool,
+        error: &RunnerError,
+    ) {
+        let message = self.redactor.redact_bounded(
+            &format!("accepted invocation worker failed: {error}"),
+            1_000,
+        );
+        if deferred {
+            let _ = self
+                .store
+                .persist_deferred_failure(
+                    id,
+                    &DeferredFailure {
+                        kind: DeferredFailureKind::Execution,
+                        redacted_message: message.clone(),
+                    },
+                    bazel_mcp_types::unix_timestamp_ms(),
+                )
+                .await;
+        }
+        if self
+            .store
+            .get_invocation(id)
+            .await
+            .is_ok_and(|record| !record.state.is_terminal())
+        {
+            let _ = self
+                .store
+                .transition(
+                    id,
+                    InvocationState::Failed,
+                    Some(Termination::SpawnFailure {
+                        message: message.clone(),
+                    }),
+                    Some(bazel_mcp_types::InvocationSummary {
+                        success: false,
+                        headline: "Accepted Bazel invocation could not be executed".to_owned(),
+                        truncated: true,
+                        ..Default::default()
+                    }),
+                )
+                .await;
+        }
     }
 
     async fn validate_bazel_version(

--- a/crates/bazel-mcp-runner/tests/process.rs
+++ b/crates/bazel-mcp-runner/tests/process.rs
@@ -10,11 +10,12 @@ use bazel_mcp_policy::PolicyConfig;
 use bazel_mcp_runner::{InspectRequest, InspectView, InvocationService, RunnerConfig};
 use bazel_mcp_store::Store;
 use bazel_mcp_types::{
-    Artifact, ArtifactKind, BazelCommand, Diagnostic, DiagnosticCategory, InvocationRecord,
-    InvocationRequest, InvocationState, InvocationSummary, Severity, Termination, TestCase,
-    TestResult, TestStatus,
+    Artifact, ArtifactKind, BazelCommand, DeferredRetrieval, Diagnostic, DiagnosticCategory,
+    InvocationRecord, InvocationRequest, InvocationState, InvocationSummary, ResultDisposition,
+    Severity, Termination, TestCase, TestResult, TestStatus,
 };
 use tempfile::TempDir;
+use tokio_util::sync::CancellationToken;
 
 async fn wait_for_path(path: &Path) {
     for _ in 0..500 {
@@ -24,6 +25,16 @@ async fn wait_for_path(path: &Path) {
         tokio::time::sleep(Duration::from_millis(10)).await;
     }
     panic!("timed out waiting for {}", path.display());
+}
+
+async fn wait_for_invocation(service: &InvocationService, id: bazel_mcp_types::InvocationId) {
+    for _ in 0..500 {
+        if service.store().get_invocation(id).await.is_ok() {
+            return;
+        }
+        tokio::time::sleep(Duration::from_millis(10)).await;
+    }
+    panic!("timed out waiting for invocation {id}");
 }
 
 async fn service(root: &TempDir, workspace: &Path, script: &str) -> InvocationService {
@@ -270,13 +281,102 @@ async fn cancellation_stops_a_running_process_group() {
         let service = service.clone();
         async move { service.run(request).await.unwrap() }
     });
-    tokio::time::sleep(Duration::from_millis(150)).await;
+    wait_for_invocation(&service, id).await;
     assert!(service.cancel(id).await.unwrap().cancellation_requested);
     let record = tokio::time::timeout(Duration::from_secs(3), running)
         .await
         .unwrap()
         .unwrap();
     assert_eq!(record.state, InvocationState::Cancelled);
+}
+
+#[tokio::test]
+async fn deferred_submission_commits_before_completion_and_survives_wait_cancellation() {
+    let root = tempfile::tempdir().unwrap();
+    let workspace = root.path().join("workspace");
+    tokio::fs::create_dir(&workspace).await.unwrap();
+    let launches = root.path().join("launches");
+    let service = service(
+        &root,
+        &workspace,
+        &format!(
+            "#!/bin/sh\nfor arg in \"$@\"; do [ \"$arg\" = //:warm ] && exit 0; done\necho run >> '{}'\nsleep 0.4\nexit 0\n",
+            launches.display()
+        ),
+    )
+    .await;
+    service
+        .run(InvocationRequest::new(
+            workspace.clone(),
+            BazelCommand::Build,
+            vec!["//:warm".into()],
+        ))
+        .await
+        .unwrap();
+    let request = InvocationRequest::new(
+        workspace.clone(),
+        BazelCommand::Build,
+        vec!["//:deferred".into()],
+    );
+    let id = request.id;
+    let started = Instant::now();
+    let accepted = service
+        .submit(
+            request,
+            ResultDisposition::Deferred {
+                retrieval: DeferredRetrieval::InlineResult,
+                expires_at_ms: bazel_mcp_types::unix_timestamp_ms() + 60_000,
+            },
+        )
+        .await
+        .unwrap();
+    assert_eq!(accepted, id);
+    assert!(started.elapsed() < Duration::from_millis(300));
+    let visible = service
+        .deferred_result(id, DeferredRetrieval::InlineResult)
+        .await
+        .unwrap();
+    assert!(!visible.invocation.state.is_terminal());
+
+    let cancelled_wait = CancellationToken::new();
+    cancelled_wait.cancel();
+    assert!(matches!(
+        service.wait(id, cancelled_wait).await,
+        Err(bazel_mcp_runner::RunnerError::WaitCancelled(found)) if found == id
+    ));
+
+    let completed = tokio::time::timeout(
+        Duration::from_secs(3),
+        service.wait(id, CancellationToken::new()),
+    )
+    .await
+    .unwrap()
+    .unwrap();
+    assert_eq!(completed.state, InvocationState::Succeeded);
+    assert_eq!(
+        tokio::fs::read_to_string(&launches)
+            .await
+            .unwrap()
+            .lines()
+            .count(),
+        1
+    );
+
+    let rejected = InvocationRequest::new(workspace, BazelCommand::Clean, Vec::new());
+    let rejected_id = rejected.id;
+    assert!(
+        service
+            .submit(
+                rejected,
+                ResultDisposition::Deferred {
+                    retrieval: DeferredRetrieval::InlineResult,
+                    expires_at_ms: bazel_mcp_types::unix_timestamp_ms() + 60_000,
+                },
+            )
+            .await
+            .is_err()
+    );
+    assert!(service.store().get_invocation(rejected_id).await.is_err());
 }
 
 #[tokio::test]
@@ -354,7 +454,9 @@ async fn bounds_hundreds_of_pending_requests_with_an_explicit_queue_limit() {
             }),
         ));
     }
-    tokio::time::sleep(Duration::from_millis(100)).await;
+    for (id, _) in &accepted {
+        wait_for_invocation(&service, *id).await;
+    }
     for index in 8..300 {
         let error = service
             .run(InvocationRequest::new(
@@ -367,6 +469,7 @@ async fn bounds_hundreds_of_pending_requests_with_an_explicit_queue_limit() {
         assert!(matches!(error, bazel_mcp_runner::RunnerError::QueueFull(8)));
     }
     for (id, task) in accepted {
+        wait_for_invocation(&service, id).await;
         service.cancel(id).await.unwrap();
         let record = tokio::time::timeout(Duration::from_secs(3), task)
             .await
@@ -428,7 +531,7 @@ async fn queued_cancellation_returns_a_complete_terminal_summary() {
         let service = service.clone();
         async move { service.run(queued_request).await.unwrap() }
     });
-    tokio::time::sleep(Duration::from_millis(50)).await;
+    wait_for_invocation(&service, queued_id).await;
     assert!(
         service
             .cancel(queued_id)
@@ -459,6 +562,15 @@ async fn scheduler_uses_effective_output_base_and_never_evaluates_arguments() {
         .await
         .unwrap();
     let service = service(&root, &first, "#!/bin/sh\nsleep 0.3\nexit 0\n").await;
+
+    service
+        .run(InvocationRequest::new(
+            first.clone(),
+            BazelCommand::Build,
+            vec!["//:warm-version-cache".into()],
+        ))
+        .await
+        .unwrap();
 
     let shell_marker = root.path().join("shell-evaluated");
     let literal_argument = format!("$(touch {})", shell_marker.display());

--- a/crates/bazel-mcp-server/Cargo.toml
+++ b/crates/bazel-mcp-server/Cargo.toml
@@ -32,6 +32,7 @@ tokio.workspace = true
 tokio-util.workspace = true
 toon-format.workspace = true
 toml.workspace = true
+time.workspace = true
 tracing.workspace = true
 tracing-subscriber.workspace = true
 uuid.workspace = true

--- a/crates/bazel-mcp-server/src/config.rs
+++ b/crates/bazel-mcp-server/src/config.rs
@@ -18,6 +18,15 @@ pub enum ResultEncoding {
     Both,
 }
 
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum McpExecutionPolicy {
+    #[default]
+    Auto,
+    SyncOnly,
+    TasksRequired,
+}
+
 #[derive(Clone, Debug, Parser)]
 #[command(name = "bazel-mcp", version, about)]
 pub struct Cli {
@@ -62,6 +71,9 @@ pub struct ServerConfig {
     pub maximum_pending_invocations: usize,
     pub retention_cleanup_interval_seconds: u64,
     pub isolated_bazel_server_idle_seconds: u64,
+    pub mcp_execution_policy: McpExecutionPolicy,
+    pub task_ttl_seconds: u64,
+    pub task_poll_interval_ms: u64,
 }
 
 impl Default for ServerConfig {
@@ -92,6 +104,9 @@ impl Default for ServerConfig {
             maximum_pending_invocations: 256,
             retention_cleanup_interval_seconds: 60 * 60,
             isolated_bazel_server_idle_seconds: 60,
+            mcp_execution_policy: McpExecutionPolicy::Auto,
+            task_ttl_seconds: 24 * 60 * 60,
+            task_poll_interval_ms: 2_000,
         }
     }
 }
@@ -139,6 +154,12 @@ impl ServerConfig {
         }
         if config.isolated_bazel_server_idle_seconds == 0 {
             anyhow::bail!("isolated Bazel server idle timeout must be greater than zero");
+        }
+        if config.task_ttl_seconds == 0 {
+            anyhow::bail!("task TTL must be greater than zero");
+        }
+        if !(100..=60_000).contains(&config.task_poll_interval_ms) {
+            anyhow::bail!("task poll interval must be between 100 and 60000 milliseconds");
         }
         if !config.allow_unsupported_bazel_versions
             && config.supported_bazel_major_versions.is_empty()
@@ -371,6 +392,57 @@ mod tests {
             );
             let config = ServerConfig::load(&cli(path)).unwrap();
             assert_eq!(config.result_encoding, expected);
+        }
+    }
+
+    #[test]
+    fn task_configuration_defaults_and_round_trips() {
+        let config = ServerConfig::default();
+        assert_eq!(config.mcp_execution_policy, McpExecutionPolicy::Auto);
+        assert_eq!(config.task_ttl_seconds, 86_400);
+        assert_eq!(config.task_poll_interval_ms, 2_000);
+
+        for (name, expected) in [
+            ("auto", McpExecutionPolicy::Auto),
+            ("sync_only", McpExecutionPolicy::SyncOnly),
+            ("tasks_required", McpExecutionPolicy::TasksRequired),
+        ] {
+            let encoded = serde_json::to_string(&expected).unwrap();
+            let decoded: McpExecutionPolicy = serde_json::from_str(&encoded).unwrap();
+            assert_eq!(decoded, expected, "policy {name}");
+        }
+        assert!(serde_json::from_str::<McpExecutionPolicy>("\"detached\"").is_err());
+    }
+
+    #[test]
+    fn validates_task_lifecycle_settings_for_every_policy() {
+        let root = tempdir().unwrap();
+        let workspace = root.path().join("workspace");
+        fs::create_dir(&workspace).unwrap();
+
+        for extra in [
+            "task_ttl_seconds = 0\n",
+            "task_poll_interval_ms = 99\n",
+            "task_poll_interval_ms = 60001\n",
+        ] {
+            let path = write_config(root.path(), &workspace, extra);
+            assert!(ServerConfig::load(&cli(path)).is_err(), "accepted {extra}");
+        }
+
+        for (name, expected) in [
+            ("auto", McpExecutionPolicy::Auto),
+            ("sync_only", McpExecutionPolicy::SyncOnly),
+            ("tasks_required", McpExecutionPolicy::TasksRequired),
+        ] {
+            let path = write_config(
+                root.path(),
+                &workspace,
+                &format!(
+                    "mcp_execution_policy = {name:?}\ntask_ttl_seconds = 1\ntask_poll_interval_ms = 100\n"
+                ),
+            );
+            let config = ServerConfig::load(&cli(path)).unwrap();
+            assert_eq!(config.mcp_execution_policy, expected);
         }
     }
 }

--- a/crates/bazel-mcp-server/src/handler.rs
+++ b/crates/bazel-mcp-server/src/handler.rs
@@ -1,22 +1,26 @@
-use std::{path::PathBuf, str::FromStr};
+use std::{collections::BTreeMap, path::PathBuf, str::FromStr, time::Duration};
 
 use bazel_mcp_runner::{InspectRequest, InspectView, InvocationService};
 use bazel_mcp_types::{
-    BazelCommand, Diagnostic, InvocationId, InvocationRequest, QueryRow, TargetCounts, Termination,
-    TestCounts,
+    BazelCommand, DeferredResultView, DeferredRetrieval, DeferredTerminalState, Diagnostic,
+    InvocationId, InvocationRecord, InvocationRequest, InvocationState, PageRequest, QueryRow,
+    ResultDisposition, TargetCounts, Termination, TestCounts,
 };
 use rmcp::{
-    RoleServer, ServerHandler,
-    handler::server::{router::tool::ToolRouter, wrapper::Parameters},
-    model::{CallToolResult, ContentBlock, Meta, ProgressNotificationParam},
+    ErrorData, RoleServer,
+    handler::server::{router::tool::ToolRouter, tool::ToolCallContext, wrapper::Parameters},
+    model::*,
     schemars,
-    service::Peer,
-    tool, tool_handler, tool_router,
+    service::{NotificationContext, Peer, RequestContext, Service, ServiceRole},
+    tool, tool_router,
 };
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
-use crate::ResultEncoding;
+use crate::{McpExecutionPolicy, ResultEncoding};
+
+const TASKS_EXTENSION: &str = "io.modelcontextprotocol/tasks";
+const IMMEDIATE_RESPONSE: &str = "io.modelcontextprotocol/model-immediate-response";
 
 #[derive(Clone)]
 pub struct BazelMcpServer {
@@ -24,10 +28,9 @@ pub struct BazelMcpServer {
     result_encoding: ResultEncoding,
     progress_initial_delay: std::time::Duration,
     progress_interval: std::time::Duration,
-    #[expect(
-        dead_code,
-        reason = "the rmcp tool_handler macro reads this router field"
-    )]
+    execution_policy: McpExecutionPolicy,
+    task_ttl: Duration,
+    task_poll_interval_ms: u64,
     tool_router: ToolRouter<Self>,
 }
 
@@ -105,6 +108,9 @@ impl BazelMcpServer {
             result_encoding,
             progress_initial_delay: std::time::Duration::from_secs(30),
             progress_interval: std::time::Duration::from_secs(60),
+            execution_policy: McpExecutionPolicy::Auto,
+            task_ttl: Duration::from_secs(24 * 60 * 60),
+            task_poll_interval_ms: 2_000,
             tool_router: Self::tool_router(),
         }
     }
@@ -117,6 +123,19 @@ impl BazelMcpServer {
     ) -> Self {
         self.progress_initial_delay = initial_delay;
         self.progress_interval = interval;
+        self
+    }
+
+    #[must_use]
+    pub fn with_task_execution(
+        mut self,
+        policy: McpExecutionPolicy,
+        ttl: Duration,
+        poll_interval_ms: u64,
+    ) -> Self {
+        self.execution_policy = policy;
+        self.task_ttl = ttl;
+        self.task_poll_interval_ms = poll_interval_ms;
         self
     }
 }
@@ -192,76 +211,7 @@ impl BazelMcpServer {
                 .record_progress_notifications(id, progress_notifications)
                 .await;
         }
-        let exit_code = match &record.termination {
-            Some(Termination::Exit { code }) => Some(*code),
-            _ => None,
-        };
-        let summary = record
-            .summary
-            .as_ref()
-            .ok_or_else(|| "completed invocation has no summary".to_owned())?;
-        let mut diagnostic_count = summary.diagnostics.len();
-        let mut query_sample_count = summary.query_sample.len();
-        loop {
-            let result = RunResult {
-                invocation_id: record.request.id.to_string(),
-                state: record.state,
-                command: record.request.command.as_str(),
-                exit_code,
-                duration_ms: record.metrics.bazel_wall_ms,
-                stdout_bytes: record.metrics.raw_stdout_bytes,
-                stderr_bytes: record.metrics.raw_stderr_bytes,
-                headline: &summary.headline,
-                targets: summary.target_counts.clone(),
-                tests: summary.test_counts.clone(),
-                diagnostics: &summary.diagnostics[..diagnostic_count],
-                query_result_count: summary.query_result_count,
-                query_sample: (query_sample_count > 0)
-                    .then_some(&summary.query_sample[..query_sample_count]),
-                truncated: summary.truncated
-                    || diagnostic_count < summary.diagnostics.len()
-                    || query_sample_count < summary.query_sample.len(),
-                available_views: &[
-                    "summary",
-                    "diagnostics",
-                    "tests",
-                    "coverage",
-                    "artifacts",
-                    "query_results",
-                    "log",
-                ],
-                more_available: summary.truncated
-                    || diagnostic_count < summary.diagnostics.len()
-                    || query_sample_count < summary.query_sample.len()
-                    || !summary.targets.is_empty()
-                    || !summary.tests.is_empty()
-                    || summary.inspect_hint.is_some(),
-            };
-            let value = serde_json::to_value(&result).map_err(|error| error.to_string())?;
-            let limit = if summary.success { 2 * 1024 } else { 8 * 1024 };
-            let bytes = self.model_visible_bytes(&value)?;
-            if bytes <= limit {
-                if let Err(error) = self
-                    .runner
-                    .record_model_visible_result(record.request.id, bytes, false)
-                    .await
-                {
-                    tracing::warn!(
-                        invocation_id = %record.request.id,
-                        %error,
-                        "could not persist model-visible response metrics"
-                    );
-                }
-                return self.encode(value);
-            }
-            if query_sample_count > 0 {
-                query_sample_count -= 1;
-            } else if diagnostic_count > 0 {
-                diagnostic_count -= 1;
-            } else {
-                return Err("bounded bazel.run response could not fit its hard byte limit".into());
-            }
-        }
+        self.build_run_result(&record, false).await
     }
 
     #[tool(
@@ -351,6 +301,87 @@ impl BazelMcpServer {
 }
 
 impl BazelMcpServer {
+    async fn build_run_result(
+        &self,
+        record: &InvocationRecord,
+        tool_error: bool,
+    ) -> Result<CallToolResult, String> {
+        let exit_code = match &record.termination {
+            Some(Termination::Exit { code }) => Some(*code),
+            _ => None,
+        };
+        let summary = record
+            .summary
+            .as_ref()
+            .ok_or_else(|| "completed invocation has no summary".to_owned())?;
+        let mut diagnostic_count = summary.diagnostics.len();
+        let mut query_sample_count = summary.query_sample.len();
+        loop {
+            let result = RunResult {
+                invocation_id: record.request.id.to_string(),
+                state: record.state,
+                command: record.request.command.as_str(),
+                exit_code,
+                duration_ms: record.metrics.bazel_wall_ms,
+                stdout_bytes: record.metrics.raw_stdout_bytes,
+                stderr_bytes: record.metrics.raw_stderr_bytes,
+                headline: &summary.headline,
+                targets: summary.target_counts.clone(),
+                tests: summary.test_counts.clone(),
+                diagnostics: &summary.diagnostics[..diagnostic_count],
+                query_result_count: summary.query_result_count,
+                query_sample: (query_sample_count > 0)
+                    .then_some(&summary.query_sample[..query_sample_count]),
+                truncated: summary.truncated
+                    || diagnostic_count < summary.diagnostics.len()
+                    || query_sample_count < summary.query_sample.len(),
+                available_views: &[
+                    "summary",
+                    "diagnostics",
+                    "tests",
+                    "coverage",
+                    "artifacts",
+                    "query_results",
+                    "log",
+                ],
+                more_available: summary.truncated
+                    || diagnostic_count < summary.diagnostics.len()
+                    || query_sample_count < summary.query_sample.len()
+                    || !summary.targets.is_empty()
+                    || !summary.tests.is_empty()
+                    || summary.inspect_hint.is_some(),
+            };
+            let value = serde_json::to_value(&result).map_err(|error| error.to_string())?;
+            let limit = if summary.success { 2 * 1024 } else { 8 * 1024 };
+            let bytes = self.model_visible_bytes(&value)?;
+            if bytes <= limit {
+                if let Err(error) = self
+                    .runner
+                    .record_model_visible_result(record.request.id, bytes, false)
+                    .await
+                {
+                    tracing::warn!(
+                        invocation_id = %record.request.id,
+                        %error,
+                        "could not persist model-visible response metrics"
+                    );
+                }
+                let mut encoded = self.encode(value)?;
+                if tool_error {
+                    encoded.is_error = Some(true);
+                }
+                return Ok(encoded);
+            }
+            if query_sample_count > 0 {
+                query_sample_count -= 1;
+            } else if diagnostic_count > 0 {
+                diagnostic_count -= 1;
+            } else {
+                return Err("bounded bazel.run response could not fit its hard byte limit".into());
+            }
+        }
+    }
+
     fn single_representation_budget(&self, visible_budget: usize) -> usize {
         match self.result_encoding {
             ResultEncoding::Text | ResultEncoding::Toon | ResultEncoding::Structured => {
@@ -395,12 +426,771 @@ impl BazelMcpServer {
     }
 }
 
-#[tool_handler(
-    name = "bazel-mcp",
-    version = "0.1.0",
-    instructions = "Run Bazel through bazel.run; use bazel.inspect only for bounded follow-up evidence."
-)]
-impl ServerHandler for BazelMcpServer {}
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum ProtocolFamily {
+    Earlier,
+    LegacyTasks,
+    TasksExtension,
+}
+
+impl ProtocolFamily {
+    const fn as_str(self) -> &'static str {
+        match self {
+            Self::Earlier => "synchronous",
+            Self::LegacyTasks => "legacy_tasks",
+            Self::TasksExtension => "tasks_extension",
+        }
+    }
+}
+
+impl BazelMcpServer {
+    fn protocol_family(version: Option<&ProtocolVersion>) -> ProtocolFamily {
+        match version {
+            Some(version) if version == &ProtocolVersion::V_2025_11_25 => {
+                ProtocolFamily::LegacyTasks
+            }
+            Some(version) if version.as_str() >= "2026-06-30" => ProtocolFamily::TasksExtension,
+            _ => ProtocolFamily::Earlier,
+        }
+    }
+
+    fn initialize_result(&self, version: ProtocolVersion) -> InitializeResult {
+        let family = Self::protocol_family(Some(&version));
+        let mut capabilities = ServerCapabilities::default();
+        capabilities.tools = Some(ToolsCapability::default());
+        match family {
+            ProtocolFamily::LegacyTasks => {
+                let tasks = if self.execution_policy == McpExecutionPolicy::SyncOnly {
+                    let mut tasks = TasksCapability::default();
+                    tasks.list = Some(JsonObject::new());
+                    tasks.cancel = Some(JsonObject::new());
+                    tasks
+                } else {
+                    TasksCapability::server_default()
+                };
+                capabilities.tasks = Some(tasks);
+            }
+            ProtocolFamily::TasksExtension => {
+                capabilities.extensions = Some(BTreeMap::from([(
+                    TASKS_EXTENSION.to_owned(),
+                    JsonObject::new(),
+                )]));
+            }
+            ProtocolFamily::Earlier => {}
+        }
+        let mut result = InitializeResult::new(capabilities)
+            .with_server_info(Implementation::new("bazel-mcp", env!("CARGO_PKG_VERSION")))
+            .with_instructions(
+                "Run Bazel through bazel.run; use bazel.inspect only for bounded follow-up evidence.",
+            );
+        result.protocol_version = version;
+        result
+    }
+
+    fn tools_for(&self, family: ProtocolFamily) -> Vec<Tool> {
+        let mut tools = self.tool_router.list_all();
+        if family == ProtocolFamily::LegacyTasks {
+            for tool in &mut tools {
+                if tool.name == "bazel.run" {
+                    tool.execution = match self.execution_policy {
+                        McpExecutionPolicy::Auto => {
+                            Some(ToolExecution::new().with_task_support(TaskSupport::Optional))
+                        }
+                        McpExecutionPolicy::SyncOnly => None,
+                        McpExecutionPolicy::TasksRequired => {
+                            Some(ToolExecution::new().with_task_support(TaskSupport::Required))
+                        }
+                    };
+                }
+            }
+        }
+        tools
+    }
+
+    fn extension_capable(meta: &Meta) -> bool {
+        meta.client_capabilities()
+            .and_then(|capabilities| capabilities.extensions)
+            .is_some_and(|extensions| extensions.contains_key(TASKS_EXTENSION))
+    }
+
+    fn trace_task_call(family: ProtocolFamily, method: &'static str) {
+        tracing::info!(
+            target: "bazel_mcp::metrics",
+            metric = "task_protocol_calls_total",
+            increment = 1_u64,
+            protocol_family = family.as_str(),
+            method,
+            "handled task protocol call"
+        );
+    }
+
+    fn trace_task_response<T: Serialize>(
+        family: ProtocolFamily,
+        phase: &'static str,
+        response: &T,
+    ) {
+        if let Ok(response) = serde_json::to_vec(response) {
+            tracing::info!(
+                target: "bazel_mcp::metrics",
+                metric = "task_protocol_response_bytes",
+                protocol_family = family.as_str(),
+                phase,
+                observe_bytes = response.len(),
+                "observed task protocol response size"
+            );
+        }
+    }
+
+    fn missing_extension_capability() -> ErrorData {
+        tracing::info!(
+            target: "bazel_mcp::metrics",
+            metric = "task_capability_mismatch_total",
+            increment = 1_u64,
+            protocol_family = ProtocolFamily::TasksExtension.as_str(),
+            "rejected request missing the task extension capability"
+        );
+        ErrorData::new(
+            ErrorCode(-32_003),
+            "Missing Required Client Capability",
+            Some(serde_json::json!({
+                "requiredCapabilities": {
+                    "extensions": { (TASKS_EXTENSION): {} }
+                }
+            })),
+        )
+    }
+
+    fn method_not_found(message: impl Into<String>) -> ErrorData {
+        ErrorData::new(ErrorCode::METHOD_NOT_FOUND, message.into(), None)
+    }
+
+    fn task_not_found(id: &str) -> ErrorData {
+        tracing::info!(
+            target: "bazel_mcp::metrics",
+            metric = "task_unknown_or_expired_id_total",
+            increment = 1_u64,
+            "rejected unknown or expired deferred result identifier"
+        );
+        ErrorData::invalid_params(format!("unknown or expired task ID: {id}"), None)
+    }
+
+    fn decode_run_request(arguments: Option<JsonObject>) -> Result<InvocationRequest, String> {
+        let params: RunParams =
+            serde_json::from_value(serde_json::Value::Object(arguments.unwrap_or_default()))
+                .map_err(|error| format!("invalid bazel.run arguments: {error}"))?;
+        let command = match BazelCommand::from_str(&params.command) {
+            Ok(command) => command,
+            Err(never) => match never {},
+        };
+        let mut request =
+            InvocationRequest::new(PathBuf::from(params.workspace), command, params.args);
+        request.startup_arguments = params.startup_args;
+        request.timeout_ms = params
+            .timeout_seconds
+            .map(|seconds| seconds.saturating_mul(1_000));
+        Ok(request)
+    }
+
+    async fn submit_deferred(
+        &self,
+        arguments: Option<JsonObject>,
+        retrieval: DeferredRetrieval,
+    ) -> Result<DeferredResultView, CallToolResult> {
+        let started = std::time::Instant::now();
+        let request = Self::decode_run_request(arguments).map_err(tool_error)?;
+        let ttl_ms = i64::try_from(self.task_ttl.as_millis()).unwrap_or(i64::MAX);
+        let expires_at_ms = bazel_mcp_types::unix_timestamp_ms().saturating_add(ttl_ms);
+        let id = self
+            .runner
+            .submit(
+                request,
+                ResultDisposition::Deferred {
+                    retrieval,
+                    expires_at_ms,
+                },
+            )
+            .await
+            .map_err(|error| tool_error(error.to_string()))?;
+        let mut view = self
+            .runner
+            .deferred_result(id, retrieval)
+            .await
+            .map_err(|error| tool_error(error.to_string()))?;
+        let minimum_expiry = view.deferred.created_at_ms.saturating_add(ttl_ms);
+        if view.deferred.expires_at_ms < minimum_expiry {
+            self.runner
+                .extend_deferred_expiry(id, minimum_expiry)
+                .await
+                .map_err(|error| tool_error(error.to_string()))?;
+            view = self
+                .runner
+                .deferred_result(id, retrieval)
+                .await
+                .map_err(|error| tool_error(error.to_string()))?;
+        }
+        tracing::info!(
+            target: "bazel_mcp::metrics",
+            metric = "deferred_invocations_accepted_total",
+            increment = 1_u64,
+            retrieval = retrieval.as_str(),
+            "deferred invocation accepted"
+        );
+        tracing::info!(
+            target: "bazel_mcp::metrics",
+            metric = "task_creation_acknowledgement_latency_ms",
+            observe_ms = u64::try_from(started.elapsed().as_millis()).unwrap_or(u64::MAX),
+            retrieval = retrieval.as_str(),
+            "observed task creation acknowledgement latency"
+        );
+        Ok(view)
+    }
+
+    fn legacy_task(&self, view: &DeferredResultView) -> Task {
+        let status = if view.deferred.terminal_override == Some(DeferredTerminalState::Cancelled) {
+            TaskStatus::Cancelled
+        } else if view.deferred.failure.is_some() {
+            TaskStatus::Failed
+        } else if view.invocation.state.is_terminal() {
+            TaskStatus::Completed
+        } else {
+            TaskStatus::Working
+        };
+        self.task_object(view, status)
+    }
+
+    fn extension_status(&self, view: &DeferredResultView) -> TaskStatus {
+        if view
+            .deferred
+            .failure
+            .as_ref()
+            .is_some_and(|failure| failure.kind == bazel_mcp_types::DeferredFailureKind::Internal)
+        {
+            TaskStatus::Failed
+        } else if view.invocation.state == InvocationState::Cancelled {
+            TaskStatus::Cancelled
+        } else if view.invocation.state.is_terminal() {
+            TaskStatus::Completed
+        } else {
+            TaskStatus::Working
+        }
+    }
+
+    fn task_object(&self, view: &DeferredResultView, status: TaskStatus) -> Task {
+        let elapsed_ms = bazel_mcp_types::unix_timestamp_ms()
+            .saturating_sub(view.deferred.created_at_ms)
+            .max(0);
+        let status_name = match status {
+            TaskStatus::Working => "working",
+            TaskStatus::InputRequired => "input_required",
+            TaskStatus::Completed => "completed",
+            TaskStatus::Failed => "failed",
+            TaskStatus::Cancelled => "cancelled",
+            _ => "unknown",
+        };
+        Task::new(
+            view.deferred.invocation_id.to_string(),
+            status,
+            format_timestamp(view.deferred.created_at_ms),
+            format_timestamp(view.deferred.updated_at_ms),
+        )
+        .with_status_message(format!("state={status_name} elapsed_ms={elapsed_ms}"))
+        .with_ttl(view.deferred.advertised_ttl_ms())
+        .with_poll_interval(self.task_poll_interval_ms)
+    }
+
+    fn extension_task_value(&self, view: &DeferredResultView) -> serde_json::Value {
+        let status = self.extension_status(view);
+        serde_json::json!({
+            "resultType": "task",
+            "taskId": view.deferred.invocation_id.to_string(),
+            "status": task_status_name(&status),
+            "createdAt": format_timestamp(view.deferred.created_at_ms),
+            "lastUpdatedAt": format_timestamp(view.deferred.updated_at_ms),
+            "ttlMs": view.deferred.advertised_ttl_ms(),
+            "pollIntervalMs": self.task_poll_interval_ms,
+        })
+    }
+
+    async fn extension_get_value(
+        &self,
+        view: &DeferredResultView,
+    ) -> Result<serde_json::Value, ErrorData> {
+        let status = self.extension_status(view);
+        let mut value = serde_json::json!({
+            "resultType": "complete",
+            "taskId": view.deferred.invocation_id.to_string(),
+            "status": task_status_name(&status),
+            "createdAt": format_timestamp(view.deferred.created_at_ms),
+            "lastUpdatedAt": format_timestamp(view.deferred.updated_at_ms),
+            "ttlMs": view.deferred.advertised_ttl_ms(),
+            "pollIntervalMs": self.task_poll_interval_ms,
+        });
+        if status == TaskStatus::Completed {
+            let tool_error = view.deferred.failure.is_some();
+            let result = self
+                .build_run_result(&view.invocation, tool_error)
+                .await
+                .map_err(|error| ErrorData::internal_error(error, None))?;
+            value["result"] = serde_json::to_value(result)
+                .map_err(|error| ErrorData::internal_error(error.to_string(), None))?;
+        } else if status == TaskStatus::Failed {
+            let message = view
+                .deferred
+                .failure
+                .as_ref()
+                .map_or("Deferred invocation failed", |failure| {
+                    failure.redacted_message.as_str()
+                });
+            value["error"] = serde_json::json!({
+                "code": ErrorCode::INTERNAL_ERROR.0,
+                "message": message,
+            });
+        }
+        Ok(value)
+    }
+
+    async fn call_tool_request(
+        &self,
+        params: CallToolRequestParams,
+        context: RequestContext<RoleServer>,
+    ) -> Result<ServerResult, ErrorData> {
+        let family = Self::protocol_family(context.protocol_version().as_ref());
+        let is_run = params.name == "bazel.run";
+        match family {
+            ProtocolFamily::LegacyTasks => {
+                if self.execution_policy != McpExecutionPolicy::SyncOnly && params.task.is_some() {
+                    if !is_run {
+                        return Err(Self::method_not_found(
+                            "task execution is not supported for this tool",
+                        ));
+                    }
+                    Self::trace_task_call(ProtocolFamily::LegacyTasks, "tools/call");
+                    let view = match self
+                        .submit_deferred(params.arguments, DeferredRetrieval::SeparateResult)
+                        .await
+                    {
+                        Ok(view) => view,
+                        Err(result) => return Ok(ServerResult::CallToolResult(result)),
+                    };
+                    let task = self.legacy_task(&view);
+                    let mut meta = Meta::new();
+                    meta.0.insert(
+                        IMMEDIATE_RESPONSE.to_owned(),
+                        serde_json::Value::String(format!(
+                            "Bazel invocation {} is running.",
+                            view.deferred.invocation_id
+                        )),
+                    );
+                    meta.0.insert(
+                        RelatedTaskMetadata::META_KEY.to_owned(),
+                        serde_json::json!({"taskId": view.deferred.invocation_id.to_string()}),
+                    );
+                    let result = CreateTaskResult::new(task).with_meta(meta);
+                    Self::trace_task_response(ProtocolFamily::LegacyTasks, "creation", &result);
+                    return Ok(ServerResult::CreateTaskResult(result));
+                }
+                if is_run
+                    && self.execution_policy == McpExecutionPolicy::TasksRequired
+                    && params.task.is_none()
+                {
+                    tracing::info!(
+                        target: "bazel_mcp::metrics",
+                        metric = "task_capability_mismatch_total",
+                        increment = 1_u64,
+                        protocol_family = ProtocolFamily::LegacyTasks.as_str(),
+                        "rejected request missing legacy task augmentation"
+                    );
+                    return Err(Self::method_not_found(
+                        "bazel.run requires task-based invocation",
+                    ));
+                }
+            }
+            ProtocolFamily::TasksExtension => {
+                if is_run && self.execution_policy != McpExecutionPolicy::SyncOnly {
+                    if !Self::extension_capable(&context.meta) {
+                        if self.execution_policy == McpExecutionPolicy::TasksRequired {
+                            return Err(Self::missing_extension_capability());
+                        }
+                    } else {
+                        Self::trace_task_call(ProtocolFamily::TasksExtension, "tools/call");
+                        let view = match self
+                            .submit_deferred(params.arguments, DeferredRetrieval::InlineResult)
+                            .await
+                        {
+                            Ok(view) => view,
+                            Err(result) => return Ok(ServerResult::CallToolResult(result)),
+                        };
+                        let result = CustomResult::new(self.extension_task_value(&view));
+                        Self::trace_task_response(
+                            ProtocolFamily::TasksExtension,
+                            "creation",
+                            &result,
+                        );
+                        return Ok(ServerResult::CustomResult(result));
+                    }
+                }
+            }
+            ProtocolFamily::Earlier => {
+                if is_run && self.execution_policy == McpExecutionPolicy::TasksRequired {
+                    tracing::info!(
+                        target: "bazel_mcp::metrics",
+                        metric = "task_capability_mismatch_total",
+                        increment = 1_u64,
+                        protocol_family = ProtocolFamily::Earlier.as_str(),
+                        "rejected request on a protocol without task support"
+                    );
+                    return Err(Self::method_not_found(
+                        "task execution is unavailable for the negotiated protocol",
+                    ));
+                }
+            }
+        }
+        self.tool_router
+            .call(ToolCallContext::new(self, params, context))
+            .await
+            .map(ServerResult::CallToolResult)
+    }
+
+    async fn legacy_get_task(&self, task_id: &str) -> Result<GetTaskResult, ErrorData> {
+        let id = parse_task_id(task_id)?;
+        let view = self
+            .runner
+            .deferred_result(id, DeferredRetrieval::SeparateResult)
+            .await
+            .map_err(|_| Self::task_not_found(task_id))?;
+        let result = GetTaskResult::new(self.legacy_task(&view));
+        Self::trace_task_response(ProtocolFamily::LegacyTasks, "polling", &result);
+        Ok(result)
+    }
+
+    async fn legacy_task_result(
+        &self,
+        task_id: &str,
+        cancellation: tokio_util::sync::CancellationToken,
+    ) -> Result<GetTaskPayloadResult, ErrorData> {
+        let id = parse_task_id(task_id)?;
+        self.runner
+            .deferred_result(id, DeferredRetrieval::SeparateResult)
+            .await
+            .map_err(|_| Self::task_not_found(task_id))?;
+        let record = self
+            .runner
+            .wait(id, cancellation)
+            .await
+            .map_err(|error| ErrorData::internal_error(error.to_string(), None))?;
+        let view = self
+            .runner
+            .deferred_result(id, DeferredRetrieval::SeparateResult)
+            .await
+            .map_err(|_| Self::task_not_found(task_id))?;
+        let mut result = self
+            .build_run_result(&record, view.deferred.failure.is_some())
+            .await
+            .map_err(|error| ErrorData::internal_error(error, None))?;
+        let mut meta = result.meta.take().unwrap_or_default();
+        meta.0.insert(
+            RelatedTaskMetadata::META_KEY.to_owned(),
+            serde_json::json!({"taskId": task_id}),
+        );
+        result.meta = Some(meta);
+        let result = serde_json::to_value(result)
+            .map(GetTaskPayloadResult::new)
+            .map_err(|error| ErrorData::internal_error(error.to_string(), None))?;
+        Self::trace_task_response(ProtocolFamily::LegacyTasks, "final_result", &result);
+        Ok(result)
+    }
+
+    async fn legacy_cancel_task(
+        &self,
+        task_id: &str,
+        cancellation: tokio_util::sync::CancellationToken,
+    ) -> Result<CancelTaskResult, ErrorData> {
+        let id = parse_task_id(task_id)?;
+        let view = self
+            .runner
+            .deferred_result(id, DeferredRetrieval::SeparateResult)
+            .await
+            .map_err(|_| Self::task_not_found(task_id))?;
+        if view.invocation.state.is_terminal()
+            || view.deferred.terminal_override == Some(DeferredTerminalState::Cancelled)
+        {
+            return Err(ErrorData::invalid_params("task is already terminal", None));
+        }
+        self.runner
+            .record_deferred_cancellation(id)
+            .await
+            .map_err(|error| ErrorData::internal_error(error.to_string(), None))?;
+        self.runner
+            .cancel(id)
+            .await
+            .map_err(|error| ErrorData::internal_error(error.to_string(), None))?;
+        let finalizer = self.runner.clone();
+        tokio::spawn(async move {
+            if finalizer
+                .wait(id, tokio_util::sync::CancellationToken::new())
+                .await
+                .is_ok()
+            {
+                let _ = finalizer.set_deferred_cancelled(id).await;
+            }
+        });
+        self.runner
+            .wait(id, cancellation)
+            .await
+            .map_err(|error| ErrorData::internal_error(error.to_string(), None))?;
+        self.runner
+            .set_deferred_cancelled(id)
+            .await
+            .map_err(|error| ErrorData::internal_error(error.to_string(), None))?;
+        let view = self
+            .runner
+            .deferred_result(id, DeferredRetrieval::SeparateResult)
+            .await
+            .map_err(|_| Self::task_not_found(task_id))?;
+        let result = CancelTaskResult::new(self.legacy_task(&view));
+        Self::trace_task_response(ProtocolFamily::LegacyTasks, "control", &result);
+        Ok(result)
+    }
+
+    async fn extension_get_task(&self, task_id: &str) -> Result<CustomResult, ErrorData> {
+        let id = parse_task_id(task_id)?;
+        let view = self
+            .runner
+            .deferred_result(id, DeferredRetrieval::InlineResult)
+            .await
+            .map_err(|_| Self::task_not_found(task_id))?;
+        let terminal = self.extension_status(&view) != TaskStatus::Working;
+        let result = self
+            .extension_get_value(&view)
+            .await
+            .map(CustomResult::new)?;
+        Self::trace_task_response(
+            ProtocolFamily::TasksExtension,
+            if terminal { "final_result" } else { "polling" },
+            &result,
+        );
+        Ok(result)
+    }
+
+    async fn extension_cancel_task(&self, task_id: &str) -> Result<CustomResult, ErrorData> {
+        let id = parse_task_id(task_id)?;
+        self.runner
+            .deferred_result(id, DeferredRetrieval::InlineResult)
+            .await
+            .map_err(|_| Self::task_not_found(task_id))?;
+        self.runner
+            .record_deferred_cancellation(id)
+            .await
+            .map_err(|error| ErrorData::internal_error(error.to_string(), None))?;
+        self.runner
+            .cancel(id)
+            .await
+            .map_err(|error| ErrorData::internal_error(error.to_string(), None))?;
+        let result = CustomResult::new(serde_json::json!({"resultType": "complete"}));
+        Self::trace_task_response(ProtocolFamily::TasksExtension, "control", &result);
+        Ok(result)
+    }
+
+    async fn custom_request(
+        &self,
+        request: CustomRequest,
+        context: RequestContext<RoleServer>,
+    ) -> Result<ServerResult, ErrorData> {
+        match request.method.as_str() {
+            "server/discover" => Ok(ServerResult::CustomResult(CustomResult::new(
+                serde_json::json!({
+                    "capabilities": {
+                        "extensions": { (TASKS_EXTENSION): {} }
+                    }
+                }),
+            ))),
+            "tasks/update"
+                if Self::protocol_family(context.protocol_version().as_ref())
+                    == ProtocolFamily::TasksExtension =>
+            {
+                Self::trace_task_call(ProtocolFamily::TasksExtension, "tasks/update");
+                if !Self::extension_capable(&context.meta) {
+                    return Err(Self::missing_extension_capability());
+                }
+                let task_id = request
+                    .params
+                    .as_ref()
+                    .and_then(|params| params.get("taskId"))
+                    .and_then(serde_json::Value::as_str)
+                    .ok_or_else(|| ErrorData::invalid_params("taskId is required", None))?;
+                let id = parse_task_id(task_id)?;
+                self.runner
+                    .deferred_result(id, DeferredRetrieval::InlineResult)
+                    .await
+                    .map_err(|_| Self::task_not_found(task_id))?;
+                let result = CustomResult::new(serde_json::json!({"resultType": "complete"}));
+                Self::trace_task_response(ProtocolFamily::TasksExtension, "control", &result);
+                Ok(ServerResult::CustomResult(result))
+            }
+            _ => Err(Self::method_not_found(request.method)),
+        }
+    }
+}
+
+impl Service<RoleServer> for BazelMcpServer {
+    async fn handle_request(
+        &self,
+        request: <RoleServer as ServiceRole>::PeerReq,
+        context: RequestContext<RoleServer>,
+    ) -> Result<<RoleServer as ServiceRole>::Resp, ErrorData> {
+        match request {
+            ClientRequest::InitializeRequest(request) => {
+                let requested = request.params.protocol_version.clone();
+                let negotiated = if ProtocolVersion::KNOWN_VERSIONS.contains(&requested)
+                    || requested.as_str() == "2026-06-30"
+                {
+                    requested
+                } else {
+                    ProtocolVersion::LATEST
+                };
+                let mut peer_info = request.params;
+                peer_info.protocol_version = negotiated.clone();
+                context.peer.set_peer_info(peer_info);
+                tracing::info!(
+                    protocol_family = Self::protocol_family(Some(&negotiated)).as_str(),
+                    protocol_version = negotiated.as_str(),
+                    "negotiated MCP protocol family"
+                );
+                Ok(ServerResult::InitializeResult(
+                    self.initialize_result(negotiated),
+                ))
+            }
+            ClientRequest::PingRequest(_) => Ok(ServerResult::empty(())),
+            ClientRequest::ListToolsRequest(_) => {
+                let family = Self::protocol_family(context.protocol_version().as_ref());
+                Ok(ServerResult::ListToolsResult(
+                    ListToolsResult::with_all_items(self.tools_for(family)),
+                ))
+            }
+            ClientRequest::CallToolRequest(request) => {
+                self.call_tool_request(request.params, context).await
+            }
+            ClientRequest::GetTaskRequest(request) => {
+                let family = Self::protocol_family(context.protocol_version().as_ref());
+                Self::trace_task_call(family, "tasks/get");
+                match family {
+                    ProtocolFamily::LegacyTasks => self
+                        .legacy_get_task(&request.params.task_id)
+                        .await
+                        .map(ServerResult::GetTaskResult),
+                    ProtocolFamily::TasksExtension => {
+                        if !Self::extension_capable(&context.meta) {
+                            return Err(Self::missing_extension_capability());
+                        }
+                        self.extension_get_task(&request.params.task_id)
+                            .await
+                            .map(ServerResult::CustomResult)
+                    }
+                    ProtocolFamily::Earlier => Err(Self::method_not_found("tasks/get")),
+                }
+            }
+            ClientRequest::ListTasksRequest(request) => {
+                let family = Self::protocol_family(context.protocol_version().as_ref());
+                Self::trace_task_call(family, "tasks/list");
+                if family != ProtocolFamily::LegacyTasks {
+                    return Err(Self::method_not_found("tasks/list"));
+                }
+                let cursor = request.params.and_then(|params| params.cursor);
+                let page = self
+                    .runner
+                    .list_deferred_results(
+                        DeferredRetrieval::SeparateResult,
+                        PageRequest { cursor, limit: 100 },
+                    )
+                    .await
+                    .map_err(|error| ErrorData::invalid_params(error.to_string(), None))?;
+                let mut result = ListTasksResult::new(
+                    page.items
+                        .iter()
+                        .map(|view| self.legacy_task(view))
+                        .collect(),
+                );
+                result.next_cursor = page.next_cursor;
+                Self::trace_task_response(ProtocolFamily::LegacyTasks, "polling", &result);
+                Ok(ServerResult::ListTasksResult(result))
+            }
+            ClientRequest::GetTaskPayloadRequest(request) => {
+                let family = Self::protocol_family(context.protocol_version().as_ref());
+                Self::trace_task_call(family, "tasks/result");
+                if family != ProtocolFamily::LegacyTasks {
+                    return Err(Self::method_not_found("tasks/result"));
+                }
+                self.legacy_task_result(&request.params.task_id, context.ct)
+                    .await
+                    .map(ServerResult::GetTaskPayloadResult)
+            }
+            ClientRequest::CancelTaskRequest(request) => {
+                let family = Self::protocol_family(context.protocol_version().as_ref());
+                Self::trace_task_call(family, "tasks/cancel");
+                match family {
+                    ProtocolFamily::LegacyTasks => self
+                        .legacy_cancel_task(&request.params.task_id, context.ct)
+                        .await
+                        .map(ServerResult::CancelTaskResult),
+                    ProtocolFamily::TasksExtension => {
+                        if !Self::extension_capable(&context.meta) {
+                            return Err(Self::missing_extension_capability());
+                        }
+                        self.extension_cancel_task(&request.params.task_id)
+                            .await
+                            .map(ServerResult::CustomResult)
+                    }
+                    ProtocolFamily::Earlier => Err(Self::method_not_found("tasks/cancel")),
+                }
+            }
+            ClientRequest::CustomRequest(request) => self.custom_request(request, context).await,
+            other => Err(Self::method_not_found(other.method())),
+        }
+    }
+
+    async fn handle_notification(
+        &self,
+        _notification: <RoleServer as ServiceRole>::PeerNot,
+        _context: NotificationContext<RoleServer>,
+    ) -> Result<(), ErrorData> {
+        Ok(())
+    }
+
+    fn get_info(&self) -> <RoleServer as ServiceRole>::Info {
+        self.initialize_result(ProtocolVersion::LATEST)
+    }
+}
+
+fn tool_error(message: impl Into<String>) -> CallToolResult {
+    CallToolResult::error(vec![ContentBlock::text(message.into())])
+}
+
+fn parse_task_id(value: &str) -> Result<InvocationId, ErrorData> {
+    parse_id(value).map_err(|_| ErrorData::invalid_params("taskId must be a UUID", None))
+}
+
+fn task_status_name(status: &TaskStatus) -> &'static str {
+    match status {
+        TaskStatus::Working => "working",
+        TaskStatus::InputRequired => "input_required",
+        TaskStatus::Completed => "completed",
+        TaskStatus::Failed => "failed",
+        TaskStatus::Cancelled => "cancelled",
+        _ => "unknown",
+    }
+}
+
+fn format_timestamp(timestamp_ms: i64) -> String {
+    let nanos = i128::from(timestamp_ms).saturating_mul(1_000_000);
+    time::OffsetDateTime::from_unix_timestamp_nanos(nanos)
+        .ok()
+        .and_then(|timestamp| {
+            timestamp
+                .format(&time::format_description::well_known::Rfc3339)
+                .ok()
+        })
+        .unwrap_or_else(|| "1970-01-01T00:00:00Z".to_owned())
+}
 
 fn parse_id(value: &str) -> Result<InvocationId, String> {
     Uuid::parse_str(value)
@@ -448,5 +1238,83 @@ mod tests {
         let both = BazelMcpServer::new(runner, ResultEncoding::Both);
         assert_eq!(both.model_visible_bytes(&value).unwrap(), one * 2);
         assert_eq!(both.single_representation_budget(8_192), 4_096);
+    }
+
+    #[tokio::test]
+    async fn negotiated_capabilities_and_tool_metadata_do_not_mix_dialects() {
+        let root = tempdir().unwrap();
+        let runner = InvocationService::new(
+            Store::open(root.path()).await.unwrap(),
+            RunnerConfig::default(),
+        )
+        .unwrap();
+        let server = BazelMcpServer::new(runner, ResultEncoding::Text).with_task_execution(
+            McpExecutionPolicy::Auto,
+            Duration::from_secs(60),
+            500,
+        );
+
+        let legacy = serde_json::to_value(
+            server
+                .initialize_result(ProtocolVersion::V_2025_11_25)
+                .capabilities,
+        )
+        .unwrap();
+        assert_eq!(
+            legacy,
+            serde_json::json!({
+                "tools": {},
+                "tasks": {
+                    "list": {},
+                    "cancel": {},
+                    "requests": {"tools": {"call": {}}}
+                }
+            })
+        );
+        let legacy_tools = server.tools_for(ProtocolFamily::LegacyTasks);
+        assert_eq!(legacy_tools.len(), 3);
+        assert_eq!(
+            legacy_tools
+                .iter()
+                .find(|tool| tool.name == "bazel.run")
+                .unwrap()
+                .task_support(),
+            TaskSupport::Optional
+        );
+        assert!(
+            legacy_tools
+                .iter()
+                .filter(|tool| tool.name != "bazel.run")
+                .all(|tool| tool.execution.is_none())
+        );
+
+        let extension_version: ProtocolVersion = serde_json::from_str("\"2026-06-30\"").unwrap();
+        let extension =
+            serde_json::to_value(server.initialize_result(extension_version).capabilities).unwrap();
+        assert_eq!(
+            extension,
+            serde_json::json!({
+                "tools": {},
+                "extensions": {(TASKS_EXTENSION): {}}
+            })
+        );
+        assert!(
+            server
+                .tools_for(ProtocolFamily::TasksExtension)
+                .iter()
+                .all(|tool| tool.execution.is_none())
+        );
+        assert_eq!(
+            serde_json::to_value(BazelMcpServer::missing_extension_capability()).unwrap(),
+            serde_json::json!({
+                "code": -32003,
+                "message": "Missing Required Client Capability",
+                "data": {
+                    "requiredCapabilities": {
+                        "extensions": {(TASKS_EXTENSION): {}}
+                    }
+                }
+            })
+        );
     }
 }

--- a/crates/bazel-mcp-server/src/lib.rs
+++ b/crates/bazel-mcp-server/src/lib.rs
@@ -3,14 +3,14 @@
 mod config;
 mod handler;
 
-pub use config::{Cli, ResultEncoding, ServerConfig};
+pub use config::{Cli, McpExecutionPolicy, ResultEncoding, ServerConfig};
 pub use handler::BazelMcpServer;
 
 use anyhow::Context;
 use bazel_mcp_policy::PolicyConfig;
 use bazel_mcp_runner::{InvocationService, RunnerConfig};
 use bazel_mcp_store::Store;
-use rmcp::ServiceExt;
+use rmcp::RoleServer;
 
 pub async fn serve(config: ServerConfig) -> anyhow::Result<()> {
     let store = Store::open(&config.cache_root)
@@ -57,9 +57,23 @@ pub async fn serve(config: ServerConfig) -> anyhow::Result<()> {
         },
     )?;
     let shutdown_runner = runner.clone();
-    let server = BazelMcpServer::new(runner, config.result_encoding).with_progress_timing(
-        std::time::Duration::from_secs(config.progress_initial_seconds),
-        std::time::Duration::from_secs(config.progress_interval_seconds),
+    let server = BazelMcpServer::new(runner, config.result_encoding)
+        .with_progress_timing(
+            std::time::Duration::from_secs(config.progress_initial_seconds),
+            std::time::Duration::from_secs(config.progress_interval_seconds),
+        )
+        .with_task_execution(
+            config.mcp_execution_policy,
+            std::time::Duration::from_secs(config.task_ttl_seconds),
+            config.task_poll_interval_ms,
+        );
+    tracing::info!(
+        policy = ?config.mcp_execution_policy,
+        task_ttl_seconds = config.task_ttl_seconds,
+        task_poll_interval_ms = config.task_poll_interval_ms,
+        legacy_protocol = "2025-11-25",
+        extension_protocol = "2026-06-30",
+        "configured negotiated MCP task execution"
     );
     let cleanup_store = store;
     let cleanup_age =
@@ -86,10 +100,11 @@ pub async fn serve(config: ServerConfig) -> anyhow::Result<()> {
             }
         }
     });
-    let running = server
-        .serve(rmcp::transport::stdio())
-        .await
-        .context("start stdio MCP transport")?;
+    let running = rmcp::service::serve_directly::<RoleServer, _, _, _, _>(
+        server,
+        rmcp::transport::stdio(),
+        None,
+    );
     let service_cancellation = running.cancellation_token();
     let shutdown_wait = config
         .cancellation_interrupt_grace_seconds

--- a/crates/bazel-mcp-store/Cargo.toml
+++ b/crates/bazel-mcp-store/Cargo.toml
@@ -16,6 +16,7 @@ serde_json.workspace = true
 sha2.workspace = true
 thiserror.workspace = true
 tokio.workspace = true
+tracing.workspace = true
 turso.workspace = true
 
 [dev-dependencies]

--- a/crates/bazel-mcp-store/migrations/0005_deferred_results.sql
+++ b/crates/bazel-mcp-store/migrations/0005_deferred_results.sql
@@ -1,0 +1,15 @@
+CREATE TABLE deferred_results (
+    invocation_id TEXT PRIMARY KEY
+        REFERENCES invocations(id) ON DELETE CASCADE,
+    retrieval_kind TEXT NOT NULL,
+    created_at_ms INTEGER NOT NULL,
+    updated_at_ms INTEGER NOT NULL,
+    expires_at_ms INTEGER NOT NULL,
+    cancellation_requested_at_ms INTEGER,
+    terminal_override TEXT,
+    failure_kind TEXT,
+    failure_message TEXT
+);
+
+CREATE INDEX deferred_results_expiry
+    ON deferred_results(expires_at_ms);

--- a/crates/bazel-mcp-store/src/cursor.rs
+++ b/crates/bazel-mcp-store/src/cursor.rs
@@ -11,6 +11,38 @@ pub(crate) struct InvocationCursor {
     pub id: String,
 }
 
+#[derive(Debug, Serialize, Deserialize)]
+pub(crate) struct DeferredCursor {
+    context: String,
+    pub created_at_ms: i64,
+    pub id: String,
+}
+
+impl DeferredCursor {
+    pub fn new(retrieval: &str, created_at_ms: i64, id: String) -> Self {
+        Self {
+            context: cursor_context(&["deferred", retrieval]),
+            created_at_ms,
+            id,
+        }
+    }
+
+    pub fn encode(&self) -> Result<String, StoreError> {
+        Ok(URL_SAFE_NO_PAD.encode(serde_json::to_vec(self)?))
+    }
+
+    pub fn decode_for(value: &str, retrieval: &str) -> Result<Self, StoreError> {
+        let raw = URL_SAFE_NO_PAD
+            .decode(value)
+            .map_err(|_| StoreError::InvalidCursor)?;
+        let cursor: Self = serde_json::from_slice(&raw).map_err(|_| StoreError::InvalidCursor)?;
+        if cursor.context != cursor_context(&["deferred", retrieval]) {
+            return Err(StoreError::InvalidCursor);
+        }
+        Ok(cursor)
+    }
+}
+
 impl InvocationCursor {
     pub fn new(workspace: Option<&str>, requested_at_ms: i64, id: String) -> Self {
         Self {

--- a/crates/bazel-mcp-store/src/database.rs
+++ b/crates/bazel-mcp-store/src/database.rs
@@ -6,8 +6,10 @@ use std::{
 };
 
 use bazel_mcp_types::{
-    Artifact, CoverageFile, Diagnostic, InvocationId, InvocationMetrics, InvocationRecord,
-    InvocationState, InvocationSummary, Page, PageRequest, QueryRow, Termination, TestResult,
+    Artifact, CoverageFile, DeferredFailure, DeferredFailureKind, DeferredResultRecord,
+    DeferredResultView, DeferredRetrieval, DeferredTerminalState, Diagnostic, InvocationId,
+    InvocationMetrics, InvocationRecord, InvocationState, InvocationSummary, Page, PageRequest,
+    QueryRow, Termination, TestResult,
 };
 use thiserror::Error;
 use tokio::sync::Mutex;
@@ -15,14 +17,15 @@ use turso::{Connection, Database, Value, params};
 
 use crate::{
     InvocationPaths,
-    cursor::{InvocationCursor, OrdinalCursor},
+    cursor::{DeferredCursor, InvocationCursor, OrdinalCursor},
 };
 
 const MIGRATION_1: &str = include_str!("../migrations/0001_initial.sql");
 const MIGRATION_2: &str = include_str!("../migrations/0002_targets_coverage.sql");
 const MIGRATION_3: &str = include_str!("../migrations/0003_canonical_arguments.sql");
 const MIGRATION_4: &str = include_str!("../migrations/0004_cancellation_reason.sql");
-const LATEST_SCHEMA_VERSION: i64 = 4;
+const MIGRATION_5: &str = include_str!("../migrations/0005_deferred_results.sql");
+const LATEST_SCHEMA_VERSION: i64 = 5;
 
 #[derive(Debug, Error)]
 pub enum StoreError {
@@ -30,6 +33,8 @@ pub enum StoreError {
     NonUtf8Path(PathBuf),
     #[error("invocation was not found: {0}")]
     NotFound(InvocationId),
+    #[error("deferred result was not found or has expired: {0}")]
+    DeferredNotFound(InvocationId),
     #[error("invalid pagination cursor")]
     InvalidCursor,
     #[error("unexpected database value in column {0}")]
@@ -91,6 +96,15 @@ impl Store {
         &self,
         record: &InvocationRecord,
     ) -> Result<InvocationPaths, StoreError> {
+        self.create_invocation_with_deferred(record, None).await
+    }
+
+    /// Atomically accept an invocation and its optional deferred-result handle.
+    pub async fn create_invocation_with_deferred(
+        &self,
+        record: &InvocationRecord,
+        deferred: Option<&DeferredResultRecord>,
+    ) -> Result<InvocationPaths, StoreError> {
         let paths = self.paths_for(record);
         paths.create().await?;
         let result = async {
@@ -116,6 +130,34 @@ impl Store {
                     ],
                 )
                 .await?;
+            if let Some(deferred) = deferred {
+                transaction
+                    .execute(
+                        "INSERT INTO deferred_results (
+                            invocation_id, retrieval_kind, created_at_ms, updated_at_ms,
+                            expires_at_ms, cancellation_requested_at_ms, terminal_override,
+                            failure_kind, failure_message
+                         ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)",
+                        params![
+                            deferred.invocation_id.to_string(),
+                            deferred.retrieval.as_str(),
+                            deferred.created_at_ms,
+                            deferred.updated_at_ms,
+                            deferred.expires_at_ms,
+                            option_i64(deferred.cancellation_requested_at_ms),
+                            deferred
+                                .terminal_override
+                                .map_or(Value::Null, |value| Value::Text(value.as_str().into())),
+                            deferred.failure.as_ref().map_or(Value::Null, |failure| {
+                                Value::Text(failure.kind.as_str().into())
+                            }),
+                            deferred.failure.as_ref().map_or(Value::Null, |failure| {
+                                Value::Text(failure.redacted_message.clone())
+                            }),
+                        ],
+                    )
+                    .await?;
+            }
             transaction.commit().await?;
             Ok::<_, StoreError>(())
         }
@@ -125,6 +167,254 @@ impl Store {
             return Err(error);
         }
         Ok(paths)
+    }
+
+    pub async fn get_deferred_result(
+        &self,
+        id: InvocationId,
+        retrieval: DeferredRetrieval,
+        now_ms: i64,
+    ) -> Result<DeferredResultView, StoreError> {
+        let invocation = self.get_invocation(id).await?;
+        let connection = self.database.connect()?;
+        let mut rows = connection
+            .query(
+                "SELECT retrieval_kind, created_at_ms, updated_at_ms, expires_at_ms,
+                        cancellation_requested_at_ms, terminal_override,
+                        failure_kind, failure_message
+                 FROM deferred_results
+                 WHERE invocation_id = ?1 AND retrieval_kind = ?2",
+                params![id.to_string(), retrieval.as_str()],
+            )
+            .await?;
+        let Some(row) = rows.next().await? else {
+            return Err(StoreError::DeferredNotFound(id));
+        };
+        let deferred = deferred_from_row(id, &row)?;
+        drop(rows);
+        if deferred.is_expired(now_ms, invocation.state.is_terminal()) {
+            let deleted = connection
+                .execute(
+                    "DELETE FROM deferred_results WHERE invocation_id = ?1",
+                    params![id.to_string()],
+                )
+                .await?;
+            if deleted > 0 {
+                tracing::info!(
+                    target: "bazel_mcp::metrics",
+                    metric = "deferred_invocations_expired_total",
+                    increment = deleted,
+                    "expired deferred invocation metadata during lookup"
+                );
+            }
+            return Err(StoreError::DeferredNotFound(id));
+        }
+        Ok(DeferredResultView {
+            deferred,
+            invocation,
+        })
+    }
+
+    pub async fn list_deferred_results(
+        &self,
+        retrieval: DeferredRetrieval,
+        now_ms: i64,
+        page: PageRequest,
+    ) -> Result<Page<DeferredResultView>, StoreError> {
+        let limit = page.limit.clamp(1, 200) as usize;
+        let cursor = page
+            .cursor
+            .as_deref()
+            .map(|value| DeferredCursor::decode_for(value, retrieval.as_str()))
+            .transpose()?;
+        let connection = self.database.connect()?;
+        let query = "SELECT d.invocation_id, d.retrieval_kind, d.created_at_ms,
+                            d.updated_at_ms, d.expires_at_ms,
+                            d.cancellation_requested_at_ms, d.terminal_override,
+                            d.failure_kind, d.failure_message,
+                            i.request_json, i.state, i.started_at_ms, i.finished_at_ms,
+                            i.termination_json, i.summary_json, i.metrics_json,
+                            i.canonical_arguments_json, i.cancellation_reason
+                     FROM deferred_results d
+                     JOIN invocations i ON i.id = d.invocation_id
+                     WHERE d.retrieval_kind = ?1
+                       AND (i.state NOT IN ('succeeded', 'failed', 'cancelled', 'timed_out', 'interrupted')
+                            OR d.expires_at_ms > ?2)
+                       AND (?3 IS NULL OR d.created_at_ms < ?3
+                            OR (d.created_at_ms = ?3 AND d.invocation_id < ?4))
+                     ORDER BY d.created_at_ms DESC, d.invocation_id DESC
+                     LIMIT ?5";
+        let cursor_time = cursor
+            .as_ref()
+            .map_or(Value::Null, |value| Value::Integer(value.created_at_ms));
+        let cursor_id = cursor
+            .as_ref()
+            .map_or_else(String::new, |value| value.id.clone());
+        let mut rows = connection
+            .query(
+                query,
+                params![
+                    retrieval.as_str(),
+                    now_ms,
+                    cursor_time,
+                    cursor_id,
+                    i64::try_from(limit + 1).unwrap_or(i64::MAX),
+                ],
+            )
+            .await?;
+        let mut items = Vec::new();
+        while let Some(row) = rows.next().await? {
+            let id_text: String = row.get(0)?;
+            let id = parse_invocation_id(&id_text, 0)?;
+            let deferred = deferred_from_joined_row(id, &row)?;
+            let invocation = record_from_joined_deferred_row(&row)?;
+            items.push(DeferredResultView {
+                deferred,
+                invocation,
+            });
+        }
+        let truncated = items.len() > limit;
+        items.truncate(limit);
+        let next_cursor = if truncated {
+            items
+                .last()
+                .map(|view| {
+                    DeferredCursor::new(
+                        retrieval.as_str(),
+                        view.deferred.created_at_ms,
+                        view.deferred.invocation_id.to_string(),
+                    )
+                    .encode()
+                })
+                .transpose()?
+        } else {
+            None
+        };
+        Ok(Page {
+            items,
+            next_cursor,
+            truncated,
+        })
+    }
+
+    pub async fn record_deferred_cancellation(
+        &self,
+        id: InvocationId,
+        requested_at_ms: i64,
+    ) -> Result<(), StoreError> {
+        let _guard = self.write_coordinator.lock().await;
+        let connection = self.database.connect()?;
+        let changed = connection
+            .execute(
+                "UPDATE deferred_results
+                 SET cancellation_requested_at_ms = COALESCE(cancellation_requested_at_ms, ?2),
+                     updated_at_ms = MAX(updated_at_ms, ?2)
+                 WHERE invocation_id = ?1",
+                params![id.to_string(), requested_at_ms],
+            )
+            .await?;
+        if changed == 0 {
+            return Err(StoreError::DeferredNotFound(id));
+        }
+        Ok(())
+    }
+
+    pub async fn set_deferred_terminal_override(
+        &self,
+        id: InvocationId,
+        state: DeferredTerminalState,
+        updated_at_ms: i64,
+    ) -> Result<(), StoreError> {
+        let _guard = self.write_coordinator.lock().await;
+        let connection = self.database.connect()?;
+        let changed = connection
+            .execute(
+                "UPDATE deferred_results
+                 SET terminal_override = ?2, updated_at_ms = MAX(updated_at_ms, ?3)
+                 WHERE invocation_id = ?1",
+                params![id.to_string(), state.as_str(), updated_at_ms],
+            )
+            .await?;
+        if changed == 0 {
+            return Err(StoreError::DeferredNotFound(id));
+        }
+        Ok(())
+    }
+
+    pub async fn persist_deferred_failure(
+        &self,
+        id: InvocationId,
+        failure: &DeferredFailure,
+        updated_at_ms: i64,
+    ) -> Result<(), StoreError> {
+        let _guard = self.write_coordinator.lock().await;
+        let connection = self.database.connect()?;
+        let changed = connection
+            .execute(
+                "UPDATE deferred_results
+                 SET failure_kind = ?2, failure_message = ?3,
+                     updated_at_ms = MAX(updated_at_ms, ?4)
+                 WHERE invocation_id = ?1",
+                params![
+                    id.to_string(),
+                    failure.kind.as_str(),
+                    failure.redacted_message.as_str(),
+                    updated_at_ms,
+                ],
+            )
+            .await?;
+        if changed == 0 {
+            return Err(StoreError::DeferredNotFound(id));
+        }
+        Ok(())
+    }
+
+    pub async fn extend_deferred_expiry(
+        &self,
+        id: InvocationId,
+        minimum_expires_at_ms: i64,
+        updated_at_ms: i64,
+    ) -> Result<(), StoreError> {
+        let _guard = self.write_coordinator.lock().await;
+        let connection = self.database.connect()?;
+        let changed = connection
+            .execute(
+                "UPDATE deferred_results
+                 SET expires_at_ms = MAX(expires_at_ms, ?2),
+                     updated_at_ms = MAX(updated_at_ms, ?3)
+                 WHERE invocation_id = ?1",
+                params![id.to_string(), minimum_expires_at_ms, updated_at_ms],
+            )
+            .await?;
+        if changed == 0 {
+            return Err(StoreError::DeferredNotFound(id));
+        }
+        Ok(())
+    }
+
+    pub async fn delete_expired_deferred_results(&self, now_ms: i64) -> Result<usize, StoreError> {
+        let _guard = self.write_coordinator.lock().await;
+        let connection = self.database.connect()?;
+        let deleted = connection
+            .execute(
+                "DELETE FROM deferred_results
+                 WHERE expires_at_ms <= ?1
+                   AND invocation_id IN (
+                       SELECT id FROM invocations
+                       WHERE state IN ('succeeded', 'failed', 'cancelled', 'timed_out', 'interrupted')
+                   )",
+                params![now_ms],
+            )
+            .await?;
+        if deleted > 0 {
+            tracing::info!(
+                target: "bazel_mcp::metrics",
+                metric = "deferred_invocations_expired_total",
+                increment = deleted,
+                "expired deferred invocation metadata during retention"
+            );
+        }
+        Ok(usize::try_from(deleted).unwrap_or(usize::MAX))
     }
 
     pub async fn get_invocation(&self, id: InvocationId) -> Result<InvocationRecord, StoreError> {
@@ -178,6 +468,23 @@ impl Store {
             )
             .await?;
         replace_normalized_summary(&transaction, id, record.summary.as_ref()).await?;
+        if next.is_terminal() {
+            let terminal_at_ms = record
+                .finished_at_ms
+                .unwrap_or_else(bazel_mcp_types::unix_timestamp_ms);
+            transaction
+                .execute(
+                    "UPDATE deferred_results
+                     SET expires_at_ms = MAX(
+                             expires_at_ms,
+                             ?2 + MAX(1, expires_at_ms - created_at_ms)
+                         ),
+                         updated_at_ms = MAX(updated_at_ms, ?2)
+                     WHERE invocation_id = ?1",
+                    params![id.to_string(), terminal_at_ms],
+                )
+                .await?;
+        }
         transaction.commit().await?;
         self.paths_for(&record).write_metadata(&record).await?;
         Ok(record)
@@ -398,8 +705,10 @@ impl Store {
         maximum_age: Duration,
         maximum_bytes: u64,
     ) -> Result<usize, StoreError> {
-        let cutoff = bazel_mcp_types::unix_timestamp_ms()
-            .saturating_sub(i64::try_from(maximum_age.as_millis()).unwrap_or(i64::MAX));
+        let now_ms = bazel_mcp_types::unix_timestamp_ms();
+        self.delete_expired_deferred_results(now_ms).await?;
+        let cutoff =
+            now_ms.saturating_sub(i64::try_from(maximum_age.as_millis()).unwrap_or(i64::MAX));
         let connection = self.database.connect()?;
         let mut rows = connection
             .query(
@@ -450,11 +759,66 @@ impl Store {
         let mut deleted = 0;
         for id in selected {
             if let Ok(record) = self.get_invocation(id).await {
-                self.delete_terminal_invocation(&record).await?;
+                if self.deferred_protects_invocation(id, now_ms).await? {
+                    self.prune_deferred_evidence(&record).await?;
+                } else {
+                    self.delete_terminal_invocation(&record).await?;
+                }
                 deleted += 1;
             }
         }
         Ok(deleted)
+    }
+
+    async fn deferred_protects_invocation(
+        &self,
+        id: InvocationId,
+        now_ms: i64,
+    ) -> Result<bool, StoreError> {
+        let connection = self.database.connect()?;
+        let mut rows = connection
+            .query(
+                "SELECT 1 FROM deferred_results
+                 WHERE invocation_id = ?1 AND expires_at_ms > ?2",
+                params![id.to_string(), now_ms],
+            )
+            .await?;
+        Ok(rows.next().await?.is_some())
+    }
+
+    async fn prune_deferred_evidence(&self, record: &InvocationRecord) -> Result<(), StoreError> {
+        if !record.state.is_terminal() {
+            return Ok(());
+        }
+        let paths = self.paths_for(record);
+        let tombstone = paths.directory.with_extension("deleting");
+        if paths.directory.exists() {
+            tokio::fs::rename(&paths.directory, &tombstone).await?;
+        }
+        let _guard = self.write_coordinator.lock().await;
+        let mut connection = self.database.connect()?;
+        let transaction = connection.transaction().await?;
+        for table in [
+            "diagnostics",
+            "test_results",
+            "query_rows",
+            "artifacts",
+            "target_results",
+            "coverage_files",
+        ] {
+            transaction
+                .execute(
+                    &format!("DELETE FROM {table} WHERE invocation_id = ?1"),
+                    params![record.request.id.to_string()],
+                )
+                .await?;
+        }
+        transaction.commit().await?;
+        drop(_guard);
+        if tombstone.exists() {
+            tokio::fs::remove_dir_all(tombstone).await?;
+        }
+        Ok(())
     }
 
     async fn delete_terminal_invocation(
@@ -472,6 +836,12 @@ impl Store {
         let _guard = self.write_coordinator.lock().await;
         let mut connection = self.database.connect()?;
         let transaction = connection.transaction().await?;
+        transaction
+            .execute(
+                "DELETE FROM deferred_results WHERE invocation_id = ?1",
+                params![record.request.id.to_string()],
+            )
+            .await?;
         for table in [
             "diagnostics",
             "test_results",
@@ -824,6 +1194,7 @@ impl Store {
             (2_i64, MIGRATION_2),
             (3_i64, MIGRATION_3),
             (4_i64, MIGRATION_4),
+            (5_i64, MIGRATION_5),
         ] {
             if !migration_applied(&connection, version).await? {
                 apply_migration(&connection, version, sql).await?;
@@ -835,7 +1206,7 @@ impl Store {
 
     async fn recover_interrupted(&self) -> Result<(), StoreError> {
         let _guard = self.write_coordinator.lock().await;
-        let connection = self.database.connect()?;
+        let mut connection = self.database.connect()?;
         let mut rows = connection
             .query(
                 "SELECT request_json, state, started_at_ms, finished_at_ms,
@@ -851,22 +1222,60 @@ impl Store {
         }
         drop(rows);
         let finished_at_ms = bazel_mcp_types::unix_timestamp_ms();
-        let termination = serde_json::to_string(&Termination::Interrupted)?;
-        connection
-            .execute(
-                "UPDATE invocations SET state = 'interrupted', finished_at_ms = ?1,
-                    termination_json = ?2 WHERE state IN ('queued', 'starting', 'running')",
-                params![finished_at_ms, termination],
-            )
-            .await?;
+        let transaction = connection.transaction().await?;
+        let mut orphaned_deferred = 0_u64;
         for mut record in interrupted {
             record.state = InvocationState::Interrupted;
             record.finished_at_ms = Some(finished_at_ms);
             record.termination = Some(Termination::Interrupted);
+            record.summary = Some(InvocationSummary {
+                success: false,
+                headline: "Bazel invocation was interrupted by server restart".to_owned(),
+                truncated: true,
+                inspect_hint: Some("log".to_owned()),
+                ..InvocationSummary::default()
+            });
+            transaction
+                .execute(
+                    "UPDATE invocations
+                     SET state = 'interrupted', finished_at_ms = ?2,
+                         termination_json = ?3, summary_json = ?4
+                     WHERE id = ?1",
+                    params![
+                        record.request.id.to_string(),
+                        finished_at_ms,
+                        serde_json::to_string(&Termination::Interrupted)?,
+                        serde_json::to_string(record.summary.as_ref().expect("summary set"))?,
+                    ],
+                )
+                .await?;
+            orphaned_deferred = orphaned_deferred.saturating_add(
+                transaction
+                    .execute(
+                        "UPDATE deferred_results
+                         SET expires_at_ms = MAX(
+                                 expires_at_ms,
+                                 ?2 + MAX(1, expires_at_ms - created_at_ms)
+                             ),
+                             updated_at_ms = MAX(updated_at_ms, ?2)
+                         WHERE invocation_id = ?1",
+                        params![record.request.id.to_string(), finished_at_ms],
+                    )
+                    .await?,
+            );
             let paths = self.paths_for(&record);
             if paths.directory.is_dir() {
                 paths.write_metadata(&record).await?;
             }
+        }
+        transaction.commit().await?;
+        if orphaned_deferred > 0 {
+            tracing::info!(
+                target: "bazel_mcp::metrics",
+                metric = "orphaned_deferred_work_total",
+                increment = orphaned_deferred,
+                "recovered orphaned deferred invocation metadata"
+            );
         }
         Ok(())
     }
@@ -957,6 +1366,20 @@ async fn validate_schema(connection: &Connection) -> Result<(), StoreError> {
         ("artifacts", &["invocation_id", "record_json"]),
         ("target_results", &["invocation_id", "record_json"]),
         ("coverage_files", &["invocation_id", "record_json"]),
+        (
+            "deferred_results",
+            &[
+                "invocation_id",
+                "retrieval_kind",
+                "created_at_ms",
+                "updated_at_ms",
+                "expires_at_ms",
+                "cancellation_requested_at_ms",
+                "terminal_override",
+                "failure_kind",
+                "failure_message",
+            ],
+        ),
     ] {
         let mut rows = connection
             .query(&format!("PRAGMA table_info({table})"), ())
@@ -1186,10 +1609,88 @@ fn record_from_row(row: &turso::Row) -> Result<InvocationRecord, StoreError> {
     Ok(record)
 }
 
+fn record_from_joined_deferred_row(row: &turso::Row) -> Result<InvocationRecord, StoreError> {
+    let request_json: String = row.get(9)?;
+    let mut record = InvocationRecord::queued(serde_json::from_str(&request_json)?);
+    let state: String = row.get(10)?;
+    record.state = parse_state(&state).ok_or(StoreError::InvalidColumn(10))?;
+    record.started_at_ms = nullable_i64(row, 11)?;
+    record.finished_at_ms = nullable_i64(row, 12)?;
+    record.termination = nullable_json(row, 13)?;
+    record.summary = nullable_json(row, 14)?;
+    let metrics: String = row.get(15)?;
+    record.metrics = serde_json::from_str(&metrics)?;
+    record.canonical_arguments = nullable_json(row, 16)?;
+    record.cancellation_reason = nullable_text(row, 17)?;
+    Ok(record)
+}
+
+fn deferred_from_row(
+    id: InvocationId,
+    row: &turso::Row,
+) -> Result<DeferredResultRecord, StoreError> {
+    deferred_from_columns(id, row, 0)
+}
+
+fn deferred_from_joined_row(
+    id: InvocationId,
+    row: &turso::Row,
+) -> Result<DeferredResultRecord, StoreError> {
+    deferred_from_columns(id, row, 1)
+}
+
+fn deferred_from_columns(
+    id: InvocationId,
+    row: &turso::Row,
+    offset: usize,
+) -> Result<DeferredResultRecord, StoreError> {
+    let retrieval: String = row.get(offset)?;
+    let retrieval =
+        DeferredRetrieval::parse(&retrieval).ok_or(StoreError::InvalidColumn(offset))?;
+    let terminal_override = nullable_text(row, offset + 5)?
+        .map(|value| {
+            DeferredTerminalState::parse(&value).ok_or(StoreError::InvalidColumn(offset + 5))
+        })
+        .transpose()?;
+    let failure_kind = nullable_text(row, offset + 6)?;
+    let failure_message = nullable_text(row, offset + 7)?;
+    let failure = match (failure_kind, failure_message) {
+        (None, None) => None,
+        (Some(kind), Some(redacted_message)) => Some(DeferredFailure {
+            kind: DeferredFailureKind::parse(&kind).ok_or(StoreError::InvalidColumn(offset + 6))?,
+            redacted_message,
+        }),
+        _ => return Err(StoreError::InvalidColumn(offset + 6)),
+    };
+    Ok(DeferredResultRecord {
+        invocation_id: id,
+        retrieval,
+        created_at_ms: row.get(offset + 1)?,
+        updated_at_ms: row.get(offset + 2)?,
+        expires_at_ms: row.get(offset + 3)?,
+        cancellation_requested_at_ms: nullable_i64(row, offset + 4)?,
+        terminal_override,
+        failure,
+    })
+}
+
+fn parse_invocation_id(value: &str, column: usize) -> Result<InvocationId, StoreError> {
+    serde_json::from_value(serde_json::Value::String(value.to_owned()))
+        .map_err(|_| StoreError::InvalidColumn(column))
+}
+
 fn nullable_i64(row: &turso::Row, index: usize) -> Result<Option<i64>, StoreError> {
     match row.get_value(index)? {
         Value::Null => Ok(None),
         Value::Integer(value) => Ok(Some(value)),
+        _ => Err(StoreError::InvalidColumn(index)),
+    }
+}
+
+fn nullable_text(row: &turso::Row, index: usize) -> Result<Option<String>, StoreError> {
+    match row.get_value(index)? {
+        Value::Null => Ok(None),
+        Value::Text(value) => Ok(Some(value)),
         _ => Err(StoreError::InvalidColumn(index)),
     }
 }
@@ -1302,6 +1803,157 @@ mod tests {
             .unwrap();
         let record = store.get_invocation(id).await.unwrap();
         assert_eq!(record.state, InvocationState::Running);
+    }
+
+    #[tokio::test]
+    async fn deferred_results_are_atomic_typed_paged_and_expiry_aware() {
+        let root = tempdir().unwrap();
+        let store = Store::open(root.path()).await.unwrap();
+        let now = 10_000_i64;
+        let mut ids = Vec::new();
+        for offset in 0..3_i64 {
+            let mut request = InvocationRequest::new(
+                PathBuf::from("/tmp/workspace"),
+                BazelCommand::Build,
+                vec![format!("//:task-{offset}")],
+            );
+            request.requested_at_ms = now + offset;
+            let id = request.id;
+            let record = InvocationRecord::queued(request);
+            let deferred = DeferredResultRecord::new(
+                id,
+                DeferredRetrieval::SeparateResult,
+                now + offset,
+                now + offset + 1_000,
+            );
+            store
+                .create_invocation_with_deferred(&record, Some(&deferred))
+                .await
+                .unwrap();
+            ids.push(id);
+        }
+
+        let first = store
+            .get_deferred_result(ids[0], DeferredRetrieval::SeparateResult, now)
+            .await
+            .unwrap();
+        assert_eq!(first.invocation.request.id, ids[0]);
+        assert!(matches!(
+            store
+                .get_deferred_result(ids[0], DeferredRetrieval::InlineResult, now)
+                .await,
+            Err(StoreError::DeferredNotFound(_))
+        ));
+
+        let page = store
+            .list_deferred_results(
+                DeferredRetrieval::SeparateResult,
+                now,
+                PageRequest {
+                    cursor: None,
+                    limit: 2,
+                },
+            )
+            .await
+            .unwrap();
+        assert_eq!(page.items.len(), 2);
+        assert!(page.truncated);
+        assert_eq!(page.items[0].deferred.invocation_id, ids[2]);
+        let second_page = store
+            .list_deferred_results(
+                DeferredRetrieval::SeparateResult,
+                now,
+                PageRequest {
+                    cursor: page.next_cursor,
+                    limit: 2,
+                },
+            )
+            .await
+            .unwrap();
+        assert_eq!(second_page.items.len(), 1);
+        assert_eq!(second_page.items[0].deferred.invocation_id, ids[0]);
+
+        store
+            .record_deferred_cancellation(ids[0], now + 10)
+            .await
+            .unwrap();
+        store
+            .persist_deferred_failure(
+                ids[0],
+                &DeferredFailure {
+                    kind: DeferredFailureKind::Execution,
+                    redacted_message: "bounded failure".to_owned(),
+                },
+                now + 11,
+            )
+            .await
+            .unwrap();
+        store
+            .set_deferred_terminal_override(ids[0], DeferredTerminalState::Cancelled, now + 12)
+            .await
+            .unwrap();
+        let updated = store
+            .get_deferred_result(ids[0], DeferredRetrieval::SeparateResult, now + 20)
+            .await
+            .unwrap();
+        assert_eq!(
+            updated.deferred.cancellation_requested_at_ms,
+            Some(now + 10)
+        );
+        assert_eq!(
+            updated.deferred.terminal_override,
+            Some(DeferredTerminalState::Cancelled)
+        );
+        assert_eq!(
+            updated.deferred.failure.unwrap().redacted_message,
+            "bounded failure"
+        );
+
+        store
+            .transition(ids[1], InvocationState::Starting, None, None)
+            .await
+            .unwrap();
+        store
+            .transition(ids[1], InvocationState::Running, None, None)
+            .await
+            .unwrap();
+        store
+            .transition(
+                ids[1],
+                InvocationState::Succeeded,
+                Some(Termination::Exit { code: 0 }),
+                Some(InvocationSummary {
+                    success: true,
+                    headline: "done".to_owned(),
+                    ..Default::default()
+                }),
+            )
+            .await
+            .unwrap();
+        let terminal = store
+            .get_deferred_result(
+                ids[1],
+                DeferredRetrieval::SeparateResult,
+                bazel_mcp_types::unix_timestamp_ms(),
+            )
+            .await
+            .unwrap();
+        assert!(
+            terminal.deferred.expires_at_ms
+                >= terminal
+                    .invocation
+                    .finished_at_ms
+                    .unwrap()
+                    .saturating_add(1_000)
+        );
+
+        // A queued task is never expired, even after its initial window.
+        assert!(
+            store
+                .get_deferred_result(ids[2], DeferredRetrieval::SeparateResult, i64::MAX,)
+                .await
+                .is_ok()
+        );
     }
 
     #[tokio::test]
@@ -1438,9 +2090,9 @@ mod tests {
             .await
             .unwrap();
         let row = rows.next().await.unwrap().unwrap();
-        assert_eq!(row.get::<i64>(0).unwrap(), 4);
+        assert_eq!(row.get::<i64>(0).unwrap(), 5);
         assert_eq!(row.get::<i64>(1).unwrap(), 1);
-        assert_eq!(row.get::<i64>(2).unwrap(), 4);
+        assert_eq!(row.get::<i64>(2).unwrap(), 5);
 
         let mut rows = connection
             .query("PRAGMA table_info(invocations)", ())

--- a/crates/bazel-mcp-types/src/deferred.rs
+++ b/crates/bazel-mcp-types/src/deferred.rs
@@ -1,0 +1,198 @@
+use serde::{Deserialize, Serialize};
+
+use crate::{InvocationId, InvocationRecord};
+
+/// Whether a submitted invocation stays attached to its caller or is durable.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ResultDisposition {
+    Attached,
+    Deferred {
+        retrieval: DeferredRetrieval,
+        expires_at_ms: i64,
+    },
+}
+
+/// Protocol-neutral result placement for a deferred invocation.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum DeferredRetrieval {
+    SeparateResult,
+    InlineResult,
+}
+
+impl DeferredRetrieval {
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::SeparateResult => "separate_result",
+            Self::InlineResult => "inline_result",
+        }
+    }
+
+    #[must_use]
+    pub fn parse(value: &str) -> Option<Self> {
+        match value {
+            "separate_result" => Some(Self::SeparateResult),
+            "inline_result" => Some(Self::InlineResult),
+            _ => None,
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum DeferredTerminalState {
+    Cancelled,
+}
+
+impl DeferredTerminalState {
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Cancelled => "cancelled",
+        }
+    }
+
+    #[must_use]
+    pub fn parse(value: &str) -> Option<Self> {
+        match value {
+            "cancelled" => Some(Self::Cancelled),
+            _ => None,
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum DeferredFailureKind {
+    Queue,
+    Execution,
+    Internal,
+}
+
+impl DeferredFailureKind {
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Queue => "queue",
+            Self::Execution => "execution",
+            Self::Internal => "internal",
+        }
+    }
+
+    #[must_use]
+    pub fn parse(value: &str) -> Option<Self> {
+        match value {
+            "queue" => Some(Self::Queue),
+            "execution" => Some(Self::Execution),
+            "internal" => Some(Self::Internal),
+            _ => None,
+        }
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub struct DeferredFailure {
+    pub kind: DeferredFailureKind,
+    pub redacted_message: String,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub struct DeferredResultRecord {
+    pub invocation_id: InvocationId,
+    pub retrieval: DeferredRetrieval,
+    pub created_at_ms: i64,
+    pub updated_at_ms: i64,
+    pub expires_at_ms: i64,
+    pub cancellation_requested_at_ms: Option<i64>,
+    pub terminal_override: Option<DeferredTerminalState>,
+    pub failure: Option<DeferredFailure>,
+}
+
+impl DeferredResultRecord {
+    #[must_use]
+    pub fn new(
+        invocation_id: InvocationId,
+        retrieval: DeferredRetrieval,
+        created_at_ms: i64,
+        expires_at_ms: i64,
+    ) -> Self {
+        Self {
+            invocation_id,
+            retrieval,
+            created_at_ms,
+            updated_at_ms: created_at_ms,
+            expires_at_ms: expires_at_ms.max(created_at_ms.saturating_add(1)),
+            cancellation_requested_at_ms: None,
+            terminal_override: None,
+            failure: None,
+        }
+    }
+
+    #[must_use]
+    pub fn configured_ttl_ms(&self) -> i64 {
+        self.expires_at_ms.saturating_sub(self.updated_at_ms).max(1)
+    }
+
+    /// Extend expiry so a terminal result remains available for one configured TTL.
+    pub fn extend_terminal_expiry(&mut self, terminal_at_ms: i64) -> bool {
+        let required = terminal_at_ms.saturating_add(self.configured_ttl_ms());
+        if required > self.expires_at_ms {
+            self.expires_at_ms = required;
+            self.updated_at_ms = terminal_at_ms.max(self.updated_at_ms);
+            true
+        } else {
+            false
+        }
+    }
+
+    #[must_use]
+    pub fn advertised_ttl_ms(&self) -> u64 {
+        u64::try_from(self.expires_at_ms.saturating_sub(self.created_at_ms)).unwrap_or(u64::MAX)
+    }
+
+    #[must_use]
+    pub fn is_expired(&self, now_ms: i64, invocation_terminal: bool) -> bool {
+        invocation_terminal && self.expires_at_ms <= now_ms
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct DeferredResultView {
+    pub deferred: DeferredResultRecord,
+    pub invocation: InvocationRecord,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn terminal_expiry_is_deterministic_and_never_shortens() {
+        let mut record = DeferredResultRecord::new(
+            InvocationId::new(),
+            DeferredRetrieval::InlineResult,
+            1_000,
+            11_000,
+        );
+        assert_eq!(record.configured_ttl_ms(), 10_000);
+        assert!(record.extend_terminal_expiry(20_000));
+        assert_eq!(record.expires_at_ms, 30_000);
+        assert_eq!(record.advertised_ttl_ms(), 29_000);
+        assert!(!record.extend_terminal_expiry(15_000));
+        assert_eq!(record.expires_at_ms, 30_000);
+    }
+
+    #[test]
+    fn nonterminal_tasks_do_not_expire() {
+        let record = DeferredResultRecord::new(
+            InvocationId::new(),
+            DeferredRetrieval::SeparateResult,
+            1_000,
+            2_000,
+        );
+        assert!(!record.is_expired(3_000, false));
+        assert!(record.is_expired(3_000, true));
+    }
+}

--- a/crates/bazel-mcp-types/src/lib.rs
+++ b/crates/bazel-mcp-types/src/lib.rs
@@ -3,6 +3,7 @@
 mod artifact;
 mod command;
 mod coverage;
+mod deferred;
 mod diagnostic;
 mod invocation;
 mod pagination;
@@ -13,6 +14,10 @@ mod test;
 pub use artifact::{Artifact, ArtifactKind};
 pub use command::{BazelCommand, CommandClass};
 pub use coverage::{CoverageFile, CoverageSummary};
+pub use deferred::{
+    DeferredFailure, DeferredFailureKind, DeferredResultRecord, DeferredResultView,
+    DeferredRetrieval, DeferredTerminalState, ResultDisposition,
+};
 pub use diagnostic::{Diagnostic, DiagnosticCategory, DiagnosticLocation, Severity};
 pub use invocation::{
     InvocationId, InvocationMetrics, InvocationRecord, InvocationRequest, InvocationState,

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -106,6 +106,30 @@ Available values are:
 | `structured` | MCP structured content only. |
 | `both` | Structured content plus backwards-compatible JSON text. |
 
+### Configure negotiated task execution
+
+```toml
+mcp_execution_policy = "auto"
+task_ttl_seconds = 86400
+task_poll_interval_ms = 2000
+```
+
+`auto` is the recommended default. The server discovers support at runtime and
+uses synchronous execution for ordinary clients, the experimental task flow
+for clients negotiating MCP `2025-11-25` and sending `params.task`, or the
+`io.modelcontextprotocol/tasks` extension for clients negotiating its
+`2026-06-30` base protocol and declaring the extension in per-request
+capabilities. The task dialect is never selected from a host name.
+
+`sync_only` always returns an ordinary `CallToolResult` for new calls. Existing
+unexpired task handles remain readable and cancellable after a restart or
+policy change. `tasks_required` rejects `bazel.run` before starting Bazel when
+the client did not declare a compatible task flow.
+
+The TTL is the minimum time a terminal task result remains available. A task
+that is still queued or running never expires. The poll interval is advisory
+and must be between 100 and 60,000 milliseconds.
+
 ## Reference
 
 | Setting | Default | Description |
@@ -126,6 +150,9 @@ Available values are:
 | `cancellation_terminate_grace_seconds` | `5` | Additional time allowed after termination. |
 | `progress_initial_seconds` | `30` | Delay before the first MCP progress notification. |
 | `progress_interval_seconds` | `60` | Interval between later progress notifications. |
+| `mcp_execution_policy` | `auto` | New-run policy: `auto`, `sync_only`, or `tasks_required`. |
+| `task_ttl_seconds` | `86400` | Minimum terminal task-result availability window; must be greater than zero. |
+| `task_poll_interval_ms` | `2000` | Suggested task polling interval, from 100 through 60,000 ms. |
 | `retention_days` | `7` | Maximum age of retained invocation evidence. |
 | `maximum_storage_bytes` | `10737418240` | Maximum cache size before older evidence is removed. |
 | `retention_cleanup_interval_seconds` | `3600` | Interval between retention sweeps. |

--- a/examples/config.toml
+++ b/examples/config.toml
@@ -8,6 +8,12 @@ cancellation_interrupt_grace_seconds = 10
 cancellation_terminate_grace_seconds = 5
 progress_initial_seconds = 30
 progress_interval_seconds = 60
+# "auto" negotiates synchronous, legacy 2025-11-25 tasks, or the Tasks extension.
+# Use "sync_only" as a host compatibility escape hatch, or "tasks_required"
+# only when detached execution is mandatory.
+mcp_execution_policy = "auto"
+task_ttl_seconds = 86400
+task_poll_interval_ms = 2000
 redaction_patterns = ["(?i)token=[^\\s]+"]
 retention_days = 7
 maximum_storage_bytes = 10737418240

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -205,6 +205,7 @@ dependencies = [
  "sha2",
  "thiserror",
  "tokio",
+ "tracing",
  "turso",
 ]
 

--- a/scripts/compat/claude-code.lock
+++ b/scripts/compat/claude-code.lock
@@ -1,0 +1,13 @@
+{
+  "package": "@anthropic-ai/claude-code",
+  "version": "2.1.204",
+  "tarball": "https://registry.npmjs.org/@anthropic-ai/claude-code/-/claude-code-2.1.204.tgz",
+  "sha1": "b34139bd500ec82f463568ec8933c296d568c1c5",
+  "integrity": "sha512-DmU1s/YJVvbdTAYiv9YTdA06qaD27otG5OJ2VVGGguQPMiyvfcoPP+//JJACbmBDcxMm121aqBssOXDp+4UXeQ==",
+  "platforms": [
+    "darwin-arm64",
+    "darwin-x64",
+    "linux-arm64",
+    "linux-x64"
+  ]
+}

--- a/scripts/compat/package-lock.json
+++ b/scripts/compat/package-lock.json
@@ -1,0 +1,163 @@
+{
+  "name": "bazel-mcp-claude-compat",
+  "version": "0.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "bazel-mcp-claude-compat",
+      "version": "0.0.0",
+      "devDependencies": {
+        "@anthropic-ai/claude-code": "2.1.204"
+      }
+    },
+    "node_modules/@anthropic-ai/claude-code": {
+      "version": "2.1.204",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-code/-/claude-code-2.1.204.tgz",
+      "integrity": "sha512-DmU1s/YJVvbdTAYiv9YTdA06qaD27otG5OJ2VVGGguQPMiyvfcoPP+//JJACbmBDcxMm121aqBssOXDp+4UXeQ==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "SEE LICENSE IN README.md",
+      "bin": {
+        "claude": "bin/claude.exe"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      },
+      "optionalDependencies": {
+        "@anthropic-ai/claude-code-darwin-arm64": "2.1.204",
+        "@anthropic-ai/claude-code-darwin-x64": "2.1.204",
+        "@anthropic-ai/claude-code-linux-arm64": "2.1.204",
+        "@anthropic-ai/claude-code-linux-arm64-musl": "2.1.204",
+        "@anthropic-ai/claude-code-linux-x64": "2.1.204",
+        "@anthropic-ai/claude-code-linux-x64-musl": "2.1.204",
+        "@anthropic-ai/claude-code-win32-arm64": "2.1.204",
+        "@anthropic-ai/claude-code-win32-x64": "2.1.204"
+      }
+    },
+    "node_modules/@anthropic-ai/claude-code-darwin-arm64": {
+      "version": "2.1.204",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-code-darwin-arm64/-/claude-code-darwin-arm64-2.1.204.tgz",
+      "integrity": "sha512-gR8r5FZrM2sivcpKTI9zOippDNxnvMATZDsgh9PYFVr7e40aHvvBsSgforiKgcJNICeh8hF6VhBfvX2MAOVGNg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@anthropic-ai/claude-code-darwin-x64": {
+      "version": "2.1.204",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-code-darwin-x64/-/claude-code-darwin-x64-2.1.204.tgz",
+      "integrity": "sha512-swM86reqWhh6QPMbp+pLPHbT+4bIpilwRwWyLgOv/rsRDmjYCaom00qU4VVMe1poxtvwlymx4/lGwA0l5akwlw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@anthropic-ai/claude-code-linux-arm64": {
+      "version": "2.1.204",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-code-linux-arm64/-/claude-code-linux-arm64-2.1.204.tgz",
+      "integrity": "sha512-modtmDBn++ENMTwu+OKuq/iJmSXIIeijw3sn+Cd7zoKzZuGGGVAiOshpojrJO7RgSUXPmM2HIr5n1pKoF4mYMQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@anthropic-ai/claude-code-linux-arm64-musl": {
+      "version": "2.1.204",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-code-linux-arm64-musl/-/claude-code-linux-arm64-musl-2.1.204.tgz",
+      "integrity": "sha512-ZntUfFY+U1GdPN5iuTlNrCgH2b6fqv+tqFoZwWYdMoKMmYdJwmVP1ztDy/bsVnoSbG7meMQ68Zg4U3W7HUnyTA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@anthropic-ai/claude-code-linux-x64": {
+      "version": "2.1.204",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-code-linux-x64/-/claude-code-linux-x64-2.1.204.tgz",
+      "integrity": "sha512-jCOk6WtIxgRUxikj/6u6/SmxsOss/bSCkQFCmTjqEeGv8Bl7hkba1n61vW02JP5G1UeFLZSct9csJux6fjDRuQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@anthropic-ai/claude-code-linux-x64-musl": {
+      "version": "2.1.204",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-code-linux-x64-musl/-/claude-code-linux-x64-musl-2.1.204.tgz",
+      "integrity": "sha512-mKfJSGTpliUm5Fz+0xnqIuxSy4MlrSfdw5cGRy1Uyo2wMHZ81NCTHb2tkn4gPwUvFCj26g8jlsqHt5KS68E8OQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@anthropic-ai/claude-code-win32-arm64": {
+      "version": "2.1.204",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-code-win32-arm64/-/claude-code-win32-arm64-2.1.204.tgz",
+      "integrity": "sha512-2s3QcjsaAxbFxQQKjkT/6awRxZ29h45sHP6pdiWmWI3gdaBOhV+aNiNkbxdoNSo8ZroNmzJtDukne3k9ExaHGw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@anthropic-ai/claude-code-win32-x64": {
+      "version": "2.1.204",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-code-win32-x64/-/claude-code-win32-x64-2.1.204.tgz",
+      "integrity": "sha512-nSrV3StPDFpEzde5GtJHsCk+6aqKqDGbAf0qQzK8JzCUCi++TvoR2QA7HLiEsfk0Uy6lyCVKQJBsyvr5ve+EFA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    }
+  }
+}

--- a/scripts/compat/package.json
+++ b/scripts/compat/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "bazel-mcp-claude-compat",
+  "version": "0.0.0",
+  "private": true,
+  "description": "Pinned Claude Code dependency for credential-free MCP compatibility tests",
+  "devDependencies": {
+    "@anthropic-ai/claude-code": "2.1.204"
+  }
+}

--- a/scripts/compat/stdio-proxy.py
+++ b/scripts/compat/stdio-proxy.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python3
+"""Transparent stdio proxy that records normalized MCP JSON lines."""
+
+import argparse
+import json
+import subprocess
+import sys
+import threading
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--trace", required=True)
+    parser.add_argument("command", nargs=argparse.REMAINDER)
+    arguments = parser.parse_args()
+    if not arguments.command:
+        parser.error("a server command is required")
+
+    child = subprocess.Popen(
+        arguments.command,
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    trace = open(arguments.trace, "a", encoding="utf-8")
+    trace_lock = threading.Lock()
+
+    def record(direction, line):
+        try:
+            message = json.loads(line)
+        except (UnicodeDecodeError, json.JSONDecodeError):
+            message = {"invalid": line.decode("utf-8", errors="replace").rstrip("\n")}
+        with trace_lock:
+            trace.write(json.dumps({"direction": direction, "message": message}, sort_keys=True))
+            trace.write("\n")
+            trace.flush()
+
+    def client_to_server():
+        try:
+            for line in sys.stdin.buffer:
+                record("client_to_server", line)
+                child.stdin.write(line)
+                child.stdin.flush()
+        finally:
+            child.stdin.close()
+
+    def server_to_client():
+        for line in child.stdout:
+            record("server_to_client", line)
+            sys.stdout.buffer.write(line)
+            sys.stdout.buffer.flush()
+
+    def server_stderr():
+        for chunk in iter(lambda: child.stderr.read(8192), b""):
+            sys.stderr.buffer.write(chunk)
+            sys.stderr.buffer.flush()
+
+    threads = [
+        threading.Thread(target=client_to_server, daemon=True),
+        threading.Thread(target=server_to_client, daemon=True),
+        threading.Thread(target=server_stderr, daemon=True),
+    ]
+    for thread in threads:
+        thread.start()
+    status = child.wait()
+    threads[1].join(timeout=2)
+    threads[2].join(timeout=2)
+    trace.close()
+    raise SystemExit(status)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/compat/test-claude-code.py
+++ b/scripts/compat/test-claude-code.py
@@ -1,0 +1,359 @@
+#!/usr/bin/env python3
+"""Pinned Claude Code compatibility test using a loopback mock Messages API."""
+
+import argparse
+import http.server
+import json
+import os
+import pathlib
+import shutil
+import socketserver
+import subprocess
+import sys
+import tempfile
+import threading
+
+
+ROOT = pathlib.Path(__file__).resolve().parents[2]
+LOCK = json.loads((ROOT / "scripts/compat/claude-code.lock").read_text())
+
+
+def message_payload(block, stop_reason):
+    return {
+        "id": "msg_bazel_mcp_compat",
+        "type": "message",
+        "role": "assistant",
+        "model": "claude-compat-mock",
+        "content": [block],
+        "stop_reason": stop_reason,
+        "stop_sequence": None,
+        "usage": {"input_tokens": 1, "output_tokens": 1},
+    }
+
+
+class MockMessagesHandler(http.server.BaseHTTPRequestHandler):
+    workspace = ""
+    requests = []
+
+    def log_message(self, _format, *_arguments):
+        return
+
+    def do_POST(self):
+        length = int(self.headers.get("content-length", "0"))
+        body = json.loads(self.rfile.read(length) or b"{}")
+        type(self).requests.append({"path": self.path, "body": body})
+        if "count_tokens" in self.path:
+            self.send_response(200)
+            self.send_header("content-type", "application/json")
+            self.end_headers()
+            self.wfile.write(b'{"input_tokens":1}')
+            return
+
+        saw_tool_result = any(
+            isinstance(content, list)
+            and any(
+                isinstance(block, dict) and block.get("type") == "tool_result"
+                for block in content
+            )
+            for message in body.get("messages", [])
+            for content in [message.get("content")]
+        )
+        if saw_tool_result:
+            block = {"type": "text", "text": "Bazel result acknowledged."}
+            stop_reason = "end_turn"
+        else:
+            tool = next(
+                (
+                    tool
+                    for tool in body.get("tools", [])
+                    if "bazel_run" in tool.get("name", "")
+                    or "bazel.run" in tool.get("name", "")
+                ),
+                None,
+            )
+            if tool is None:
+                block = {"type": "text", "text": "No Bazel MCP tool was available."}
+                stop_reason = "end_turn"
+            else:
+                block = {
+                    "type": "tool_use",
+                    "id": "toolu_bazel_mcp_compat",
+                    "name": tool["name"],
+                    "input": {
+                        "workspace": type(self).workspace,
+                        "command": "build",
+                        "args": ["//:compat"],
+                    },
+                }
+                stop_reason = "tool_use"
+        payload = message_payload(block, stop_reason)
+        if body.get("stream"):
+            self.send_response(200)
+            self.send_header("content-type", "text/event-stream")
+            self.send_header("cache-control", "no-cache")
+            self.end_headers()
+            start = dict(payload)
+            start["content"] = []
+            start["stop_reason"] = None
+            events = [
+                ("message_start", {"type": "message_start", "message": start}),
+                (
+                    "content_block_start",
+                    {
+                        "type": "content_block_start",
+                        "index": 0,
+                        "content_block": (
+                            {**block, "input": {}}
+                            if block["type"] == "tool_use"
+                            else {**block, "text": ""}
+                        ),
+                    },
+                ),
+            ]
+            if block["type"] == "tool_use":
+                events.append(
+                    (
+                        "content_block_delta",
+                        {
+                            "type": "content_block_delta",
+                            "index": 0,
+                            "delta": {
+                                "type": "input_json_delta",
+                                "partial_json": json.dumps(block["input"]),
+                            },
+                        },
+                    )
+                )
+            else:
+                events.append(
+                    (
+                        "content_block_delta",
+                        {
+                            "type": "content_block_delta",
+                            "index": 0,
+                            "delta": {"type": "text_delta", "text": block["text"]},
+                        },
+                    )
+                )
+            events.extend(
+                [
+                    ("content_block_stop", {"type": "content_block_stop", "index": 0}),
+                    (
+                        "message_delta",
+                        {
+                            "type": "message_delta",
+                            "delta": {"stop_reason": stop_reason, "stop_sequence": None},
+                            "usage": {"output_tokens": 1},
+                        },
+                    ),
+                    ("message_stop", {"type": "message_stop"}),
+                ]
+            )
+            for event, data in events:
+                self.wfile.write(f"event: {event}\ndata: {json.dumps(data)}\n\n".encode())
+                self.wfile.flush()
+        else:
+            encoded = json.dumps(payload).encode()
+            self.send_response(200)
+            self.send_header("content-type", "application/json")
+            self.send_header("content-length", str(len(encoded)))
+            self.end_headers()
+            self.wfile.write(encoded)
+
+
+class LoopbackServer(socketserver.ThreadingMixIn, http.server.HTTPServer):
+    daemon_threads = True
+
+
+def verify_claude():
+    executable = shutil.which("claude")
+    if not executable:
+        raise SystemExit(
+            f"Claude Code {LOCK['version']} is required; install "
+            f"{LOCK['package']}@{LOCK['version']}"
+        )
+    version = subprocess.run(
+        [executable, "--version"], capture_output=True, text=True, check=True
+    ).stdout
+    if LOCK["version"] not in version:
+        raise SystemExit(
+            f"Claude Code version mismatch: expected {LOCK['version']}, observed {version.strip()}"
+        )
+    return executable
+
+
+def trace_messages(path):
+    return [json.loads(line) for line in path.read_text().splitlines() if line]
+
+
+def run_case(claude, temporary, workspace, wrapper, policy, live=False):
+    case = temporary / policy
+    case.mkdir()
+    trace = case / "stdio.jsonl"
+    server_config = case / "server.toml"
+    server_config.write_text(
+        f"allowed_roots = [{json.dumps(str(workspace))}]\n"
+        f"cache_root = {json.dumps(str(case / 'cache'))}\n"
+        f"bazel_executable = {json.dumps(str(wrapper))}\n"
+        f"mcp_execution_policy = {json.dumps(policy)}\n"
+        "task_poll_interval_ms = 100\n"
+    )
+    mcp_config = case / "mcp.json"
+    mcp_config.write_text(
+        json.dumps(
+            {
+                "mcpServers": {
+                    "bazel": {
+                        "type": "stdio",
+                        "command": sys.executable,
+                        "args": [
+                            str(ROOT / "scripts/compat/stdio-proxy.py"),
+                            "--trace",
+                            str(trace),
+                            str(ROOT / "target/debug/bazel-mcp"),
+                            "--config",
+                            str(server_config),
+                            "--log",
+                            "error",
+                        ],
+                    }
+                }
+            }
+        )
+    )
+    env = os.environ.copy()
+    mock = None
+    thread = None
+    if live:
+        if not env.get("ANTHROPIC_API_KEY"):
+            raise SystemExit("ANTHROPIC_API_KEY is required for test-claude-code-live")
+    else:
+        MockMessagesHandler.workspace = str(workspace)
+        MockMessagesHandler.requests = []
+        mock = LoopbackServer(("127.0.0.1", 0), MockMessagesHandler)
+        thread = threading.Thread(target=mock.serve_forever, daemon=True)
+        thread.start()
+        env.update({
+            "ANTHROPIC_BASE_URL": f"http://127.0.0.1:{mock.server_port}",
+            "ANTHROPIC_API_KEY": "dummy-compatibility-key",
+        })
+    env.update({
+        "CLAUDE_CONFIG_DIR": str(case / "claude-config"),
+        "DISABLE_TELEMETRY": "1",
+        "DISABLE_ERROR_REPORTING": "1",
+        "CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC": "1",
+    })
+    command = [
+        claude,
+        "--bare",
+        "--print",
+        "--strict-mcp-config",
+        "--mcp-config",
+        str(mcp_config),
+        "--no-session-persistence",
+        "--allowedTools",
+        "mcp__bazel__*",
+    ]
+    if live:
+        command.extend(["--max-budget-usd", "0.10"])
+    try:
+        completed = subprocess.run(
+            command,
+            cwd=workspace,
+            env=env,
+            input="Build //:compat with the Bazel MCP server and report the result.\n",
+            capture_output=True,
+            text=True,
+            timeout=60,
+        )
+    finally:
+        if mock is not None:
+            mock.shutdown()
+            mock.server_close()
+            thread.join(timeout=2)
+    if completed.returncode != 0:
+        raise AssertionError(
+            f"Claude Code {policy} case failed ({completed.returncode}):\n"
+            f"stdout={completed.stdout}\nstderr={completed.stderr}"
+        )
+    messages = trace_messages(trace)
+    client = [
+        item["message"]
+        for item in messages
+        if item["direction"] == "client_to_server"
+    ]
+    server = [
+        item["message"]
+        for item in messages
+        if item["direction"] == "server_to_client"
+    ]
+    initialized = next(message for message in client if message.get("method") == "initialize")
+    assert initialized["params"]["protocolVersion"] == "2025-11-25"
+    list_request = next(message for message in client if message.get("method") == "tools/list")
+    listed = next(message for message in server if message.get("id") == list_request["id"])
+    assert [tool["name"] for tool in listed["result"]["tools"]] == [
+        "bazel.cancel",
+        "bazel.inspect",
+        "bazel.run",
+    ]
+    call = next(message for message in client if message.get("method") == "tools/call")
+    response = next(message for message in server if message.get("id") == call["id"])
+    run_tool = next(tool for tool in listed["result"]["tools"] if tool["name"] == "bazel.run")
+    assert "task" not in call["params"], call["params"]
+    if policy == "sync_only":
+        assert "execution" not in next(
+            tool for tool in listed["result"]["tools"] if tool["name"] == "bazel.run"
+        )
+        assert response["result"]["isError"] is False
+    elif policy == "auto":
+        assert run_tool["execution"]["taskSupport"] == "optional"
+        assert response["result"]["isError"] is False
+    else:
+        assert run_tool["execution"]["taskSupport"] == "required"
+        assert response["error"]["code"] == -32601
+    assert not any(
+        message.get("method", "").startswith("tasks/") for message in client
+    )
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--live", action="store_true")
+    arguments = parser.parse_args()
+    claude = verify_claude()
+    server = ROOT / "target/debug/bazel-mcp"
+    if not server.is_file():
+        raise SystemExit("build target/debug/bazel-mcp before running compatibility")
+    with tempfile.TemporaryDirectory() as name:
+        temporary = pathlib.Path(name)
+        workspace = temporary / "workspace"
+        workspace.mkdir()
+        (workspace / "MODULE.bazel").write_text("module(name='claude_compat')\n")
+        launches = temporary / "launches.jsonl"
+        wrapper = temporary / "fake-bazel.py"
+        wrapper.write_text(
+            "#!/usr/bin/env python3\n"
+            "import json, pathlib, sys, time\n"
+            "if sys.argv[1:] == ['--version']:\n"
+            "    print('bazel 9.1.0')\n"
+            "    raise SystemExit(0)\n"
+            f"path = pathlib.Path({str(launches)!r})\n"
+            "with path.open('a') as output:\n"
+            "    output.write(json.dumps(sys.argv[1:]) + '\\n')\n"
+            "time.sleep(0.4)\n"
+        )
+        wrapper.chmod(0o700)
+        for policy in ("sync_only", "auto", "tasks_required"):
+            before = len(launches.read_text().splitlines()) if launches.exists() else 0
+            run_case(claude, temporary, workspace, wrapper, policy, arguments.live)
+            after = len(launches.read_text().splitlines()) if launches.exists() else 0
+            expected = before if policy == "tasks_required" else before + 1
+            assert after == expected
+    kind = "live" if arguments.live else "credential-free"
+    print(
+        f"Claude Code {LOCK['version']} {kind} synchronous fallback and task-policy compatibility passed"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/test-mcp-conformance.py
+++ b/scripts/test-mcp-conformance.py
@@ -1,103 +1,618 @@
 #!/usr/bin/env python3
-"""Stdio checks complementing official MCP conformance 0.1.15.
+"""Credential-free stdio conformance for negotiated Bazel MCP execution."""
 
-The upstream server runner currently accepts an HTTP URL, while bazel-mcp is a
-stdio-only local server. These checks exercise the same initialize/tools
-contracts at the actual production boundary.
-"""
 import json
 import pathlib
 import subprocess
-import sys
 import tempfile
+import threading
+import time
+import uuid
 
 
-def send(process, value):
-    process.stdin.write(json.dumps(value, separators=(",", ":")) + "\n")
-    process.stdin.flush()
+TASKS_EXTENSION = "io.modelcontextprotocol/tasks"
 
 
-def receive(process, request_id, notifications=None):
-    while True:
-        line = process.stdout.readline()
-        if not line:
-            raise AssertionError("server closed stdout")
-        message = json.loads(line)
-        if message.get("id") == request_id:
-            return message
-        if notifications is not None:
-            notifications.append(message)
+class Session:
+    def __init__(self, server, config):
+        self.process = subprocess.Popen(
+            [str(server), "--config", str(config), "--log", "bazel_mcp=info"],
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+        self.next_id = 1
+        self.messages = []
+        self.stderr_lines = []
+        self.stderr_reader = threading.Thread(target=self._drain_stderr, daemon=True)
+        self.stderr_reader.start()
+
+    def _drain_stderr(self):
+        for line in self.process.stderr:
+            self.stderr_lines.append(line)
+
+    def stderr(self):
+        self.stderr_reader.join(timeout=1)
+        return "".join(self.stderr_lines)
+
+    def request(self, method, params=None):
+        request_id = self.next_id
+        self.next_id += 1
+        message = {"jsonrpc": "2.0", "id": request_id, "method": method}
+        if params is not None:
+            message["params"] = params
+        self.process.stdin.write(json.dumps(message, separators=(",", ":")) + "\n")
+        self.process.stdin.flush()
+        while True:
+            line = self.process.stdout.readline()
+            if not line:
+                raise AssertionError(f"server closed stdout: {self.stderr()}")
+            response = json.loads(line)
+            self.messages.append(response)
+            if response.get("id") == request_id:
+                return response
+
+    def notify(self, method, params=None):
+        message = {"jsonrpc": "2.0", "method": method}
+        if params is not None:
+            message["params"] = params
+        self.process.stdin.write(json.dumps(message, separators=(",", ":")) + "\n")
+        self.process.stdin.flush()
+
+    def cancel_request(self, method, params, delay=0.1):
+        request_id = self.next_id
+        self.next_id += 1
+        message = {
+            "jsonrpc": "2.0",
+            "id": request_id,
+            "method": method,
+            "params": params,
+        }
+        self.process.stdin.write(json.dumps(message, separators=(",", ":")) + "\n")
+        self.process.stdin.flush()
+        time.sleep(delay)
+        self.notify(
+            "notifications/cancelled",
+            {"requestId": request_id, "reason": "conformance cancellation"},
+        )
+        return request_id
+
+    def initialize(self, version):
+        response = self.request(
+            "initialize",
+            {
+                "protocolVersion": version,
+                "capabilities": {},
+                "clientInfo": {"name": "bazel-mcp-conformance", "version": "1"},
+            },
+        )
+        assert "error" not in response, response
+        assert response["result"]["protocolVersion"] == version
+        assert response["result"]["serverInfo"]["name"] == "bazel-mcp"
+        self.notify("notifications/initialized")
+        return response["result"]
+
+    def close(self):
+        self.process.stdin.close()
+        assert self.process.wait(timeout=15) == 0
+        stderr = self.stderr()
+        assert "CONFORMANCE_SECRET" not in stderr
+        for message in self.messages:
+            json.dumps(message)
+
+
+def extension_meta():
+    return {
+        "io.modelcontextprotocol/clientCapabilities": {
+            "extensions": {TASKS_EXTENSION: {}}
+        }
+    }
+
+
+def run_arguments(workspace, target="//:slow", command="build"):
+    return {"workspace": str(workspace), "command": command, "args": [target]}
+
+
+def tool_json(result):
+    if result.get("structuredContent") is not None:
+        return result["structuredContent"]
+    return json.loads(result["content"][0]["text"])
+
+
+def listed_tools(session):
+    response = session.request("tools/list", {})
+    assert "error" not in response, response
+    tools = response["result"]["tools"]
+    assert [tool["name"] for tool in tools] == [
+        "bazel.cancel",
+        "bazel.inspect",
+        "bazel.run",
+    ]
+    for tool in tools:
+        assert tool["description"]
+        assert tool["inputSchema"]["type"] == "object"
+    return tools
+
+
+def without_execution(tools):
+    return [{key: value for key, value in tool.items() if key != "execution"} for tool in tools]
+
+
+def poll_extension(session, task_id, timeout=10):
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        response = session.request(
+            "tasks/get", {"taskId": task_id, "_meta": extension_meta()}
+        )
+        assert "error" not in response, response
+        result = response["result"]
+        assert result["resultType"] == "complete"
+        if result["status"] != "working":
+            return result
+        time.sleep(0.05)
+    raise AssertionError(f"task {task_id} did not become terminal")
+
+
+def write_config(path, workspace, cache, wrapper, policy):
+    path.write_text(
+        f"allowed_roots = [{json.dumps(str(workspace))}]\n"
+        f"cache_root = {json.dumps(str(cache))}\n"
+        f"bazel_executable = {json.dumps(str(wrapper))}\n"
+        f"mcp_execution_policy = {json.dumps(policy)}\n"
+        "task_ttl_seconds = 3600\n"
+        "task_poll_interval_ms = 100\n"
+        "progress_initial_seconds = 1\n"
+        "progress_interval_seconds = 60\n"
+        "cancellation_interrupt_grace_seconds = 1\n"
+        "cancellation_terminate_grace_seconds = 1\n"
+    )
 
 
 def main():
     root = pathlib.Path.cwd()
     server = root / "target/debug/bazel-mcp"
-    with tempfile.TemporaryDirectory() as temporary:
-        temporary = pathlib.Path(temporary)
+    assert server.is_file(), "build target/debug/bazel-mcp before conformance"
+    with tempfile.TemporaryDirectory() as temporary_name:
+        temporary = pathlib.Path(temporary_name)
         workspace = temporary / "workspace"
         workspace.mkdir()
         (workspace / "MODULE.bazel").write_text("module(name='conformance')\n")
-        wrapper = workspace / "tools" / "bazel"
-        wrapper.parent.mkdir()
+        launches = temporary / "launches"
+        wrapper = temporary / "fake-bazel"
         wrapper.write_text(
             "#!/bin/sh\n"
             "if [ \"${1:-}\" = --version ]; then echo 'bazel 9.1.0'; exit 0; fi\n"
-            "sleep 2\nexit 0\n"
+            f"echo invocation >> {json.dumps(str(launches))}\n"
+            f"trap 'echo cancelled >> {json.dumps(str(launches))}; exit 130' INT TERM\n"
+            "delay=1.2\nstatus=0\ncrash_parent=0\n"
+            "for arg in \"$@\"; do\n"
+            "  [ \"$arg\" = //:instant ] && delay=0\n"
+            "  [ \"$arg\" = //:cancel ] && delay=5\n"
+            "  [ \"$arg\" = //:fail ] && status=7\n"
+            "  [ \"$arg\" = //:crash-server ] && delay=0.4 && crash_parent=1\n"
+            "done\n"
+            "sleep \"$delay\"\n"
+            "[ \"$crash_parent\" -eq 1 ] && kill -9 \"$PPID\"\n"
+            "exit \"$status\"\n"
         )
         wrapper.chmod(0o700)
-        config = temporary / "config.toml"
-        config.write_text(
-            f'allowed_roots = [{json.dumps(str(workspace))}]\n'
-            f'cache_root = {json.dumps(str(temporary / "cache"))}\n'
-            'progress_initial_seconds = 1\n'
-            'progress_interval_seconds = 60\n'
+
+        def session(name, policy="auto"):
+            config = temporary / f"{name}.toml"
+            write_config(
+                config, workspace, temporary / f"cache-{name}", wrapper, policy
+            )
+            return Session(server, config)
+
+        invalid_config = temporary / "invalid-policy.toml"
+        write_config(
+            invalid_config,
+            workspace,
+            temporary / "cache-invalid-policy",
+            wrapper,
+            "detached",
         )
-        process = subprocess.Popen(
-            [str(server), "--config", str(config), "--log", "error"],
-            stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=sys.stderr,
+        invalid_startup = subprocess.run(
+            [str(server), "--config", str(invalid_config)],
+            input="",
+            capture_output=True,
             text=True,
+            timeout=5,
+            check=False,
         )
-        send(process, {
-            "jsonrpc": "2.0", "id": 1, "method": "initialize",
-            "params": {"protocolVersion": "2025-06-18", "capabilities": {},
-                       "clientInfo": {"name": "conformance", "version": "1"}},
-        })
-        initialized = receive(process, 1)
-        assert "error" not in initialized
-        assert initialized["result"]["serverInfo"]["name"] == "bazel-mcp"
-        send(process, {"jsonrpc": "2.0", "method": "notifications/initialized"})
-        send(process, {"jsonrpc": "2.0", "id": 2, "method": "tools/list", "params": {}})
-        listed = receive(process, 2)
-        tools = listed["result"]["tools"]
-        assert [tool["name"] for tool in tools] == ["bazel.cancel", "bazel.inspect", "bazel.run"]
-        for tool in tools:
-            assert tool["description"]
-            assert tool["inputSchema"]["type"] == "object"
-        progress = []
-        send(process, {
-            "jsonrpc": "2.0", "id": 3, "method": "tools/call",
-            "params": {"name": "bazel.run",
-                       "_meta": {"progressToken": "conformance-progress"},
-                       "arguments": {"workspace": str(workspace),
-                                     "command": "build", "args": ["//..."]}},
-        })
-        completed = receive(process, 3, progress)
+        assert invalid_startup.returncode != 0
+        assert invalid_startup.stdout == ""
+        assert invalid_startup.stderr
+
+        # Earlier clients remain synchronous and keep bounded progress behavior.
+        sync = session("sync")
+        initialized = sync.initialize("2025-06-18")
+        assert "tasks" not in initialized["capabilities"]
+        sync_tools = listed_tools(sync)
+        completed = sync.request(
+            "tools/call",
+            {
+                "name": "bazel.run",
+                "_meta": {"progressToken": "conformance-progress"},
+                "arguments": run_arguments(workspace),
+            },
+        )
         assert completed["result"]["isError"] is False
+        assert tool_json(completed["result"])["state"] == "succeeded"
         assert any(
             message.get("method") == "notifications/progress"
-            and message.get("params", {}).get("progressToken") == "conformance-progress"
-            for message in progress
+            for message in sync.messages
         )
-        send(process, {
-            "jsonrpc": "2.0", "id": 4, "method": "tools/call",
-            "params": {"name": "bazel.run", "arguments": {
-                "workspace": str(workspace), "command": "clean", "args": []}},
-        })
-        denied = receive(process, 4)
+        failed = sync.request(
+            "tools/call",
+            {
+                "name": "bazel.run",
+                "arguments": run_arguments(workspace, "//:fail"),
+            },
+        )
+        assert failed["result"]["isError"] is False
+        assert tool_json(failed["result"])["state"] == "failed"
+        sync.cancel_request(
+            "tools/call",
+            {
+                "name": "bazel.run",
+                "arguments": run_arguments(workspace, "//:cancel"),
+            },
+        )
+        assert "error" not in sync.request("ping", {})
+        cancellation_deadline = time.monotonic() + 5
+        while "cancelled" not in launches.read_text():
+            assert time.monotonic() < cancellation_deadline
+            time.sleep(0.05)
+        sync.close()
+
+        # Legacy 2025-11-25 task creation, polling, listing, result, and cancellation.
+        legacy = session("legacy")
+        initialized = legacy.initialize("2025-11-25")
+        assert initialized["capabilities"]["tasks"]["requests"]["tools"]["call"] == {}
+        tools = listed_tools(legacy)
+        assert without_execution(tools) == sync_tools
+        run_tool = next(tool for tool in tools if tool["name"] == "bazel.run")
+        assert run_tool["execution"]["taskSupport"] == "optional"
+        started = time.monotonic()
+        created = legacy.request(
+            "tools/call",
+            {
+                "name": "bazel.run",
+                "arguments": run_arguments(workspace),
+                "task": {"ttl": 1},
+            },
+        )
+        assert time.monotonic() - started < 0.5
+        task = created["result"]["task"]
+        task_id = task["taskId"]
+        uuid.UUID(task_id)
+        assert task["status"] == "working"
+        assert task["ttl"] >= 3_600_000
+        assert created["result"]["_meta"]["io.modelcontextprotocol/related-task"]["taskId"] == task_id
+        current = legacy.request("tasks/get", {"taskId": task_id})
+        assert current["result"]["taskId"] == task_id
+        listed = legacy.request("tasks/list", {})
+        assert any(item["taskId"] == task_id for item in listed["result"]["tasks"])
+        payload = legacy.request("tasks/result", {"taskId": task_id})
+        assert payload["result"]["isError"] is False
+        legacy_logical = tool_json(payload["result"])
+        assert legacy_logical["state"] == "succeeded"
+        assert payload["result"]["_meta"]["io.modelcontextprotocol/related-task"]["taskId"] == task_id
+
+        failed_id = legacy.request(
+            "tools/call",
+            {
+                "name": "bazel.run",
+                "arguments": run_arguments(workspace, "//:fail"),
+                "task": {},
+            },
+        )["result"]["task"]["taskId"]
+        failed_payload = legacy.request("tasks/result", {"taskId": failed_id})
+        assert failed_payload["result"]["isError"] is False
+        assert tool_json(failed_payload["result"])["state"] == "failed"
+        assert legacy.request("tasks/get", {"taskId": failed_id})["result"]["status"] == "completed"
+
+        before = launches.read_text().count("invocation")
+        denied = legacy.request(
+            "tools/call",
+            {
+                "name": "bazel.run",
+                "arguments": run_arguments(workspace, command="clean"),
+                "task": {},
+            },
+        )
         assert denied["result"]["isError"] is True
-        process.stdin.close()
-        assert process.wait(timeout=10) == 0
-    print("stdio MCP initialize, tools, progress, schema, and error semantics passed")
+        assert launches.read_text().count("invocation") == before
+        augmented_inspect = legacy.request(
+            "tools/call",
+            {
+                "name": "bazel.inspect",
+                "arguments": {"invocation_id": task_id, "view": "summary"},
+                "task": {},
+            },
+        )
+        assert augmented_inspect["error"]["code"] == -32601
+        assert legacy.request("tasks/update", {"taskId": task_id})["error"]["code"] == -32601
+        assert legacy.request("tasks/get", {"taskId": str(uuid.uuid4())})["error"]["code"] == -32602
+
+        pagination_ids = []
+        for _ in range(101):
+            pagination_ids.append(
+                legacy.request(
+                    "tools/call",
+                    {
+                        "name": "bazel.run",
+                        "arguments": run_arguments(workspace, "//:instant"),
+                        "task": {},
+                    },
+                )["result"]["task"]["taskId"]
+            )
+        first_page = legacy.request("tasks/list", {})["result"]
+        assert len(first_page["tasks"]) == 100
+        assert first_page.get("nextCursor")
+        second_page = legacy.request(
+            "tasks/list", {"cursor": first_page["nextCursor"]}
+        )["result"]
+        first_ids = {task["taskId"] for task in first_page["tasks"]}
+        second_ids = {task["taskId"] for task in second_page["tasks"]}
+        assert first_ids.isdisjoint(second_ids)
+        assert set(pagination_ids).issubset(first_ids | second_ids)
+
+        cancelled = legacy.request(
+            "tools/call",
+            {
+                "name": "bazel.run",
+                "arguments": run_arguments(workspace, "//:cancel"),
+                "task": {},
+            },
+        )["result"]["task"]["taskId"]
+        cancel_result = legacy.request("tasks/cancel", {"taskId": cancelled})
+        assert cancel_result["result"]["status"] == "cancelled"
+        assert legacy.request("tasks/cancel", {"taskId": cancelled})["error"]["code"] == -32602
+        cancelled_payload = legacy.request("tasks/result", {"taskId": cancelled})
+        assert tool_json(cancelled_payload["result"])["state"] == "cancelled"
+        legacy.close()
+
+        # Final SEP-2663 extension: discovery, per-request capability, inline result.
+        extension = session("extension")
+        discovered = extension.request("server/discover", {})
+        assert TASKS_EXTENSION in discovered["result"]["capabilities"]["extensions"]
+        initialized = extension.initialize("2026-06-30")
+        assert "tasks" not in initialized["capabilities"]
+        assert TASKS_EXTENSION in initialized["capabilities"]["extensions"]
+        extension_tools = listed_tools(extension)
+        assert extension_tools == sync_tools
+        started = time.monotonic()
+        created = extension.request(
+            "tools/call",
+            {
+                "name": "bazel.run",
+                "arguments": run_arguments(workspace),
+                "_meta": extension_meta(),
+            },
+        )
+        assert time.monotonic() - started < 0.5
+        task = created["result"]
+        assert task["resultType"] == "task"
+        extension_id = task["taskId"]
+        immediate = extension.request(
+            "tasks/get", {"taskId": extension_id, "_meta": extension_meta()}
+        )
+        assert immediate["result"]["resultType"] == "complete"
+        assert immediate["result"]["status"] == "working"
+        updated = extension.request(
+            "tasks/update",
+            {"taskId": extension_id, "inputResponses": {}, "_meta": extension_meta()},
+        )
+        assert updated["result"] == {"resultType": "complete"}
+        assert extension.request(
+            "tasks/result", {"taskId": extension_id, "_meta": extension_meta()}
+        )["error"]["code"] == -32601
+        assert extension.request(
+            "tasks/list", {"_meta": extension_meta()}
+        )["error"]["code"] == -32601
+        terminal = poll_extension(extension, extension_id)
+        assert terminal["status"] == "completed"
+        extension_logical = tool_json(terminal["result"])
+        assert extension_logical["state"] == "succeeded"
+        for field in ("state", "command", "exit_code"):
+            assert extension_logical[field] == legacy_logical[field], (
+                field,
+                extension_logical[field],
+                legacy_logical[field],
+            )
+
+        failed_id = extension.request(
+            "tools/call",
+            {
+                "name": "bazel.run",
+                "arguments": run_arguments(workspace, "//:fail"),
+                "_meta": extension_meta(),
+            },
+        )["result"]["taskId"]
+        failed_task = poll_extension(extension, failed_id)
+        assert failed_task["status"] == "completed"
+        assert failed_task["result"]["isError"] is False
+        assert tool_json(failed_task["result"])["state"] == "failed"
+        assert extension.request(
+            "tasks/get", {"taskId": str(uuid.uuid4()), "_meta": extension_meta()}
+        )["error"]["code"] == -32602
+
+        before = launches.read_text().count("invocation")
+        denied = extension.request(
+            "tools/call",
+            {
+                "name": "bazel.run",
+                "arguments": run_arguments(workspace, command="clean"),
+                "_meta": extension_meta(),
+            },
+        )
+        assert denied["result"]["isError"] is True
+        assert launches.read_text().count("invocation") == before
+
+        # A non-declaring modern request falls back to an ordinary result.
+        fallback = extension.request(
+            "tools/call",
+            {"name": "bazel.run", "arguments": run_arguments(workspace, "//:instant")},
+        )
+        assert fallback["result"]["isError"] is False
+
+        cancelled = extension.request(
+            "tools/call",
+            {
+                "name": "bazel.run",
+                "arguments": run_arguments(workspace, "//:cancel"),
+                "_meta": extension_meta(),
+            },
+        )["result"]["taskId"]
+        ack = extension.request(
+            "tasks/cancel", {"taskId": cancelled, "_meta": extension_meta()}
+        )
+        assert ack["result"] == {"resultType": "complete"}
+        assert poll_extension(extension, cancelled)["status"] == "cancelled"
+        extension.close()
+
+        # Policy matrix: sync_only ignores task capability; tasks_required rejects early.
+        sync_only = session("sync-only", "sync_only")
+        sync_only.initialize("2025-11-25")
+        assert "execution" not in next(
+            tool for tool in listed_tools(sync_only) if tool["name"] == "bazel.run"
+        )
+        ordinary = sync_only.request(
+            "tools/call",
+            {
+                "name": "bazel.run",
+                "arguments": run_arguments(workspace, "//:instant"),
+                "task": {},
+            },
+        )
+        assert ordinary["result"]["isError"] is False
+        sync_only.close()
+
+        required_legacy = session("required-legacy", "tasks_required")
+        required_legacy.initialize("2025-11-25")
+        before = launches.read_text().count("invocation")
+        missing = required_legacy.request(
+            "tools/call",
+            {"name": "bazel.run", "arguments": run_arguments(workspace, "//:instant")},
+        )
+        assert missing["error"]["code"] == -32601
+        assert launches.read_text().count("invocation") == before
+        required_legacy.close()
+
+        required_extension = session("required-extension", "tasks_required")
+        required_extension.initialize("2026-06-30")
+        before = launches.read_text().count("invocation")
+        missing = required_extension.request(
+            "tools/call",
+            {"name": "bazel.run", "arguments": run_arguments(workspace, "//:instant")},
+        )
+        assert missing["error"]["code"] == -32003
+        assert TASKS_EXTENSION in missing["error"]["data"]["requiredCapabilities"]["extensions"]
+        assert launches.read_text().count("invocation") == before
+        required_extension.close()
+
+        expiry_config = temporary / "expiry.toml"
+        write_config(
+            expiry_config,
+            workspace,
+            temporary / "cache-expiry",
+            wrapper,
+            "auto",
+        )
+        expiry_config.write_text(
+            expiry_config.read_text().replace(
+                "task_ttl_seconds = 3600", "task_ttl_seconds = 1"
+            )
+        )
+        expiring = Session(server, expiry_config)
+        expiring.initialize("2025-11-25")
+        expiring_id = expiring.request(
+            "tools/call",
+            {
+                "name": "bazel.run",
+                "arguments": run_arguments(workspace, "//:instant"),
+                "task": {},
+            },
+        )["result"]["task"]["taskId"]
+        expiring.request("tasks/result", {"taskId": expiring_id})
+        time.sleep(1.1)
+        assert expiring.request("tasks/get", {"taskId": expiring_id})["error"]["code"] == -32602
+        expiring.close()
+
+        # A process crash never reruns Bazel; durable handles expose interruption.
+        restart_config = temporary / "restart-legacy.toml"
+        write_config(
+            restart_config,
+            workspace,
+            temporary / "cache-restart-legacy",
+            wrapper,
+            "auto",
+        )
+        crashing = Session(server, restart_config)
+        crashing.initialize("2025-11-25")
+        restart_id = crashing.request(
+            "tools/call",
+            {
+                "name": "bazel.run",
+                "arguments": run_arguments(workspace, "//:crash-server"),
+                "task": {},
+            },
+        )["result"]["task"]["taskId"]
+        assert crashing.process.wait(timeout=5) != 0
+        write_config(
+            restart_config,
+            workspace,
+            temporary / "cache-restart-legacy",
+            wrapper,
+            "sync_only",
+        )
+        recovered = Session(server, restart_config)
+        recovered.initialize("2025-11-25")
+        recovered_task = recovered.request("tasks/get", {"taskId": restart_id})
+        assert recovered_task["result"]["status"] == "completed"
+        recovered_result = recovered.request("tasks/result", {"taskId": restart_id})
+        assert tool_json(recovered_result["result"])["state"] == "interrupted"
+        recovered.close()
+
+        mismatched = Session(server, restart_config)
+        mismatched.initialize("2026-06-30")
+        assert mismatched.request(
+            "tasks/get", {"taskId": restart_id, "_meta": extension_meta()}
+        )["error"]["code"] == -32602
+        mismatched.close()
+
+        extension_restart_config = temporary / "restart-extension.toml"
+        write_config(
+            extension_restart_config,
+            workspace,
+            temporary / "cache-restart-extension",
+            wrapper,
+            "auto",
+        )
+        crashing = Session(server, extension_restart_config)
+        crashing.initialize("2026-06-30")
+        extension_restart_id = crashing.request(
+            "tools/call",
+            {
+                "name": "bazel.run",
+                "arguments": run_arguments(workspace, "//:crash-server"),
+                "_meta": extension_meta(),
+            },
+        )["result"]["taskId"]
+        assert crashing.process.wait(timeout=5) != 0
+        recovered = Session(server, extension_restart_config)
+        recovered.initialize("2026-06-30")
+        recovered_task = recovered.request(
+            "tasks/get", {"taskId": extension_restart_id, "_meta": extension_meta()}
+        )["result"]
+        assert recovered_task["status"] == "completed"
+        assert tool_json(recovered_task["result"])["state"] == "interrupted"
+        recovered.close()
+
+    print("negotiated synchronous, legacy task, extension task, and policy conformance passed")
 
 
 if __name__ == "__main__":

--- a/specs/003-configurable-mcp-task-execution.md
+++ b/specs/003-configurable-mcp-task-execution.md
@@ -1,33 +1,30 @@
-# 003: Configurable MCP Task Execution
+# 003: Negotiated MCP Task Execution
 
 | Field | Value |
 | --- | --- |
-| Status | Proposed |
+| Status | Implemented |
 | Specification | 003 |
 | Product | `bazel-mcp` |
 | Last updated | 2026-07-15 |
 
 ## Summary
 
-Add a deployment-level `mcp_execution_mode` setting with exactly three values:
-`sync`, `tasks_legacy`, and `tasks`. The selected value determines the MCP
-capabilities, `tools/list` metadata, `bazel.run` response shape, task methods,
-and cancellation semantics exposed by one server process.
+Add negotiated task execution for `bazel.run`. One server supports synchronous
+execution, the experimental task protocol from MCP `2025-11-25`, and the
+`io.modelcontextprotocol/tasks` extension defined by SEP-2663. It selects the
+wire contract at runtime from the negotiated protocol version and the client
+capabilities carried by the request.
 
-The modes are intentionally exclusive:
+A deployment-level `mcp_execution_policy` setting has exactly three values:
+`auto`, `sync_only`, and `tasks_required`. The policy controls whether a
+compatible request is deferred; it does not select or translate a task
+dialect.
 
-- `sync` preserves the current long-running `tools/call` contract and is the
-  default.
-- `tasks_legacy` implements the experimental task protocol from MCP
-  `2025-11-25`, including the request `task` field and `tasks/result`.
-- `tasks` implements the `io.modelcontextprotocol/tasks` extension defined by
-  SEP-2663, including per-request extension capabilities, polymorphic results,
-  and terminal results in `tasks/get`.
-
-The two task protocols are not wire-compatible and MUST NOT be advertised
-together. A mode that requires task execution MUST return a capability or
-protocol error to an incompatible client; it MUST NOT silently fall back to a
-synchronous result.
+The two task protocols are not wire-compatible and MUST NOT be advertised in
+the same negotiated protocol context. A server process MAY support both and
+dispatch between them as required by SEP-2663's backward-compatibility
+guidance. A task response is emitted only when the request declares support for
+the selected dialect.
 
 Task support does not add MCP tools. The server continues to expose exactly
 `bazel.run`, `bazel.inspect`, and `bazel.cancel`. Task methods are MCP protocol
@@ -36,8 +33,8 @@ methods, not tools.
 ## Relationship to specifications 001 and 002
 
 This specification amends the `bazel.run` execution behavior in specification
-001. The statement that task support is optional is replaced by the configured
-mode behavior in this document. All tool inputs, logical run results, response
+001. The statement that task support is optional is replaced by the negotiated
+policy behavior in this document. All tool inputs, logical run results, response
 budgets, evidence retention, command policy, cancellation escalation, and the
 three-tool limit remain unchanged.
 
@@ -57,15 +54,19 @@ handle lets the host release the original request, continue other work, and
 retrieve the bounded result later. It also makes a disconnect less likely to
 discard the invocation identity.
 
-MCP currently has two materially different task designs. Claude Code has
-implementation-level support for the legacy design, while newer MCP work moves
-tasks into an extension with a different negotiation and result flow. Treating
-the protocols as one feature flag would produce ambiguous response types and
-host-specific failures.
+MCP currently has two materially different task designs. The MCP SDK embedded
+in Claude Code recognizes the legacy schema, but the pinned Claude Code host
+does not opt into task execution. Newer MCP work moves tasks into an extension
+with a different negotiation and result flow. The protocol already provides
+enough information to distinguish the wire contracts: legacy tasks are selected
+by protocol `2025-11-25`, initialization capabilities, tool metadata, and
+`params.task`; extension tasks are selected by a newer protocol version and the
+per-request extension capability.
 
-The implementation therefore needs an operator-selected wire contract. This
-also leaves synchronous execution available for hosts that only accept a
-`CallToolResult` from `tools/call`.
+The implementation therefore negotiates the wire contract and leaves
+configuration to express operator policy. This permits one deployment to serve
+legacy, extension-aware, and synchronous-only hosts without guessing from host
+names or silently translating between protocols.
 
 Task support must remain storage-efficient. It does not require a second copy of
 stdout, stderr, BEP, or the final model-visible response. A small deferred-result
@@ -73,8 +74,8 @@ record points at the existing durable invocation and its bounded summary.
 
 ## Goals
 
-- Make the server's asynchronous response shape explicit and stable for a
-  deployment.
+- Select the asynchronous response shape deterministically from negotiated
+  protocol information.
 - Implement both the `2025-11-25` legacy protocol and the SEP-2663 extension
   according to their distinct wire contracts.
 - Return a task handle only after `tasks/get` can resolve it durably.
@@ -82,14 +83,15 @@ record points at the existing durable invocation and its bounded summary.
 - Reconstruct the same bounded `CallToolResult` used by synchronous execution.
 - Keep task status, results, and cancellation available across a server restart.
 - Keep task metadata compact and independent from raw evidence retention.
-- Test every mode at the stdio wire boundary.
-- Test `sync` and `tasks_legacy` through a pinned Claude Code executable, not
-  only through an SDK client.
+- Test every policy and negotiated flow at the stdio wire boundary.
+- Test synchronous fallback and task-policy rejection through a pinned Claude
+  Code executable, not only through an SDK client.
 
 ## Non-goals
 
-- Automatically choosing a mode from the connected client.
-- Advertising legacy and extension tasks from the same server process.
+- Choosing behavior from host names, executable paths, or undocumented client
+  heuristics.
+- Translating a task handle from one wire dialect into the other.
 - Adding `bazel.task_status`, `bazel.task_result`, or any other MCP tool.
 - Resuming the Bazel child process after the server process itself crashes.
 - Supporting task-hosted sampling, elicitation, or arbitrary task input in the
@@ -117,21 +119,21 @@ record points at the existing durable invocation and its bounded summary.
   may return a task handle and the invocation will continue independently of the
   original request.
 
-The implementation MUST pin the MCP schema or upstream commit used for both
-task dialects in protocol fixtures. It MUST NOT derive extension behavior from
-`rmcp::ProtocolVersion::LATEST`. Before implementation, the accepted SEP-2663
-schema's base protocol version and extension revision are recorded in a
-repository fixture. Any upstream date or schema change requires a reviewed
-golden diff.
+The implementation pins both task dialects in
+`specs/fixtures/mcp-task-protocols.json`. The accepted SEP-2663 baseline is the
+final Tasks extension at its `2026-06-30` base protocol and the exact upstream
+schema commit recorded there. Extension behavior is never derived from
+`rmcp::ProtocolVersion::LATEST`. Any upstream date or schema change requires a
+reviewed golden diff.
 
 ## Configuration
 
-### Primary setting
+### Execution policy
 
 `ServerConfig` gains:
 
 ```toml
-mcp_execution_mode = "sync"
+mcp_execution_policy = "auto"
 ```
 
 The Rust type is:
@@ -139,16 +141,35 @@ The Rust type is:
 ```rust
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
-pub enum McpExecutionMode {
+pub enum McpExecutionPolicy {
     #[default]
-    Sync,
-    TasksLegacy,
-    Tasks,
+    Auto,
+    SyncOnly,
+    TasksRequired,
 }
 ```
 
-The setting is read only at startup. Changing it requires a server restart.
-There is no per-call override and no automatic host detection.
+The policy is read only at startup. Changing it requires a server restart.
+There is no per-call policy override. Protocol version and capability
+negotiation are inputs to the policy, not host detection.
+
+- `auto` is the default. A compatible extension request is deferred. A legacy
+  request is deferred when it includes `params.task`. Other requests execute
+  synchronously.
+- `sync_only` never creates a new task and always returns the ordinary
+  synchronous result. Previously accepted, unexpired task handles remain
+  readable and cancellable after a policy change.
+- `tasks_required` requires a compatible task capability for `bazel.run` and
+  returns the dialect-specific capability or protocol error when it is absent.
+
+The server advertises task read and cancellation surfaces that are valid for the
+negotiated protocol version even when `sync_only` prevents new task creation.
+This keeps existing durable handles usable after restart. Under the legacy
+protocol, `auto` and `tasks_required` advertise
+`capabilities.tasks.requests.tools.call`; `sync_only` omits it but MAY continue
+to advertise `tasks.list` and `tasks.cancel`. Correspondingly,
+`bazel.run.execution.taskSupport` is `optional`, absent, or `required` for
+`auto`, `sync_only`, or `tasks_required`.
 
 Unknown values are startup errors. The error is written to stderr and the
 process exits nonzero before writing any MCP frame to stdout.
@@ -166,10 +187,10 @@ task_poll_interval_ms = 2000
   defaults to 24 hours and MUST be greater than zero.
 - `task_poll_interval_ms` is returned as the suggested poll interval. It
   defaults to 2,000 ms and MUST be between 100 and 60,000 inclusive.
-- Both fields are validated in every mode so a configuration can be promoted
-  between environments without discovering an invalid value only after a mode
-  switch.
-- In `sync` they have no wire effect.
+- Both fields are validated under every policy so a configuration can be
+  promoted between environments without discovering an invalid value only
+  after a policy switch.
+- They have no effect on newly executed calls under `sync_only`.
 - A legacy caller's requested `task.ttl` is advisory. The server returns and
   persists its configured actual TTL instead of accepting a shorter retention
   window that could expire a queued build.
@@ -178,59 +199,57 @@ task_poll_interval_ms = 2000
   `task_ttl_seconds`. The advertised TTL is updated to the actual duration from
   creation.
 
-The example configuration and README MUST document the mode, compatibility
+The example configuration and README MUST document the policy, compatibility
 expectations, TTL, and poll interval.
 
-## Mode contract
+## Negotiated execution contract
 
-| Behavior | `sync` | `tasks_legacy` | `tasks` |
+| Negotiated flow | Selection | `bazel.run` response | Result retrieval |
 | --- | --- | --- | --- |
-| Default | Yes | No | No |
-| `bazel.run` response | `CallToolResult` | nested `CreateTaskResult.task` | flat `CreateTaskResult` with `resultType: "task"` |
-| Client opt-in | none | `params.task` | per-request `io.modelcontextprotocol/clientCapabilities` |
-| Server advertisement | no task capability | legacy `capabilities.tasks` | `server/discover` extension capability |
-| Tool metadata | task support absent/forbidden | `bazel.run.execution.taskSupport = "required"` | no legacy task-support metadata |
-| Result retrieval | original `tools/call` | `tasks/result` | terminal `tasks/get.result` |
-| `tasks/list` | method not found | supported and paginated | method not found |
-| `tasks/update` | method not found | method not found | recognized; no input is currently requested |
-| Cancellation response | not applicable | cancelled Task object | empty acknowledged result |
-| Incompatible `bazel.run` client | synchronous result | `-32601` | `-32003` |
+| Synchronous | no compatible task request, or `sync_only` | `CallToolResult` | original `tools/call` |
+| Legacy tasks | protocol `2025-11-25` plus `params.task` | nested `CreateTaskResult.task` | `tasks/result` |
+| Tasks extension | extension-capable protocol plus per-request `io.modelcontextprotocol/clientCapabilities` | flat `CreateTaskResult` with `resultType: "task"` | terminal `tasks/get.result` |
+
+| Request | `auto` | `sync_only` | `tasks_required` |
+| --- | --- | --- | --- |
+| Extension-capable `bazel.run` | extension task | synchronous | extension task |
+| Modern request without extension capability | synchronous | synchronous | `-32003` |
+| Legacy `bazel.run` with `params.task` | legacy task | synchronous | legacy task |
+| Legacy `bazel.run` without `params.task` | synchronous | synchronous | `-32601` |
+| Earlier protocol without task support | synchronous | synchronous | `-32601` |
 
 `bazel.inspect` and `bazel.cancel` always return ordinary synchronous
-`CallToolResult` values. They never create tasks in any mode.
+`CallToolResult` values. They never create tasks under any policy or negotiated
+flow.
 
-### `sync`
+### Synchronous execution
 
-The server advertises no legacy task capability and no Tasks extension.
-`tools/list` omits `execution.taskSupport`, which has the legacy meaning
-`forbidden`.
-
-`bazel.run` performs the current flow:
+When policy negotiation selects synchronous execution, `bazel.run` performs the
+current flow:
 
 1. validate and durably create the invocation;
 2. wait for its terminal record while servicing bounded progress
    notifications; and
 3. return the encoded `CallToolResult`.
 
-For compatibility with the legacy specification's non-declaring receiver rule,
-a stray legacy `params.task` value is ignored in this mode and does not change
-the response shape. A client extension capability does not force task creation;
-the server still returns a normal result.
+Under `sync_only`, a legacy `params.task` value is ignored under the legacy
+specification's non-declaring receiver rule because the server omits
+`capabilities.tasks.requests.tools.call`. A client extension capability also
+does not force task creation. The server returns a normal result.
 
 Cancellation of the original `tools/call` maps to the invocation cancellation
 token as it does today.
 
-### `tasks_legacy`
+### Legacy tasks
 
-This mode implements only the MCP `2025-11-25` task design.
+This flow implements the MCP `2025-11-25` task design.
 
 #### Negotiation and tool discovery
 
-The server requires negotiation of protocol `2025-11-25`. A client requesting a
-protocol version that cannot express the legacy task capability is rejected
-during initialization rather than being given a different `bazel.run` shape.
+The legacy adapter is active only after negotiation of protocol `2025-11-25`.
+Other protocol versions never receive legacy task response shapes.
 
-The initialize result advertises:
+Under `auto` and `tasks_required`, the initialize result advertises:
 
 ```json
 {
@@ -248,24 +267,29 @@ The initialize result advertises:
 }
 ```
 
-`tools/list` contains exactly the existing three tools. `bazel.run` includes:
+`tools/list` contains exactly the existing three tools. Under `auto`,
+`bazel.run` includes:
 
 ```json
 {
   "execution": {
-    "taskSupport": "required"
+    "taskSupport": "optional"
   }
 }
 ```
 
-`bazel.inspect` and `bazel.cancel` omit task support. A task-augmented call to
-either is rejected with `-32601 Method not found`.
+`bazel.inspect` and `bazel.cancel` omit task support. Under `auto` and
+`tasks_required`, a task-augmented call to either is rejected with
+`-32601 Method not found`. Under `sync_only`, the server has not declared task
+support for `tools/call`, so it ignores task augmentation metadata and processes
+either tool normally.
 
 #### Creating and reading a task
 
-A `bazel.run` call MUST include `params.task`. Absence is rejected with
-`-32601 Method not found`. After validation and the acceptance commit point, the
-response is:
+A `bazel.run` call creates a legacy task only when it includes `params.task`.
+Under `auto`, absence selects synchronous execution. Under `tasks_required`,
+absence is rejected with `-32601 Method not found`. After validation and the
+acceptance commit point, the deferred response is:
 
 ```json
 {
@@ -317,11 +341,12 @@ Correctness relies on polling. `notifications/tasks/status` MAY be added as a
 best-effort optimization after polling conformance passes, but it is not part of
 the initial acceptance criteria.
 
-### `tasks`
+### Tasks extension
 
-This mode implements only the `io.modelcontextprotocol/tasks` extension from
-SEP-2663. It MUST NOT advertise any legacy `capabilities.tasks` fields or
-`execution.taskSupport` values.
+This flow implements the `io.modelcontextprotocol/tasks` extension from
+SEP-2663. In a protocol context where the extension is defined, the server MUST
+NOT advertise legacy `capabilities.tasks` fields or `execution.taskSupport`
+values.
 
 #### Discovery and per-request capability
 
@@ -351,11 +376,14 @@ Every extension request MUST carry:
 }
 ```
 
-`bazel.run` always elects to create a task in this mode. If the client omits
-the per-request capability, the server returns `-32003 Missing Required Client
+Under `auto` and `tasks_required`, `bazel.run` elects to create a task when the
+request carries the extension capability. Under `sync_only`, it returns a
+synchronous result even when the capability is present, which SEP-2663 permits.
+
+If the client omits the per-request capability, `auto` and `sync_only` return a
+synchronous result. `tasks_required` returns `-32003 Missing Required Client
 Capability` with `requiredCapabilities.extensions.io.modelcontextprotocol/tasks`
-in the error data. It MUST NOT run Bazel and MUST NOT return a synchronous
-result.
+in the error data and MUST NOT run Bazel.
 
 A legacy `params.task` field is treated as an unknown field and ignored. It does
 not opt the request into the extension.
@@ -401,10 +429,10 @@ not implemented initially. Clients poll `tasks/get`.
 
 ### Progress and task association
 
-`sync` retains the existing bounded `notifications/progress` behavior when the
-caller supplies a progress token.
+Synchronous execution retains the existing bounded `notifications/progress`
+behavior when the caller supplies a progress token.
 
-`tasks_legacy` does not emit progress notifications in the first milestone.
+The legacy task flow does not emit progress notifications in the first milestone.
 Status is available through `tasks/get`. If progress is enabled later, the
 original progress token remains valid for the task lifetime and every
 task-associated message MUST include the legacy
@@ -412,9 +440,9 @@ task-associated message MUST include the legacy
 specification. `tasks/get`, `tasks/list`, and `tasks/cancel` use their explicit
 task IDs and do not add redundant related-task metadata.
 
-`tasks` does not emit `notifications/progress` for task execution. The extension
-uses `tasks/get` and, in a future notification milestone,
-`notifications/tasks`.
+The extension task flow does not emit `notifications/progress` for task
+execution. The extension uses `tasks/get` and, in a future notification
+milestone, `notifications/tasks`.
 
 ## Shared invocation lifecycle
 
@@ -448,13 +476,13 @@ pub async fn deferred_result(
 are domain concepts in `bazel-mcp-types`; they contain no `rmcp` types or MCP
 field names.
 
-`tasks_legacy` submissions use `SeparateResult` and `tasks` submissions use
+Legacy task submissions use `SeparateResult` and extension task submissions use
 `InlineResult`. Each adapter treats the other retrieval kind as an unknown task.
-This makes the same-mode restart guarantee enforceable and prevents translating
-an existing handle into a different wire dialect after a configuration change.
+The retrieval kind, not the current execution policy, selects the read adapter
+after restart and prevents translating an existing handle into another dialect.
 
 The existing synchronous `run_with_cancellation` becomes a convenience
-composition of `submit(Attached)` and `wait`. Both task modes call
+composition of `submit(Attached)` and `wait`. Both task flows call
 `submit(Deferred)` and return after the durable commit.
 
 Submission performs all request parsing, workspace and policy validation, and
@@ -498,10 +526,10 @@ Deferred metadata and terminal summaries survive restart. On startup:
   `state: "interrupted"` rather than rerunning Bazel; and
 - no task causes an automatic second Bazel invocation.
 
-A handle is guaranteed across restart only when the server restarts in the same
-`mcp_execution_mode`. Operators MUST drain active tasks before changing modes.
-After a mode change, old invocations remain available through `bazel.inspect`,
-but protocol handles from the prior dialect are not translated or advertised.
+A handle remains available across restart until expiry regardless of an
+`mcp_execution_policy` change. The policy controls creation only. Task reads and
+cancellation dispatch from the negotiated protocol and the stored retrieval
+kind. Protocol handles are never translated between dialects.
 
 ## Durable data model
 
@@ -586,7 +614,8 @@ Task support stores only compact lifecycle metadata. It MUST NOT copy stdout,
 stderr, BEP, artifacts, or `CallToolResult` payloads.
 
 The final result is deterministically reconstructed from the retained invocation
-record and summary through the same server-side result builder used by `sync`.
+record and summary through the same server-side result builder used by
+synchronous execution.
 The configured `result_encoding` applies when the result is retrieved.
 
 An unexpired deferred result protects the small invocation record and bounded
@@ -606,7 +635,7 @@ summary.
 One pure `RunResultBuilder` in `bazel-mcp-server` converts an
 `InvocationRecord` into the logical JSON result, applies the existing success or
 failure byte ceiling, records model-visible byte metrics, and encodes the
-configured `CallToolResult`. `sync`, `tasks/result`, and terminal
+configured `CallToolResult`. Synchronous execution, `tasks/result`, and terminal
 `tasks/get.result` all use it.
 
 | Invocation/deferred condition | Legacy Task | Extension Task | Final tool result |
@@ -663,14 +692,14 @@ The following races have explicit outcomes:
 
 | Condition | Response |
 | --- | --- |
-| `tasks_legacy` `bazel.run` without `params.task` | `-32601 Method not found` |
-| Legacy task metadata on `bazel.inspect` or `bazel.cancel` | `-32601 Method not found` |
-| `tasks` `bazel.run` without per-request extension capability | `-32003 Missing Required Client Capability` |
+| `tasks_required` legacy `bazel.run` without `params.task` | `-32601 Method not found` |
+| Legacy task metadata on `bazel.inspect` or `bazel.cancel` under `auto` or `tasks_required` | `-32601 Method not found` |
+| `tasks_required` modern `bazel.run` without per-request extension capability | `-32003 Missing Required Client Capability` |
 | Extension task method without per-request capability | `-32003 Missing Required Client Capability` |
 | Unknown or expired task ID | `-32602 Invalid params` |
-| `tasks/result` in `tasks` | `-32601 Method not found` |
-| `tasks/update` in `tasks_legacy` | `-32601 Method not found` |
-| `tasks/list` in `tasks` | `-32601 Method not found` |
+| `tasks/result` in an extension protocol context | `-32601 Method not found` |
+| `tasks/update` in a legacy protocol context | `-32601 Method not found` |
+| `tasks/list` in an extension protocol context | `-32601 Method not found` |
 | Second legacy cancellation of a terminal task | `-32602 Invalid params` |
 | Extension cancellation of a known terminal task | empty acknowledged result |
 | Invalid `bazel.run` arguments before acceptance | ordinary immediate tool error; no task |
@@ -681,24 +710,28 @@ persistence in Turso text fields, or telemetry.
 
 ## Server architecture
 
-### Mode-specific adapters
+### Negotiated adapters
 
-`bazel-mcp-server` constructs one of three server adapters at startup:
+`bazel-mcp-server` keeps three response adapters behind a protocol dispatcher:
 
 ```text
-                 shared tool catalog
-                        |
-                shared result builder
-                        |
-        +---------------+----------------+
-        |               |                |
-   SyncAdapter   LegacyTasksAdapter  TasksExtensionAdapter
-        |               |                |
-     rmcp I/O       legacy methods      extension methods
+          negotiated protocol + request capabilities
+                            |
+                    policy evaluator
+                            |
+                   protocol dispatcher
+                            |
+          +-----------------+------------------+
+          |                 |                  |
+     SyncAdapter   LegacyTasksAdapter  TasksExtensionAdapter
+          |                 |                  |
+     attached wait      legacy methods      extension methods
 ```
 
-The adapters share parameter validation, tool descriptions, schemas, result
-building, and `InvocationService`. They own their own:
+The dispatcher selects an adapter per request; it does not construct one
+deployment-wide wire mode at startup. The adapters share parameter validation,
+tool descriptions, schemas, result building, and `InvocationService`. They own
+their own:
 
 - protocol version gate;
 - server capability shape;
@@ -707,9 +740,9 @@ building, and `InvocationService`. They own their own:
 - task-method dispatch; and
 - task status/result conversion.
 
-This separation prevents a runtime boolean from accidentally emitting a legacy
-field in extension mode. Golden wire tests compare the entire capability,
-tool-list, creation, polling, cancellation, and result envelopes.
+This separation prevents policy evaluation from accidentally emitting a legacy
+field in an extension protocol context. Golden wire tests compare the entire
+capability, tool-list, creation, polling, cancellation, and result envelopes.
 
 ### `rmcp` dependency strategy
 
@@ -718,10 +751,10 @@ task flow. Its task types and handler hooks may be used for
 `LegacyTasksAdapter` only after its emitted errors and fields pass the golden
 tests.
 
-The `tasks` adapter requires a version of `rmcp` that implements the accepted
-SEP-2663 schema, including `server/discover`, per-request capabilities, flat
-polymorphic results, `tasks/update`, and ack-only cancellation. Implementation
-must proceed in this order:
+The Tasks extension adapter requires a version of `rmcp` that implements the
+accepted SEP-2663 schema, including `server/discover`, per-request capabilities,
+flat polymorphic results, `tasks/update`, and ack-only cancellation.
+Implementation must proceed in this order:
 
 1. check whether a stable `rmcp` release implements the pinned extension
    revision;
@@ -732,7 +765,7 @@ must proceed in this order:
 4. do not fork protocol types into the runner, store, or domain crates.
 
 An `rmcp` upgrade is not accepted merely because it compiles. It requires
-reviewed schema diffs, all three mode transcripts, `make check`, `make test`,
+reviewed schema diffs, all negotiated-flow transcripts, `make check`, `make test`,
 `make mcp-conformance`, and the Claude Code compatibility job.
 
 ## Implementation changes by crate
@@ -765,9 +798,9 @@ reviewed schema diffs, all three mode transcripts, `make check`, `make test`,
 
 ### `bazel-mcp-server`
 
-- Add and validate `McpExecutionMode` and lifecycle settings.
+- Add and validate `McpExecutionPolicy` and lifecycle settings.
 - Extract the shared `RunResultBuilder` from `bazel_run`.
-- Build one mode-specific adapter.
+- Build the negotiated protocol dispatcher and three response adapters.
 - Implement all wire behavior and errors defined above.
 - Keep tracing and compatibility diagnostics on stderr.
 - Record protocol response-byte and lifecycle metrics without logging payloads.
@@ -779,7 +812,7 @@ reviewed schema diffs, all three mode transcripts, `make check`, `make test`,
 - Count only host/model-visible task messages as model-visible output, but report
   protocol polling bytes separately.
 - Verify that the final logical result and diagnostic fidelity are identical
-  across modes.
+  across negotiated flows.
 
 No changes are required in `bazel-mcp-bep` or `bazel-mcp-reducer` beyond
 possible test plumbing. Task protocol code MUST NOT enter either crate.
@@ -790,8 +823,8 @@ possible test plumbing. Task protocol code MUST NOT enter either crate.
 
 Configuration tests cover:
 
-- the default `sync` mode;
-- all three accepted snake-case values;
+- the default `auto` policy;
+- all three accepted snake-case policy values;
 - unknown values;
 - zero and out-of-range TTL/poll settings; and
 - serialization round trips.
@@ -806,6 +839,7 @@ Domain, store, and runner tests cover:
 - legacy terminal cancellation override;
 - extension cancellation race outcomes;
 - result survival across server restart;
+- existing task handles remaining readable after an execution-policy change;
 - no automatic rerun after recovery;
 - expiry extension on terminal transition;
 - expired-row deletion without raw-log duplication;
@@ -815,27 +849,28 @@ Domain, store, and runner tests cover:
 ### Stdio protocol conformance
 
 Extend `scripts/test-mcp-conformance.py` or replace it with a structured
-`scripts/mcp-conformance/` harness that launches a fresh server per mode and
-records newline-delimited JSON transcripts.
+`scripts/mcp-conformance/` harness that launches fresh servers across policies
+and negotiates every supported flow while recording newline-delimited JSON
+transcripts.
 
 Every transcript asserts:
 
 - stdout contains only valid MCP JSON-RPC messages;
 - stderr contains diagnostics but no secret fixture value;
 - exactly three tools are listed in stable order;
-- tool schemas and descriptions are identical across modes except for permitted
-  execution metadata;
+- tool schemas and descriptions are identical across negotiated flows except
+  for permitted legacy execution metadata;
 - the selected capability shape is exact;
 - the task ID equals the invocation ID;
 - the task handle arrives before a deliberately delayed Bazel wrapper exits;
 - `tasks/get` resolves immediately after handle creation;
 - the final `CallToolResult` is byte-budgeted and logically identical to
-  `sync`; and
+  synchronous execution; and
 - the fake Bazel wrapper records one direct argv invocation.
 
-Required mode cases:
+Required negotiated-flow cases:
 
-| Case | `sync` | `tasks_legacy` | `tasks` |
+| Case | Synchronous | Legacy tasks | Tasks extension |
 | --- | ---: | ---: | ---: |
 | successful build | yes | yes | yes |
 | nonzero Bazel exit | yes | yes | yes |
@@ -843,22 +878,32 @@ Required mode cases:
 | cancellation | attached | immediate terminal task | acknowledged/raced |
 | server restart after task creation | n/a | yes | yes |
 | unknown/expired ID | n/a | yes | yes |
-| missing task capability/opt-in | ignore/normal | `-32601` | `-32003` |
+| missing task capability/opt-in under `tasks_required` | earlier protocol `-32601` | `-32601` | `-32003` |
 | result retrieval method mismatch | n/a | yes | yes |
 | legacy list pagination | n/a | yes | method not found |
 | extension update acknowledgement | n/a | method not found | yes |
+
+Policy coverage additionally asserts that `auto` falls back synchronously when
+the request lacks task support, `sync_only` returns synchronously even for a
+capable request, and `tasks_required` never starts Bazel for an incompatible
+request. The harness MUST demonstrate legacy and extension dispatch under the
+same server configuration in separate negotiated sessions without changing
+deployment policy.
 
 Golden fixtures normalize timestamps, UUIDs, absolute paths, and durations.
 Updates require reviewed diffs and are never automatically accepted.
 
 ### Claude Code integration
 
-Claude Code is a compatibility target for `sync` and `tasks_legacy`. Its public
-MCP documentation does not make legacy Tasks a stable API guarantee, so the
-test pins and exercises the actual host executable.
+Claude Code is a compatibility target for synchronous fallback and policy
+enforcement. Although the MCP SDK code in Claude Code `2.1.204` recognizes the
+legacy Tasks schema, the pinned host does not send `params.task`. The raw stdio
+suite is therefore authoritative for the positive legacy task flow. The host
+test pins and exercises the actual executable so a future behavior change is
+detected instead of inferred from SDK support.
 
 The initial compatibility lock is Claude Code `2.1.204`, the version verified
-while drafting this specification. Store the accepted versions and platform
+while implementing this specification. Store the accepted version and platform
 checksums in `scripts/compat/claude-code.lock`. The test MUST reject a different
 binary unless an explicit update workflow is used; it MUST NOT silently test a
 floating `latest`.
@@ -897,7 +942,7 @@ and does not patch or introspect the process.
 The stdio proxy forwards bytes unchanged. Its own stdout is protocol-only, it
 writes normalized traces to a temporary file, and diagnostics go to stderr.
 
-The `sync` Claude case asserts:
+The `sync_only` Claude case asserts:
 
 - Claude Code discovers exactly the three MCP tools;
 - `bazel.run` receives no legacy task opt-in requirement;
@@ -905,21 +950,25 @@ The `sync` Claude case asserts:
 - Claude Code consumes one ordinary `CallToolResult`; and
 - the wrapper ran once.
 
-The `tasks_legacy` Claude cases assert:
+The `auto` Claude case asserts:
 
-- Claude Code negotiates `2025-11-25` legacy task support;
-- it observes `bazel.run.execution.taskSupport = "required"`;
-- it sends `tools/call.params.task`;
-- it accepts the nested `CreateTaskResult` before wrapper completion;
-- it polls `tasks/get` without creating additional model turns;
-- it retrieves the final value through `tasks/result`;
-- a nonzero Bazel exit is surfaced as a completed tool result with logical
-  `state: "failed"`; and
-- the wrapper ran exactly once in each case.
+- Claude Code observes `bazel.run.execution.taskSupport = "optional"`;
+- it does not send `tools/call.params.task`;
+- the server falls back to one attached invocation; and
+- Claude Code consumes the ordinary `CallToolResult`.
+
+The `tasks_required` Claude case asserts:
+
+- Claude Code observes `bazel.run.execution.taskSupport = "required"`;
+- it still does not send `tools/call.params.task` in the pinned version;
+- the server returns `-32601 Method not found` before acceptance; and
+- the Bazel wrapper is not launched.
 
 Cancellation and restart semantics remain mandatory in the raw stdio suite.
-They may be added to the Claude suite when the pinned host exposes a stable,
-scriptable cancellation path; they are not simulated through model prose.
+Positive legacy task execution may be added to the Claude suite when a pinned
+host release actually sends the task augmentation. Cancellation may be added
+when that host also exposes a stable, scriptable cancellation path; neither is
+simulated through model prose.
 
 `test-claude-code` fails clearly when the pinned binary is unavailable. It is
 not silently skipped and is not part of ordinary `make test`. The dedicated CI
@@ -931,10 +980,10 @@ version update requires reviewing the normalized protocol trace and lock file.
 provided credentials. It never runs in pull-request CI, never records provider
 responses or secrets in committed fixtures, and has a strict budget limit.
 
-The current Claude compatibility target does not establish support for the
-SEP-2663 `tasks` mode. That mode is gated by raw MCP extension conformance until
-a production host declares the extension; when Claude Code does so, the same
-host harness gains a third positive case.
+The current Claude compatibility target does not establish host support for
+either task dialect. Both positive task flows are gated by raw MCP conformance
+until a production host declares and uses the relevant capability. When Claude
+Code does so, the same host harness gains a positive task case.
 
 ### Make and CI integration
 
@@ -946,9 +995,9 @@ test-claude-code
 test-claude-code-live
 ```
 
-`mcp-conformance` runs all three credential-free protocol modes. It remains
-separate from ordinary unit tests because it builds and launches the production
-binary.
+`mcp-conformance` runs all three credential-free negotiated flows and the policy
+matrix. It remains separate from ordinary unit tests because it builds and
+launches the production binary.
 
 CI adds a required protocol-conformance job and a pinned Claude Code
 compatibility job. The live provider test and floating-latest compatibility
@@ -971,15 +1020,16 @@ The long Abseil benchmark is not run as an ordinary unit test.
 
 ## Observability
 
-Startup logs include the selected mode, task TTL, poll interval, and pinned
-protocol revision on stderr.
+Startup logs include the selected policy, task TTL, poll interval, and pinned
+protocol revisions on stderr. Connection diagnostics record the negotiated
+protocol family without client-provided payloads.
 
 Add counters and histograms for:
 
 - deferred invocations accepted, completed, failed, cancelled, interrupted, and
   expired;
 - task creation acknowledgement latency;
-- `tasks/get`, result, list, update, and cancellation calls by mode;
+- `tasks/get`, result, list, update, and cancellation calls by negotiated flow;
 - capability mismatch and unknown/expired-ID errors;
 - protocol response bytes for creation, polling, and final result separately;
 - lost-handle/orphaned deferred work when detectable; and
@@ -1000,8 +1050,8 @@ values, task-result payloads, or unredacted error strings.
 - Per-task status and immediate-response strings pass through secret redaction.
 - Turso failure text is redacted before insertion.
 - Task polling cannot request arbitrary files or bypass `bazel.inspect` policy.
-- Task mode never changes argv construction: Bazel is still launched directly
-  with a string vector and never through a shell.
+- Task execution never changes argv construction: Bazel is still launched
+  directly with a string vector and never through a shell.
 - The Claude mock-provider test uses only a temporary allowlisted workspace and
   dummy credentials, denies non-loopback access, and disables nonessential
   network activity.
@@ -1010,48 +1060,57 @@ values, task-result payloads, or unredacted error strings.
 
 As of this specification's drafting:
 
-| Host/version | `sync` | `tasks_legacy` | `tasks` |
+| Host/version | Synchronous | Legacy tasks | Tasks extension |
 | --- | --- | --- | --- |
 | Codex CLI 0.144.4 | compatibility target | not supported by current client result handling | no verified support |
-| Claude Code 2.1.204 | compatibility target | pinned integration target | no verified support |
+| Claude Code 2.1.204 | pinned integration target | schema recognized, host opt-in disabled | no verified support |
 | protocol harness | required | required | required |
 
 This table is empirical, versioned test evidence rather than a permanent vendor
-claim. README guidance points users to `sync` for unknown hosts,
-`tasks_legacy` for the pinned Claude Code path, and `tasks` only for clients that
-declare the SEP-2663 extension.
+claim. README guidance recommends the default `auto` policy for mixed or unknown
+hosts, `sync_only` as a compatibility escape hatch, and `tasks_required` only
+when the deployment requires detached execution. The server, not the operator,
+derives the task dialect from protocol negotiation.
 
 Implementation is delivered in these stages:
 
 1. Pin protocol schemas and add redacted golden transcripts for all three
-   modes.
+   negotiated flows.
 2. Add configuration, domain types, Turso migration, and retention behavior.
-3. Refactor `InvocationService` into submit/wait without changing `sync`
+3. Refactor `InvocationService` into submit/wait without changing synchronous
    behavior.
-4. Land `tasks_legacy` and its raw protocol tests.
-5. Land the pinned Claude Code `sync` and `tasks_legacy` integration job.
-6. Select or adapt `rmcp` and land the `tasks` extension adapter.
+4. Land legacy task negotiation and its raw protocol tests.
+5. Land the pinned Claude Code `sync_only` and `tasks_required` integration job.
+6. Select or adapt `rmcp` and land extension discovery plus the Tasks extension
+   adapter.
 7. Add benchmark transcripts, documentation, and release gates.
 
-`sync` remains the default throughout rollout. No release changes the default
-until a separate specification and host adoption evidence justify it.
+`auto` is the default throughout rollout. It preserves synchronous behavior for
+clients that do not declare a compatible task capability, so enabling task
+support does not require host-specific configuration.
 
 ## Acceptance criteria
 
 This specification is complete when:
 
-- `ServerConfig` accepts exactly `sync`, `tasks_legacy`, and `tasks` and defaults
-  to `sync`.
-- Each mode emits only its specified capability, tool metadata, result, and
-  task-method shapes.
+- `ServerConfig` accepts exactly `auto`, `sync_only`, and `tasks_required` and
+  defaults to `auto`.
+- The server derives legacy versus extension wire behavior from negotiated
+  protocol version and request capabilities, never from host identity or
+  deployment policy.
+- Each negotiated protocol context emits only its specified capability, tool
+  metadata, result, and task-method shapes.
+- `auto` falls back synchronously for non-declaring clients, `sync_only` creates
+  no new tasks, and `tasks_required` rejects incompatible calls before Bazel
+  starts.
 - The server still lists exactly `bazel.run`, `bazel.inspect`, and
   `bazel.cancel`.
-- `tasks_legacy` passes the MCP `2025-11-25` golden flow, including
+- Legacy tasks pass the MCP `2025-11-25` golden flow, including
   `tasks/result`, list pagination, and immediate cancellation semantics.
-- `tasks` passes the pinned SEP-2663 golden flow, including per-request
-  capability enforcement, flat polymorphic creation, inlined terminal results,
-  update acknowledgement, ack-only cancellation, and rejection of
-  `tasks/result`.
+- The Tasks extension passes the pinned SEP-2663 golden flow, including
+  per-request capability enforcement, flat polymorphic creation, inlined
+  terminal results, update acknowledgement, ack-only cancellation, and
+  rejection of `tasks/result`.
 - A task handle is never returned before its durable record is readable.
 - Task and invocation IDs are identical and one accepted call launches Bazel
   once.
@@ -1059,14 +1118,17 @@ This specification is complete when:
 - Nonzero Bazel exits are completed tool results, not protocol failures.
 - Task records and minimal summaries survive restart, while Bazel is never
   automatically rerun.
+- Previously accepted task handles remain readable and cancellable after an
+  execution-policy change until they expire.
 - Task metadata adds no copy of raw logs, BEP, artifacts, or final response
   payloads.
 - Expiry, cancellation races, unknown IDs, protocol mismatch errors, and restart
   recovery have deterministic tests.
 - MCP stdout remains protocol-only and all diagnostic output remains on stderr.
 - Redaction occurs before status text, Turso text fields, and telemetry.
-- The pinned Claude Code executable passes both `sync` and `tasks_legacy` host
-  integration cases with one wrapper execution per call.
+- The pinned Claude Code executable passes `sync_only` and `auto` synchronous
+  host cases with one wrapper execution per call, and the `tasks_required`
+  incompatibility case rejects before launching the wrapper.
 - `make build`, `make test`, `make check`, `make mcp-conformance`,
   `make test-claude-code`, `make test-bazel-matrix`, `make fuzz-smoke`, and the
   explicit token integration target pass.

--- a/specs/fixtures/mcp-task-protocols.json
+++ b/specs/fixtures/mcp-task-protocols.json
@@ -1,0 +1,16 @@
+{
+  "legacy": {
+    "protocolVersion": "2025-11-25",
+    "schemaSource": "https://github.com/modelcontextprotocol/modelcontextprotocol/tree/2025-11-25/schema/2025-11-25",
+    "rmcp": "2.2.0"
+  },
+  "tasksExtension": {
+    "identifier": "io.modelcontextprotocol/tasks",
+    "baseProtocolVersion": "2026-06-30",
+    "sep": 2663,
+    "status": "final",
+    "schemaSource": "https://github.com/modelcontextprotocol/ext-tasks",
+    "schemaCommit": "2c1425d9a288b9b1f489430fe1e00bb392b47e48",
+    "adapter": "bazel-mcp-server custom request/result"
+  }
+}


### PR DESCRIPTION
## Summary

- negotiate synchronous execution, MCP 2025-11-25 legacy tasks, and the final SEP-2663 Tasks extension at runtime
- add `auto`, `sync_only`, and `tasks_required` deployment policies without selecting a wire dialect from configuration
- persist deferred invocation metadata atomically, including cancellation, expiry, pagination, restart recovery, and bounded result reconstruction
- add raw stdio conformance, pinned Claude Code 2.1.204 compatibility, canonical protocol transcripts, structured lifecycle telemetry, CI coverage, and user-facing configuration docs
- document representative JSON-RPC shapes in the README

## Why

Long Bazel invocations can outlive a host's preferred attached request duration. MCP now has two incompatible task contracts, but protocol negotiation and request capabilities provide enough information to select the correct shape at runtime. This keeps ordinary clients on the existing synchronous path while allowing capable clients to receive durable handles without adding tools or duplicating retained evidence.

## User impact

The default `auto` policy is backward compatible: non-declaring clients continue to receive an ordinary `CallToolResult`. Legacy and extension-aware clients can opt into durable task execution. Operators can force synchronous behavior or reject clients without task support. The server still exposes exactly `bazel.run`, `bazel.inspect`, and `bazel.cancel`.

Claude Code 2.1.204 currently exercises synchronous fallback and task-policy rejection; the credential-free raw stdio suite is the positive conformance authority for both task dialects.

## Validation

- `make build`
- `make test`
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo shear`
- `make mcp-conformance`
- `make test-claude-code`
- Bazel 7.6.1, 8.4.2, and 9.1.0 compatibility matrix
- fuzz smoke
- five-sample pinned Abseil token gate: 89.74% fewer cumulative context tokens and 96.41% fewer model-visible bytes versus the default shell baseline
