### PR TITLE
Optimize Bazel failure evidence for agents

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -181,7 +181,6 @@ dependencies = [
  "tokio",
  "tokio-util",
  "tracing",
- "uuid",
 ]
 
 [[package]]

--- a/LEARNINGS.md
+++ b/LEARNINGS.md
@@ -8,4 +8,8 @@ efficiency. Do not include secrets or raw sensitive output.
 
 ## Entries
 
-No observations recorded yet.
+### 2026-07-15
+
+- CI diagnosis required scanning a full job log to isolate one failed Rust test;
+  prioritize the failing test name and assertion in initial Bazel MCP evidence so
+  agents can avoid fetching unrelated successful-test output.

--- a/README.md
+++ b/README.md
@@ -109,6 +109,35 @@ and selected informational commands. Successful results are limited to 2 KiB
 and unsuccessful results to 8 KiB. Follow-up `bazel.inspect` calls are also
 bounded and paginated, so an agent only retrieves the evidence it needs.
 
+Failure results rank concrete root causes before aggregated action failures.
+Equivalent fanout failures are represented once with `target: null` and a
+`repetition_count`. Test and coverage commands use Bazel's
+`--test_output=errors`. Failed-test logs are copied into private invocation
+storage before they are exposed; test results report `test_log_available` or an
+explicit `test_log_unavailable_reason`, never a synthetic or local failure-log
+URI.
+
+The `summary` view returns structured counts and bounded diagnostics. The `log`
+and `test_log` views deliberately have the simpler logical shape below in every
+result encoding:
+
+```json
+{
+  "invocation_id": "019...",
+  "view": "test_log",
+  "items": [
+    "[//foo:foo_test] assertion error: expected 3, received 4"
+  ],
+  "next_cursor": null,
+  "truncated": false
+}
+```
+
+The MCP shape has no stdout/stderr field or selector. The server automatically
+normalizes, redacts, exactly deduplicates, filters, and sequences both captured
+streams. Requested item limits are maxima; serialized byte packing may return
+fewer items with an opaque cursor that resumes after the last emitted item.
+
 Long calls can be returned as durable task handles when the MCP client declares
 task support. With the default `auto` policy, the server discovers the
 negotiated protocol and chooses synchronous execution, MCP `2025-11-25` legacy

--- a/crates/bazel-mcp-benchmark/src/bin/storage-benchmark.rs
+++ b/crates/bazel-mcp-benchmark/src/bin/storage-benchmark.rs
@@ -656,6 +656,7 @@ async fn benchmark_query(args: &Args) -> anyhow::Result<(QueryMetrics, f64)> {
             PageRequest {
                 cursor: None,
                 limit: 3,
+                max_bytes: None,
             },
         )
         .await?;
@@ -685,6 +686,7 @@ async fn benchmark_query(args: &Args) -> anyhow::Result<(QueryMetrics, f64)> {
             PageRequest {
                 cursor: None,
                 limit: 100,
+                max_bytes: None,
             },
         )
         .await?;
@@ -703,6 +705,7 @@ async fn benchmark_query(args: &Args) -> anyhow::Result<(QueryMetrics, f64)> {
             PageRequest {
                 cursor: page.next_cursor,
                 limit: 100,
+                max_bytes: None,
             },
         )
         .await?;
@@ -725,6 +728,7 @@ async fn benchmark_query(args: &Args) -> anyhow::Result<(QueryMetrics, f64)> {
             PageRequest {
                 cursor: None,
                 limit: 100,
+                max_bytes: None,
             },
         )
         .await?;
@@ -797,7 +801,8 @@ async fn benchmark_terminal(query_count_and_finalize_ms: f64) -> anyhow::Result<
             attempts: 1,
             shard: None,
             cases: Vec::new(),
-            log_uri: None,
+            test_log_available: false,
+            test_log_unavailable_reason: None,
         })
         .collect();
     let started = Instant::now();

--- a/crates/bazel-mcp-reducer/src/build.rs
+++ b/crates/bazel-mcp-reducer/src/build.rs
@@ -132,18 +132,33 @@ impl BepAccumulator {
                 }
             }
             Some(build_event::Payload::TestSummary(summary)) => {
+                let label = label_from_id(id.as_ref()).unwrap_or_else(|| "<unknown test>".into());
+                let status = test_status(summary.overall_status);
+                if let Some(diagnostic) = test_outcome_diagnostic(&label, status) {
+                    let bytes = diagnostic.message.len()
+                        + diagnostic.target.as_ref().map_or(0, String::len);
+                    if self.reserve(1, bytes) {
+                        self.diagnostics.push(diagnostic);
+                    }
+                }
                 let test = TestResult {
-                    label: label_from_id(id.as_ref()).unwrap_or_else(|| "<unknown test>".into()),
-                    status: test_status(summary.overall_status),
+                    label,
+                    status,
                     duration_ms: u64::try_from(summary.total_run_duration_millis).ok(),
                     attempts: u32::try_from(summary.attempt_count.max(1)).unwrap_or(1),
                     shard: u32::try_from(summary.shard_count)
                         .ok()
                         .filter(|value| *value > 0),
                     cases: Vec::new(),
-                    log_uri: summary.failed.first().and_then(file_uri),
+                    test_log_available: false,
+                    test_log_unavailable_reason: (status != TestStatus::Passed)
+                        .then(|| "test_log_not_snapshotted".to_owned()),
                 };
-                let bytes = test.label.len() + test.log_uri.as_ref().map_or(0, String::len);
+                let bytes = test.label.len()
+                    + test
+                        .test_log_unavailable_reason
+                        .as_ref()
+                        .map_or(0, String::len);
                 if self.reserve(1, bytes) {
                     self.tests.push(test);
                 }
@@ -215,14 +230,9 @@ impl BepAccumulator {
         let success = exit_code == Some(0);
         if !success {
             add_text_diagnostics(stderr, &mut self.diagnostics);
-            if self.diagnostics.is_empty() {
-                add_text_diagnostics(stdout, &mut self.diagnostics);
-            }
+            add_text_diagnostics(stdout, &mut self.diagnostics);
         }
 
-        self.diagnostics
-            .sort_by_key(|diagnostic| diagnostic.severity);
-        self.diagnostics = deduplicate_diagnostics(self.diagnostics);
         self.targets
             .sort_by(|left, right| left.label.cmp(&right.label));
         self.targets
@@ -249,43 +259,29 @@ impl BepAccumulator {
             }
         }
 
-        let mut truncated = self.truncated || self.diagnostics.len() > budget.max_items;
-        self.diagnostics.truncate(budget.max_items);
-        let mut used = 0_usize;
-        self.diagnostics.retain(|diagnostic| {
-            let next = used.saturating_add(diagnostic.message.len());
-            if next > budget.max_bytes {
-                truncated = true;
-                false
-            } else {
-                used = next;
-                true
-            }
-        });
-        let headline = if success {
-            format!("Bazel completed successfully in {elapsed_ms} ms")
-        } else if let Some(first) = self.diagnostics.first() {
-            format!("Bazel failed: {}", first.message)
-        } else {
-            format!("Bazel failed with exit code {exit_code:?}")
-        };
         let artifacts = self.resolve_artifacts();
-        StreamReductionOutput {
-            summary: InvocationSummary {
-                success,
-                headline,
-                targets: self.targets,
-                target_counts,
-                diagnostics: self.diagnostics,
-                tests: self.tests,
-                test_counts,
-                coverage: None,
-                query_sample: Vec::new(),
-                query_result_count: None,
-                elapsed_ms,
-                truncated,
-                inspect_hint: truncated.then(|| "diagnostics".to_owned()),
+        let mut summary = InvocationSummary {
+            success,
+            headline: if success {
+                format!("Bazel completed successfully in {elapsed_ms} ms")
+            } else {
+                format!("Bazel failed with exit code {exit_code:?}")
             },
+            targets: self.targets,
+            target_counts,
+            diagnostics: self.diagnostics,
+            tests: self.tests,
+            test_counts,
+            coverage: None,
+            query_sample: Vec::new(),
+            query_result_count: None,
+            elapsed_ms,
+            truncated: self.truncated,
+            inspect_hint: self.truncated.then(|| "diagnostics".to_owned()),
+        };
+        finalize_diagnostics(&mut summary, budget);
+        StreamReductionOutput {
+            summary,
             artifacts,
             canonical_arguments: self.canonical_arguments,
         }
@@ -381,30 +377,34 @@ pub fn reduce_invocation(input: ReductionInput<'_>) -> InvocationSummary {
                 label: label_from_id(id.as_ref()).unwrap_or_else(|| "<unknown target>".into()),
                 success: completed.success,
             }),
-            Some(build_event::Payload::TestSummary(summary)) => tests.push(TestResult {
-                label: label_from_id(id.as_ref()).unwrap_or_else(|| "<unknown test>".into()),
-                status: test_status(summary.overall_status),
-                duration_ms: u64::try_from(summary.total_run_duration_millis).ok(),
-                attempts: u32::try_from(summary.attempt_count.max(1)).unwrap_or(1),
-                shard: u32::try_from(summary.shard_count)
-                    .ok()
-                    .filter(|value| *value > 0),
-                cases: Vec::new(),
-                log_uri: summary.failed.first().and_then(file_uri),
-            }),
+            Some(build_event::Payload::TestSummary(summary)) => {
+                let label = label_from_id(id.as_ref()).unwrap_or_else(|| "<unknown test>".into());
+                let status = test_status(summary.overall_status);
+                if let Some(diagnostic) = test_outcome_diagnostic(&label, status) {
+                    diagnostics.push(diagnostic);
+                }
+                tests.push(TestResult {
+                    label,
+                    status,
+                    duration_ms: u64::try_from(summary.total_run_duration_millis).ok(),
+                    attempts: u32::try_from(summary.attempt_count.max(1)).unwrap_or(1),
+                    shard: u32::try_from(summary.shard_count)
+                        .ok()
+                        .filter(|value| *value > 0),
+                    cases: Vec::new(),
+                    test_log_available: false,
+                    test_log_unavailable_reason: (status != TestStatus::Passed)
+                        .then(|| "test_log_not_snapshotted".to_owned()),
+                });
+            }
             _ => {}
         }
     }
 
     if !success {
         add_text_diagnostics(input.stderr, &mut diagnostics);
-        if diagnostics.is_empty() {
-            add_text_diagnostics(input.stdout, &mut diagnostics);
-        }
+        add_text_diagnostics(input.stdout, &mut diagnostics);
     }
-
-    diagnostics.sort_by_key(|diagnostic| diagnostic.severity);
-    diagnostics = deduplicate_diagnostics(diagnostics);
 
     targets.sort_by(|left, right| left.label.cmp(&right.label));
     targets.dedup_by(|left, right| left.label == right.label);
@@ -427,31 +427,13 @@ pub fn reduce_invocation(input: ReductionInput<'_>) -> InvocationSummary {
             }
         }
     }
-    let mut truncated = diagnostics.len() > input.budget.max_items;
-    diagnostics.truncate(input.budget.max_items);
-    let mut used = 0_usize;
-    diagnostics.retain(|diagnostic| {
-        let next = used.saturating_add(diagnostic.message.len());
-        if next > input.budget.max_bytes {
-            truncated = true;
-            false
-        } else {
-            used = next;
-            true
-        }
-    });
-
-    let headline = if success {
-        format!("Bazel completed successfully in {} ms", input.elapsed_ms)
-    } else if let Some(first) = diagnostics.first() {
-        format!("Bazel failed: {}", first.message)
-    } else {
-        format!("Bazel failed with exit code {:?}", input.exit_code)
-    };
-
-    InvocationSummary {
+    let mut summary = InvocationSummary {
         success,
-        headline,
+        headline: if success {
+            format!("Bazel completed successfully in {} ms", input.elapsed_ms)
+        } else {
+            format!("Bazel failed with exit code {:?}", input.exit_code)
+        },
         targets,
         target_counts,
         diagnostics,
@@ -461,21 +443,40 @@ pub fn reduce_invocation(input: ReductionInput<'_>) -> InvocationSummary {
         query_sample: Vec::new(),
         query_result_count: None,
         elapsed_ms: input.elapsed_ms,
-        truncated,
-        inspect_hint: truncated.then(|| "diagnostics".to_owned()),
-    }
+        truncated: false,
+        inspect_hint: None,
+    };
+    finalize_diagnostics(&mut summary, input.budget);
+    summary
 }
 
 fn deduplicate_diagnostics(diagnostics: Vec<Diagnostic>) -> Vec<Diagnostic> {
-    let mut positions = BTreeMap::<(Severity, String, Option<String>), usize>::new();
+    let mut positions = BTreeMap::<
+        (
+            Severity,
+            DiagnosticCategory,
+            String,
+            Option<String>,
+            Option<String>,
+        ),
+        usize,
+    >::new();
     let mut unique = Vec::<Diagnostic>::new();
     for diagnostic in diagnostics {
+        let aggregate_actions = diagnostic.category == DiagnosticCategory::Action;
         let key = (
             diagnostic.severity,
+            diagnostic.category,
             diagnostic.message.clone(),
-            diagnostic.target.clone(),
+            (!aggregate_actions)
+                .then(|| diagnostic.target.clone())
+                .flatten(),
+            diagnostic.action.clone(),
         );
         if let Some(index) = positions.get(&key).copied() {
+            if aggregate_actions && unique[index].target != diagnostic.target {
+                unique[index].target = None;
+            }
             unique[index].repetition_count = unique[index]
                 .repetition_count
                 .saturating_add(diagnostic.repetition_count);
@@ -485,6 +486,90 @@ fn deduplicate_diagnostics(diagnostics: Vec<Diagnostic>) -> Vec<Diagnostic> {
         }
     }
     unique
+}
+
+/// Re-ranks, aggregates, and bounds diagnostics after all structured and local
+/// evidence enrichment has completed.
+pub fn finalize_diagnostics(summary: &mut InvocationSummary, budget: Budget) {
+    let diagnostics = std::mem::take(&mut summary.diagnostics);
+    let mut diagnostics = deduplicate_diagnostics(diagnostics);
+    diagnostics.sort_by_key(diagnostic_priority);
+
+    let mut truncated = diagnostics.len() > budget.max_items;
+    diagnostics.truncate(budget.max_items);
+    let mut used = 0_usize;
+    diagnostics.retain(|diagnostic| {
+        let next = used.saturating_add(diagnostic.message.len());
+        if next > budget.max_bytes {
+            truncated = true;
+            false
+        } else {
+            used = next;
+            true
+        }
+    });
+    summary.diagnostics = diagnostics;
+    summary.truncated |= truncated;
+    if summary.truncated {
+        summary.inspect_hint = Some("diagnostics".to_owned());
+    }
+    if !summary.success
+        && let Some(first) = summary.diagnostics.first()
+    {
+        summary.headline = format!("Bazel failed: {}", first.message);
+    }
+}
+
+fn diagnostic_priority(diagnostic: &Diagnostic) -> (Severity, u8, u8) {
+    let category = match diagnostic.category {
+        DiagnosticCategory::Loading
+        | DiagnosticCategory::Visibility
+        | DiagnosticCategory::Analysis
+        | DiagnosticCategory::Compilation => 0,
+        DiagnosticCategory::Test => 1,
+        DiagnosticCategory::Workspace => 2,
+        DiagnosticCategory::Bazel => 3,
+        DiagnosticCategory::Unknown => 4,
+        DiagnosticCategory::Action => 5,
+    };
+    let lower = diagnostic.message.to_ascii_lowercase();
+    let evidence_quality = if lower.starts_with("test failed:")
+        || lower.starts_with("test timed out:")
+        || lower.starts_with("test was incomplete:")
+        || lower.starts_with("test result was unavailable:")
+    {
+        3
+    } else if lower.contains("root_cause") && !lower.contains("error executing") {
+        0
+    } else if lower.contains("error executing") {
+        2
+    } else {
+        1
+    };
+    (diagnostic.severity, category, evidence_quality)
+}
+
+fn test_outcome_diagnostic(label: &str, status: TestStatus) -> Option<Diagnostic> {
+    let (severity, message) = match status {
+        TestStatus::Passed | TestStatus::Skipped => return None,
+        TestStatus::Flaky => (Severity::Warning, format!("Test was flaky: {label}")),
+        TestStatus::Failed => (Severity::Error, format!("Test failed: {label}")),
+        TestStatus::TimedOut => (Severity::Error, format!("Test timed out: {label}")),
+        TestStatus::Incomplete => (Severity::Error, format!("Test was incomplete: {label}")),
+        TestStatus::Remote => (
+            Severity::Error,
+            format!("Test result was unavailable: {label}"),
+        ),
+    };
+    Some(Diagnostic {
+        severity,
+        category: DiagnosticCategory::Test,
+        message,
+        location: None,
+        target: Some(label.to_owned()),
+        action: None,
+        repetition_count: 1,
+    })
 }
 
 #[must_use]
@@ -616,7 +701,6 @@ fn add_text_diagnostics(input: &[u8], diagnostics: &mut Vec<Diagnostic>) {
     for (line, count) in candidates
         .into_iter()
         .filter(|(line, _)| is_actionable(line))
-        .take(20)
     {
         diagnostics.push(Diagnostic {
             severity: if line.to_ascii_lowercase().contains("warning:") {
@@ -662,6 +746,8 @@ fn category_from_text(line: &str) -> DiagnosticCategory {
         || lower.contains("undefined reference")
     {
         DiagnosticCategory::Compilation
+    } else if lower.contains("root_cause") {
+        DiagnosticCategory::Test
     } else {
         DiagnosticCategory::Unknown
     }
@@ -700,13 +786,6 @@ fn test_status(value: i32) -> TestStatus {
         5 => TestStatus::Incomplete,
         6 => TestStatus::Remote,
         _ => TestStatus::Incomplete,
-    }
-}
-
-fn file_uri(file: &FileView<'_>) -> Option<String> {
-    match &file.file {
-        Some(file::File::Uri(uri)) => Some((*uri).to_owned()),
-        _ => None,
     }
 }
 
@@ -754,6 +833,54 @@ mod tests {
                 .any(|d| d.message.contains("bad type"))
         );
         assert!(summary.diagnostics.len() <= 2);
+    }
+
+    #[test]
+    fn ranks_root_cause_before_aggregated_fanout_failures() {
+        let events = (0..48)
+            .map(|index| {
+                let event = BuildEvent {
+                    id: encode_event_id(&BuildEventId {
+                        id: Some(owned_build_event_id::Id::ActionCompleted(Box::new(
+                            bazel_mcp_bep::proto::build_event_id::ActionCompletedId {
+                                label: format!("//pkg:fanout_{index}"),
+                                ..Default::default()
+                            },
+                        ))),
+                    }),
+                    payload: Some(owned_build_event::Payload::Action(Box::new(
+                        ActionExecuted {
+                            success: false,
+                            exit_code: 1,
+                            r#type: "CppCompile".into(),
+                            ..Default::default()
+                        },
+                    ))),
+                    ..Default::default()
+                };
+                BepEvent::from_owned(&event).unwrap()
+            })
+            .collect::<Vec<_>>();
+        let summary = reduce_invocation(ReductionInput {
+            events: &events,
+            stdout: b"",
+            stderr: b"source.cc:9: error: FANOUT_ROOT_CAUSE",
+            exit_code: Some(1),
+            elapsed_ms: 1,
+            budget: Budget {
+                max_bytes: 1_000,
+                max_items: 2,
+            },
+        });
+
+        assert!(summary.diagnostics[0].message.contains("FANOUT_ROOT_CAUSE"));
+        let action = summary
+            .diagnostics
+            .iter()
+            .find(|diagnostic| diagnostic.category == DiagnosticCategory::Action)
+            .unwrap();
+        assert_eq!(action.target, None);
+        assert_eq!(action.repetition_count, 48);
     }
 
     #[test]

--- a/crates/bazel-mcp-reducer/src/lib.rs
+++ b/crates/bazel-mcp-reducer/src/lib.rs
@@ -10,7 +10,7 @@ mod text;
 pub use budget::{Budget, Budgeted};
 pub use build::{
     BepAccumulator, ReductionInput, StreamReductionOutput, extract_canonical_arguments,
-    reduce_artifacts, reduce_invocation,
+    finalize_diagnostics, reduce_artifacts, reduce_invocation,
 };
 pub use coverage::{CoverageError, parse_lcov, parse_lcov_reader};
 pub use query::reduce_query;

--- a/crates/bazel-mcp-reducer/src/test.rs
+++ b/crates/bazel-mcp-reducer/src/test.rs
@@ -10,6 +10,14 @@ pub enum TestXmlError {
 }
 
 #[derive(Debug, Deserialize)]
+struct Document {
+    #[serde(rename = "testsuite", default)]
+    suites: Vec<Suite>,
+    #[serde(rename = "testcase", default)]
+    cases: Vec<Case>,
+}
+
+#[derive(Debug, Deserialize)]
 struct Suite {
     #[serde(rename = "testcase", default)]
     cases: Vec<Case>,
@@ -35,10 +43,11 @@ struct Message {
 }
 
 pub fn parse_test_xml(input: &str) -> Result<Vec<TestCase>, TestXmlError> {
-    let suite: Suite = from_str(input)?;
-    Ok(suite
+    let document: Document = from_str(input)?;
+    Ok(document
         .cases
         .into_iter()
+        .chain(document.suites.into_iter().flat_map(|suite| suite.cases))
         .map(|case| {
             let (status, detail) = if let Some(message) = case.failure.or(case.error) {
                 (TestStatus::Failed, message.message.or(message.text))
@@ -80,5 +89,27 @@ mod tests {
         assert_eq!(duration_ms(f64::INFINITY), None);
         assert_eq!(duration_ms(1.25), Some(1_250));
         assert_eq!(duration_ms(f64::MAX), Some(u64::MAX));
+    }
+
+    #[test]
+    fn parses_direct_testsuite_root() {
+        let cases = parse_test_xml(
+            r#"<testsuite><testcase name="one" time="0.25"><failure message="bad"/></testcase></testsuite>"#,
+        )
+        .unwrap();
+        assert_eq!(cases.len(), 1);
+        assert_eq!(cases[0].name, "one");
+        assert_eq!(cases[0].status, TestStatus::Failed);
+    }
+
+    #[test]
+    fn parses_testsuites_wrapper() {
+        let cases = parse_test_xml(
+            r#"<testsuites><testsuite><testcase name="one" time="0.25"><failure message="bad"/></testcase></testsuite><testsuite><testcase name="two" time="0.1"/></testsuite></testsuites>"#,
+        )
+        .unwrap();
+        assert_eq!(cases.len(), 2);
+        assert_eq!(cases[0].status, TestStatus::Failed);
+        assert_eq!(cases[1].status, TestStatus::Passed);
     }
 }

--- a/crates/bazel-mcp-reducer/tests/fixtures/bazel-7/cached-tests.expected.json
+++ b/crates/bazel-mcp-reducer/tests/fixtures/bazel-7/cached-tests.expected.json
@@ -28,7 +28,7 @@
         "attempts": 1,
         "shard": null,
         "cases": [],
-        "log_uri": null
+        "test_log_available": false
       },
       {
         "label": "//:sharded",
@@ -37,7 +37,7 @@
         "attempts": 1,
         "shard": 2,
         "cases": [],
-        "log_uri": null
+        "test_log_available": false
       }
     ],
     "test_counts": {

--- a/crates/bazel-mcp-reducer/tests/fixtures/bazel-7/keep-going-actions.expected.json
+++ b/crates/bazel-mcp-reducer/tests/fixtures/bazel-7/keep-going-actions.expected.json
@@ -3,7 +3,7 @@
   "terminal_error": null,
   "summary": {
     "success": false,
-    "headline": "Bazel failed: FixtureAction action failed with exit code 1",
+    "headline": "Bazel failed: ERROR: CUSTOM_ACTION_ROOT_CAUSE_TWO",
     "targets": [
       {
         "label": "//:compile_failure",
@@ -26,42 +26,6 @@
     "diagnostics": [
       {
         "severity": "error",
-        "category": "action",
-        "message": "FixtureAction action failed with exit code 1",
-        "location": null,
-        "target": "//:compile_failure",
-        "action": "FixtureAction",
-        "repetition_count": 1
-      },
-      {
-        "severity": "error",
-        "category": "action",
-        "message": "FixtureAction action failed with exit code 1",
-        "location": null,
-        "target": "//:custom_failure_one",
-        "action": "FixtureAction",
-        "repetition_count": 1
-      },
-      {
-        "severity": "error",
-        "category": "action",
-        "message": "FixtureAction action failed with exit code 1",
-        "location": null,
-        "target": "//:custom_failure_two",
-        "action": "FixtureAction",
-        "repetition_count": 1
-      },
-      {
-        "severity": "error",
-        "category": "compilation",
-        "message": "ERROR: <WORKSPACE>/BUILD.bazel:13:15: Running fixture action //:custom_failure_two failed: (Exit 1): bash failed: error executing FixtureAction command (from target //:custom_failure_two) /bin/bash -c 'echo '\\''ERROR: CUSTOM_ACTION_ROOT_CAUSE_TWO'\\'' >&2; exit 1'",
-        "location": null,
-        "target": null,
-        "action": null,
-        "repetition_count": 1
-      },
-      {
-        "severity": "error",
         "category": "compilation",
         "message": "ERROR: CUSTOM_ACTION_ROOT_CAUSE_TWO",
         "location": null,
@@ -72,25 +36,7 @@
       {
         "severity": "error",
         "category": "compilation",
-        "message": "ERROR: <WORKSPACE>/BUILD.bazel:3:15: Running fixture action //:compile_failure failed: (Exit 1): bash failed: error executing FixtureAction command (from target //:compile_failure) /bin/bash -c 'echo '\\''fixture.cc:7: error: BAZEL_MCP_CPP_ROOT_CAUSE'\\'' >&2; exit 1'",
-        "location": null,
-        "target": null,
-        "action": null,
-        "repetition_count": 1
-      },
-      {
-        "severity": "error",
-        "category": "compilation",
         "message": "fixture.cc:7: error: BAZEL_MCP_CPP_ROOT_CAUSE",
-        "location": null,
-        "target": null,
-        "action": null,
-        "repetition_count": 1
-      },
-      {
-        "severity": "error",
-        "category": "compilation",
-        "message": "ERROR: <WORKSPACE>/BUILD.bazel:8:15: Running fixture action //:custom_failure_one failed: (Exit 1): bash failed: error executing FixtureAction command (from target //:custom_failure_one) /bin/bash -c 'echo '\\''ERROR: CUSTOM_ACTION_ROOT_CAUSE_ONE'\\'' >&2; exit 1'",
         "location": null,
         "target": null,
         "action": null,
@@ -116,12 +62,48 @@
       },
       {
         "severity": "error",
+        "category": "compilation",
+        "message": "ERROR: <WORKSPACE>/BUILD.bazel:13:15: Running fixture action //:custom_failure_two failed: (Exit 1): bash failed: error executing FixtureAction command (from target //:custom_failure_two) /bin/bash -c 'echo '\\''ERROR: CUSTOM_ACTION_ROOT_CAUSE_TWO'\\'' >&2; exit 1'",
+        "location": null,
+        "target": null,
+        "action": null,
+        "repetition_count": 1
+      },
+      {
+        "severity": "error",
+        "category": "compilation",
+        "message": "ERROR: <WORKSPACE>/BUILD.bazel:3:15: Running fixture action //:compile_failure failed: (Exit 1): bash failed: error executing FixtureAction command (from target //:compile_failure) /bin/bash -c 'echo '\\''fixture.cc:7: error: BAZEL_MCP_CPP_ROOT_CAUSE'\\'' >&2; exit 1'",
+        "location": null,
+        "target": null,
+        "action": null,
+        "repetition_count": 1
+      },
+      {
+        "severity": "error",
+        "category": "compilation",
+        "message": "ERROR: <WORKSPACE>/BUILD.bazel:8:15: Running fixture action //:custom_failure_one failed: (Exit 1): bash failed: error executing FixtureAction command (from target //:custom_failure_one) /bin/bash -c 'echo '\\''ERROR: CUSTOM_ACTION_ROOT_CAUSE_ONE'\\'' >&2; exit 1'",
+        "location": null,
+        "target": null,
+        "action": null,
+        "repetition_count": 1
+      },
+      {
+        "severity": "error",
         "category": "unknown",
         "message": "FAILED:",
         "location": null,
         "target": null,
         "action": null,
         "repetition_count": 1
+      },
+      {
+        "severity": "error",
+        "category": "action",
+        "message": "FixtureAction action failed with exit code 1",
+        "location": null,
+        "target": null,
+        "action": "FixtureAction",
+        "repetition_count": 3
       }
     ],
     "tests": [],

--- a/crates/bazel-mcp-reducer/tests/fixtures/bazel-7/test-outcomes.expected.json
+++ b/crates/bazel-mcp-reducer/tests/fixtures/bazel-7/test-outcomes.expected.json
@@ -3,7 +3,7 @@
   "terminal_error": null,
   "summary": {
     "success": false,
-    "headline": "Bazel failed: FAILED: //:fail (Summary)",
+    "headline": "Bazel failed: FLAKY_ROOT_CAUSE",
     "targets": [
       {
         "label": "//:fail",
@@ -34,10 +34,64 @@
     "diagnostics": [
       {
         "severity": "error",
+        "category": "test",
+        "message": "FLAKY_ROOT_CAUSE",
+        "location": null,
+        "target": null,
+        "action": null,
+        "repetition_count": 1
+      },
+      {
+        "severity": "error",
+        "category": "test",
+        "message": "TEST_ROOT_CAUSE",
+        "location": null,
+        "target": null,
+        "action": null,
+        "repetition_count": 2
+      },
+      {
+        "severity": "error",
+        "category": "test",
+        "message": "TIMEOUT_ROOT_CAUSE",
+        "location": null,
+        "target": null,
+        "action": null,
+        "repetition_count": 2
+      },
+      {
+        "severity": "error",
+        "category": "test",
+        "message": "Test failed: //:fail",
+        "location": null,
+        "target": "//:fail",
+        "action": null,
+        "repetition_count": 1
+      },
+      {
+        "severity": "error",
+        "category": "test",
+        "message": "Test timed out: //:timeout",
+        "location": null,
+        "target": "//:timeout",
+        "action": null,
+        "repetition_count": 1
+      },
+      {
+        "severity": "error",
         "category": "unknown",
         "message": "FAILED: //:fail (Summary)",
         "location": null,
         "target": null,
+        "action": null,
+        "repetition_count": 1
+      },
+      {
+        "severity": "warning",
+        "category": "test",
+        "message": "Test was flaky: //:flaky",
+        "location": null,
+        "target": "//:flaky",
         "action": null,
         "repetition_count": 1
       }
@@ -50,7 +104,8 @@
         "attempts": 2,
         "shard": null,
         "cases": [],
-        "log_uri": "file://<OUTPUT_ROOT>_______________________________________________________________________________/fc08b3732d5c62d9023f537c006f2d55/execroot/_main/bazel-out/darwin_arm64-fastbuild/testlogs/fail/test.log"
+        "test_log_available": false,
+        "test_log_unavailable_reason": "test_log_not_snapshotted"
       },
       {
         "label": "//:flaky",
@@ -59,7 +114,8 @@
         "attempts": 2,
         "shard": null,
         "cases": [],
-        "log_uri": "file://<OUTPUT_ROOT>_______________________________________________________________________________/fc08b3732d5c62d9023f537c006f2d55/execroot/_main/bazel-out/darwin_arm64-fastbuild/testlogs/flaky/test_attempts/attempt_1.log"
+        "test_log_available": false,
+        "test_log_unavailable_reason": "test_log_not_snapshotted"
       },
       {
         "label": "//:pass",
@@ -68,7 +124,7 @@
         "attempts": 1,
         "shard": null,
         "cases": [],
-        "log_uri": null
+        "test_log_available": false
       },
       {
         "label": "//:sharded",
@@ -77,7 +133,7 @@
         "attempts": 1,
         "shard": 2,
         "cases": [],
-        "log_uri": null
+        "test_log_available": false
       },
       {
         "label": "//:timeout",
@@ -86,7 +142,8 @@
         "attempts": 2,
         "shard": null,
         "cases": [],
-        "log_uri": "file://<OUTPUT_ROOT>_______________________________________________________________________________/fc08b3732d5c62d9023f537c006f2d55/execroot/_main/bazel-out/darwin_arm64-fastbuild/testlogs/timeout/test.log"
+        "test_log_available": false,
+        "test_log_unavailable_reason": "test_log_not_snapshotted"
       }
     ],
     "test_counts": {

--- a/crates/bazel-mcp-reducer/tests/fixtures/bazel-8/cached-tests.expected.json
+++ b/crates/bazel-mcp-reducer/tests/fixtures/bazel-8/cached-tests.expected.json
@@ -28,7 +28,7 @@
         "attempts": 1,
         "shard": null,
         "cases": [],
-        "log_uri": null
+        "test_log_available": false
       },
       {
         "label": "//:sharded",
@@ -37,7 +37,7 @@
         "attempts": 1,
         "shard": 2,
         "cases": [],
-        "log_uri": null
+        "test_log_available": false
       }
     ],
     "test_counts": {

--- a/crates/bazel-mcp-reducer/tests/fixtures/bazel-8/keep-going-actions.expected.json
+++ b/crates/bazel-mcp-reducer/tests/fixtures/bazel-8/keep-going-actions.expected.json
@@ -3,7 +3,7 @@
   "terminal_error": null,
   "summary": {
     "success": false,
-    "headline": "Bazel failed: FixtureAction action failed with exit code 1",
+    "headline": "Bazel failed: fixture.cc:7: error: BAZEL_MCP_CPP_ROOT_CAUSE",
     "targets": [
       {
         "label": "//:compile_failure",
@@ -26,42 +26,6 @@
     "diagnostics": [
       {
         "severity": "error",
-        "category": "action",
-        "message": "FixtureAction action failed with exit code 1",
-        "location": null,
-        "target": "//:custom_failure_two",
-        "action": "FixtureAction",
-        "repetition_count": 1
-      },
-      {
-        "severity": "error",
-        "category": "action",
-        "message": "FixtureAction action failed with exit code 1",
-        "location": null,
-        "target": "//:custom_failure_one",
-        "action": "FixtureAction",
-        "repetition_count": 1
-      },
-      {
-        "severity": "error",
-        "category": "action",
-        "message": "FixtureAction action failed with exit code 1",
-        "location": null,
-        "target": "//:compile_failure",
-        "action": "FixtureAction",
-        "repetition_count": 1
-      },
-      {
-        "severity": "error",
-        "category": "compilation",
-        "message": "ERROR: <WORKSPACE>/BUILD.bazel:3:15: Running fixture action //:compile_failure failed: (Exit 1): bash failed: error executing FixtureAction command (from target //:compile_failure) /bin/bash -c 'echo '\\''fixture.cc:7: error: BAZEL_MCP_CPP_ROOT_CAUSE'\\'' >&2; exit 1'",
-        "location": null,
-        "target": null,
-        "action": null,
-        "repetition_count": 1
-      },
-      {
-        "severity": "error",
         "category": "compilation",
         "message": "fixture.cc:7: error: BAZEL_MCP_CPP_ROOT_CAUSE",
         "location": null,
@@ -72,25 +36,7 @@
       {
         "severity": "error",
         "category": "compilation",
-        "message": "ERROR: <WORKSPACE>/BUILD.bazel:8:15: Running fixture action //:custom_failure_one failed: (Exit 1): bash failed: error executing FixtureAction command (from target //:custom_failure_one) /bin/bash -c 'echo '\\''ERROR: CUSTOM_ACTION_ROOT_CAUSE_ONE'\\'' >&2; exit 1'",
-        "location": null,
-        "target": null,
-        "action": null,
-        "repetition_count": 1
-      },
-      {
-        "severity": "error",
-        "category": "compilation",
         "message": "ERROR: CUSTOM_ACTION_ROOT_CAUSE_ONE",
-        "location": null,
-        "target": null,
-        "action": null,
-        "repetition_count": 1
-      },
-      {
-        "severity": "error",
-        "category": "compilation",
-        "message": "ERROR: <WORKSPACE>/BUILD.bazel:13:15: Running fixture action //:custom_failure_two failed: (Exit 1): bash failed: error executing FixtureAction command (from target //:custom_failure_two) /bin/bash -c 'echo '\\''ERROR: CUSTOM_ACTION_ROOT_CAUSE_TWO'\\'' >&2; exit 1'",
         "location": null,
         "target": null,
         "action": null,
@@ -116,12 +62,48 @@
       },
       {
         "severity": "error",
+        "category": "compilation",
+        "message": "ERROR: <WORKSPACE>/BUILD.bazel:3:15: Running fixture action //:compile_failure failed: (Exit 1): bash failed: error executing FixtureAction command (from target //:compile_failure) /bin/bash -c 'echo '\\''fixture.cc:7: error: BAZEL_MCP_CPP_ROOT_CAUSE'\\'' >&2; exit 1'",
+        "location": null,
+        "target": null,
+        "action": null,
+        "repetition_count": 1
+      },
+      {
+        "severity": "error",
+        "category": "compilation",
+        "message": "ERROR: <WORKSPACE>/BUILD.bazel:8:15: Running fixture action //:custom_failure_one failed: (Exit 1): bash failed: error executing FixtureAction command (from target //:custom_failure_one) /bin/bash -c 'echo '\\''ERROR: CUSTOM_ACTION_ROOT_CAUSE_ONE'\\'' >&2; exit 1'",
+        "location": null,
+        "target": null,
+        "action": null,
+        "repetition_count": 1
+      },
+      {
+        "severity": "error",
+        "category": "compilation",
+        "message": "ERROR: <WORKSPACE>/BUILD.bazel:13:15: Running fixture action //:custom_failure_two failed: (Exit 1): bash failed: error executing FixtureAction command (from target //:custom_failure_two) /bin/bash -c 'echo '\\''ERROR: CUSTOM_ACTION_ROOT_CAUSE_TWO'\\'' >&2; exit 1'",
+        "location": null,
+        "target": null,
+        "action": null,
+        "repetition_count": 1
+      },
+      {
+        "severity": "error",
         "category": "unknown",
         "message": "FAILED:",
         "location": null,
         "target": null,
         "action": null,
         "repetition_count": 1
+      },
+      {
+        "severity": "error",
+        "category": "action",
+        "message": "FixtureAction action failed with exit code 1",
+        "location": null,
+        "target": null,
+        "action": "FixtureAction",
+        "repetition_count": 3
       }
     ],
     "tests": [],

--- a/crates/bazel-mcp-reducer/tests/fixtures/bazel-8/test-outcomes.expected.json
+++ b/crates/bazel-mcp-reducer/tests/fixtures/bazel-8/test-outcomes.expected.json
@@ -3,7 +3,7 @@
   "terminal_error": null,
   "summary": {
     "success": false,
-    "headline": "Bazel failed: FAILED: //:fail (Summary)",
+    "headline": "Bazel failed: FLAKY_ROOT_CAUSE",
     "targets": [
       {
         "label": "//:fail",
@@ -34,10 +34,64 @@
     "diagnostics": [
       {
         "severity": "error",
+        "category": "test",
+        "message": "FLAKY_ROOT_CAUSE",
+        "location": null,
+        "target": null,
+        "action": null,
+        "repetition_count": 1
+      },
+      {
+        "severity": "error",
+        "category": "test",
+        "message": "TEST_ROOT_CAUSE",
+        "location": null,
+        "target": null,
+        "action": null,
+        "repetition_count": 2
+      },
+      {
+        "severity": "error",
+        "category": "test",
+        "message": "TIMEOUT_ROOT_CAUSE",
+        "location": null,
+        "target": null,
+        "action": null,
+        "repetition_count": 2
+      },
+      {
+        "severity": "error",
+        "category": "test",
+        "message": "Test failed: //:fail",
+        "location": null,
+        "target": "//:fail",
+        "action": null,
+        "repetition_count": 1
+      },
+      {
+        "severity": "error",
+        "category": "test",
+        "message": "Test timed out: //:timeout",
+        "location": null,
+        "target": "//:timeout",
+        "action": null,
+        "repetition_count": 1
+      },
+      {
+        "severity": "error",
         "category": "unknown",
         "message": "FAILED: //:fail (Summary)",
         "location": null,
         "target": null,
+        "action": null,
+        "repetition_count": 1
+      },
+      {
+        "severity": "warning",
+        "category": "test",
+        "message": "Test was flaky: //:flaky",
+        "location": null,
+        "target": "//:flaky",
         "action": null,
         "repetition_count": 1
       }
@@ -50,7 +104,8 @@
         "attempts": 2,
         "shard": null,
         "cases": [],
-        "log_uri": "file://<OUTPUT_ROOT>_______________________________________________________________________________/a6f1284d8bd1e01a208b8cdcabc2d775/execroot/_main/bazel-out/darwin_arm64-fastbuild/testlogs/fail/test.log"
+        "test_log_available": false,
+        "test_log_unavailable_reason": "test_log_not_snapshotted"
       },
       {
         "label": "//:flaky",
@@ -59,7 +114,8 @@
         "attempts": 2,
         "shard": null,
         "cases": [],
-        "log_uri": "file://<OUTPUT_ROOT>_______________________________________________________________________________/a6f1284d8bd1e01a208b8cdcabc2d775/execroot/_main/bazel-out/darwin_arm64-fastbuild/testlogs/flaky/test_attempts/attempt_1.log"
+        "test_log_available": false,
+        "test_log_unavailable_reason": "test_log_not_snapshotted"
       },
       {
         "label": "//:pass",
@@ -68,7 +124,7 @@
         "attempts": 1,
         "shard": null,
         "cases": [],
-        "log_uri": null
+        "test_log_available": false
       },
       {
         "label": "//:sharded",
@@ -77,7 +133,7 @@
         "attempts": 1,
         "shard": 2,
         "cases": [],
-        "log_uri": null
+        "test_log_available": false
       },
       {
         "label": "//:timeout",
@@ -86,7 +142,8 @@
         "attempts": 2,
         "shard": null,
         "cases": [],
-        "log_uri": "file://<OUTPUT_ROOT>_______________________________________________________________________________/a6f1284d8bd1e01a208b8cdcabc2d775/execroot/_main/bazel-out/darwin_arm64-fastbuild/testlogs/timeout/test.log"
+        "test_log_available": false,
+        "test_log_unavailable_reason": "test_log_not_snapshotted"
       }
     ],
     "test_counts": {

--- a/crates/bazel-mcp-reducer/tests/fixtures/bazel-9/cached-tests.expected.json
+++ b/crates/bazel-mcp-reducer/tests/fixtures/bazel-9/cached-tests.expected.json
@@ -28,7 +28,7 @@
         "attempts": 1,
         "shard": null,
         "cases": [],
-        "log_uri": null
+        "test_log_available": false
       },
       {
         "label": "//:sharded",
@@ -37,7 +37,7 @@
         "attempts": 1,
         "shard": 2,
         "cases": [],
-        "log_uri": null
+        "test_log_available": false
       }
     ],
     "test_counts": {

--- a/crates/bazel-mcp-reducer/tests/fixtures/bazel-9/keep-going-actions.expected.json
+++ b/crates/bazel-mcp-reducer/tests/fixtures/bazel-9/keep-going-actions.expected.json
@@ -3,7 +3,7 @@
   "terminal_error": null,
   "summary": {
     "success": false,
-    "headline": "Bazel failed: FixtureAction action failed with exit code 1",
+    "headline": "Bazel failed: fixture.cc:7: error: BAZEL_MCP_CPP_ROOT_CAUSE",
     "targets": [
       {
         "label": "//:compile_failure",
@@ -26,42 +26,6 @@
     "diagnostics": [
       {
         "severity": "error",
-        "category": "action",
-        "message": "FixtureAction action failed with exit code 1",
-        "location": null,
-        "target": "//:custom_failure_two",
-        "action": "FixtureAction",
-        "repetition_count": 1
-      },
-      {
-        "severity": "error",
-        "category": "action",
-        "message": "FixtureAction action failed with exit code 1",
-        "location": null,
-        "target": "//:compile_failure",
-        "action": "FixtureAction",
-        "repetition_count": 1
-      },
-      {
-        "severity": "error",
-        "category": "action",
-        "message": "FixtureAction action failed with exit code 1",
-        "location": null,
-        "target": "//:custom_failure_one",
-        "action": "FixtureAction",
-        "repetition_count": 1
-      },
-      {
-        "severity": "error",
-        "category": "compilation",
-        "message": "ERROR: <WORKSPACE>/BUILD.bazel:3:15: Running fixture action //:compile_failure failed: (Exit 1): bash failed: error executing FixtureAction command (from fixture_action rule target //:compile_failure) /bin/bash -c 'echo '\\''fixture.cc:7: error: BAZEL_MCP_CPP_ROOT_CAUSE'\\'' >&2; exit 1'",
-        "location": null,
-        "target": null,
-        "action": null,
-        "repetition_count": 1
-      },
-      {
-        "severity": "error",
         "category": "compilation",
         "message": "fixture.cc:7: error: BAZEL_MCP_CPP_ROOT_CAUSE",
         "location": null,
@@ -72,25 +36,7 @@
       {
         "severity": "error",
         "category": "compilation",
-        "message": "ERROR: <WORKSPACE>/BUILD.bazel:8:15: Running fixture action //:custom_failure_one failed: (Exit 1): bash failed: error executing FixtureAction command (from fixture_action rule target //:custom_failure_one) /bin/bash -c 'echo '\\''ERROR: CUSTOM_ACTION_ROOT_CAUSE_ONE'\\'' >&2; exit 1'",
-        "location": null,
-        "target": null,
-        "action": null,
-        "repetition_count": 1
-      },
-      {
-        "severity": "error",
-        "category": "compilation",
         "message": "ERROR: CUSTOM_ACTION_ROOT_CAUSE_ONE",
-        "location": null,
-        "target": null,
-        "action": null,
-        "repetition_count": 1
-      },
-      {
-        "severity": "error",
-        "category": "compilation",
-        "message": "ERROR: <WORKSPACE>/BUILD.bazel:13:15: Running fixture action //:custom_failure_two failed: (Exit 1): bash failed: error executing FixtureAction command (from fixture_action rule target //:custom_failure_two) /bin/bash -c 'echo '\\''ERROR: CUSTOM_ACTION_ROOT_CAUSE_TWO'\\'' >&2; exit 1'",
         "location": null,
         "target": null,
         "action": null,
@@ -116,12 +62,48 @@
       },
       {
         "severity": "error",
+        "category": "compilation",
+        "message": "ERROR: <WORKSPACE>/BUILD.bazel:3:15: Running fixture action //:compile_failure failed: (Exit 1): bash failed: error executing FixtureAction command (from fixture_action rule target //:compile_failure) /bin/bash -c 'echo '\\''fixture.cc:7: error: BAZEL_MCP_CPP_ROOT_CAUSE'\\'' >&2; exit 1'",
+        "location": null,
+        "target": null,
+        "action": null,
+        "repetition_count": 1
+      },
+      {
+        "severity": "error",
+        "category": "compilation",
+        "message": "ERROR: <WORKSPACE>/BUILD.bazel:8:15: Running fixture action //:custom_failure_one failed: (Exit 1): bash failed: error executing FixtureAction command (from fixture_action rule target //:custom_failure_one) /bin/bash -c 'echo '\\''ERROR: CUSTOM_ACTION_ROOT_CAUSE_ONE'\\'' >&2; exit 1'",
+        "location": null,
+        "target": null,
+        "action": null,
+        "repetition_count": 1
+      },
+      {
+        "severity": "error",
+        "category": "compilation",
+        "message": "ERROR: <WORKSPACE>/BUILD.bazel:13:15: Running fixture action //:custom_failure_two failed: (Exit 1): bash failed: error executing FixtureAction command (from fixture_action rule target //:custom_failure_two) /bin/bash -c 'echo '\\''ERROR: CUSTOM_ACTION_ROOT_CAUSE_TWO'\\'' >&2; exit 1'",
+        "location": null,
+        "target": null,
+        "action": null,
+        "repetition_count": 1
+      },
+      {
+        "severity": "error",
         "category": "unknown",
         "message": "FAILED:",
         "location": null,
         "target": null,
         "action": null,
         "repetition_count": 1
+      },
+      {
+        "severity": "error",
+        "category": "action",
+        "message": "FixtureAction action failed with exit code 1",
+        "location": null,
+        "target": null,
+        "action": "FixtureAction",
+        "repetition_count": 3
       }
     ],
     "tests": [],

--- a/crates/bazel-mcp-reducer/tests/fixtures/bazel-9/test-outcomes.expected.json
+++ b/crates/bazel-mcp-reducer/tests/fixtures/bazel-9/test-outcomes.expected.json
@@ -3,7 +3,7 @@
   "terminal_error": null,
   "summary": {
     "success": false,
-    "headline": "Bazel failed: FAILED: //:fail (Summary)",
+    "headline": "Bazel failed: FLAKY_ROOT_CAUSE",
     "targets": [
       {
         "label": "//:fail",
@@ -34,10 +34,64 @@
     "diagnostics": [
       {
         "severity": "error",
+        "category": "test",
+        "message": "FLAKY_ROOT_CAUSE",
+        "location": null,
+        "target": null,
+        "action": null,
+        "repetition_count": 1
+      },
+      {
+        "severity": "error",
+        "category": "test",
+        "message": "TEST_ROOT_CAUSE",
+        "location": null,
+        "target": null,
+        "action": null,
+        "repetition_count": 2
+      },
+      {
+        "severity": "error",
+        "category": "test",
+        "message": "TIMEOUT_ROOT_CAUSE",
+        "location": null,
+        "target": null,
+        "action": null,
+        "repetition_count": 2
+      },
+      {
+        "severity": "error",
+        "category": "test",
+        "message": "Test failed: //:fail",
+        "location": null,
+        "target": "//:fail",
+        "action": null,
+        "repetition_count": 1
+      },
+      {
+        "severity": "error",
+        "category": "test",
+        "message": "Test timed out: //:timeout",
+        "location": null,
+        "target": "//:timeout",
+        "action": null,
+        "repetition_count": 1
+      },
+      {
+        "severity": "error",
         "category": "unknown",
         "message": "FAILED: //:fail (Summary)",
         "location": null,
         "target": null,
+        "action": null,
+        "repetition_count": 1
+      },
+      {
+        "severity": "warning",
+        "category": "test",
+        "message": "Test was flaky: //:flaky",
+        "location": null,
+        "target": "//:flaky",
         "action": null,
         "repetition_count": 1
       }
@@ -50,7 +104,8 @@
         "attempts": 2,
         "shard": null,
         "cases": [],
-        "log_uri": "file://<OUTPUT_ROOT>_______________________________________________________________________________/90ef6f76d84382381adcd7adfcc3ad35/execroot/_main/bazel-out/darwin_arm64-fastbuild/testlogs/fail/test.log"
+        "test_log_available": false,
+        "test_log_unavailable_reason": "test_log_not_snapshotted"
       },
       {
         "label": "//:flaky",
@@ -59,7 +114,8 @@
         "attempts": 2,
         "shard": null,
         "cases": [],
-        "log_uri": "file://<OUTPUT_ROOT>_______________________________________________________________________________/90ef6f76d84382381adcd7adfcc3ad35/execroot/_main/bazel-out/darwin_arm64-fastbuild/testlogs/flaky/test_attempts/attempt_1.log"
+        "test_log_available": false,
+        "test_log_unavailable_reason": "test_log_not_snapshotted"
       },
       {
         "label": "//:pass",
@@ -68,7 +124,7 @@
         "attempts": 1,
         "shard": null,
         "cases": [],
-        "log_uri": null
+        "test_log_available": false
       },
       {
         "label": "//:sharded",
@@ -77,7 +133,7 @@
         "attempts": 1,
         "shard": 2,
         "cases": [],
-        "log_uri": null
+        "test_log_available": false
       },
       {
         "label": "//:timeout",
@@ -86,7 +142,8 @@
         "attempts": 2,
         "shard": null,
         "cases": [],
-        "log_uri": "file://<OUTPUT_ROOT>_______________________________________________________________________________/90ef6f76d84382381adcd7adfcc3ad35/execroot/_main/bazel-out/darwin_arm64-fastbuild/testlogs/timeout/test.log"
+        "test_log_available": false,
+        "test_log_unavailable_reason": "test_log_not_snapshotted"
       }
     ],
     "test_counts": {

--- a/crates/bazel-mcp-runner/Cargo.toml
+++ b/crates/bazel-mcp-runner/Cargo.toml
@@ -21,7 +21,6 @@ serde_json.workspace = true
 thiserror.workspace = true
 tokio.workspace = true
 tokio-util.workspace = true
-uuid.workspace = true
 tracing.workspace = true
 
 [dev-dependencies]

--- a/crates/bazel-mcp-runner/src/service.rs
+++ b/crates/bazel-mcp-runner/src/service.rs
@@ -1,5 +1,5 @@
 use std::{
-    collections::HashMap,
+    collections::{BTreeMap, HashMap},
     io,
     panic::{AssertUnwindSafe, catch_unwind},
     path::{Path, PathBuf},
@@ -15,7 +15,8 @@ use bazel_mcp_policy::{
     validate_workspace,
 };
 use bazel_mcp_reducer::{
-    Budget, StreamReductionOutput, normalize_terminal_text, parse_lcov_reader, parse_test_xml,
+    Budget, StreamReductionOutput, finalize_diagnostics, normalize_terminal_text,
+    parse_lcov_reader, parse_test_xml,
 };
 use bazel_mcp_store::{InvocationCompletion, InvocationPaths, Store, StoreError};
 use bazel_mcp_types::{
@@ -27,7 +28,7 @@ use bazel_mcp_types::{
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 use tokio::{
-    io::{AsyncReadExt, AsyncSeekExt},
+    io::{AsyncBufReadExt, AsyncWriteExt, BufReader},
     process::Command,
     sync::{Mutex, OwnedSemaphorePermit, Semaphore},
 };
@@ -146,6 +147,7 @@ pub enum InspectView {
     Summary,
     Diagnostics,
     Tests,
+    TestLog,
     Coverage,
     Artifacts,
     QueryResults,
@@ -164,43 +166,44 @@ pub struct InspectRequest {
     pub max_bytes: usize,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Serialize, Deserialize)]
 struct LogCursor {
     invocation_id: InvocationId,
-    end: u64,
+    view: InspectView,
+    next_record: u64,
+    filter: Option<String>,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+struct EvidenceRecord {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    label: Option<String>,
+    text: String,
 }
 
 impl LogCursor {
     fn encode(&self) -> Result<String, RunnerError> {
-        let mut bytes = Vec::with_capacity(26);
-        bytes.extend_from_slice(&[1, 5]);
-        bytes.extend_from_slice(self.invocation_id.as_uuid().as_bytes());
-        bytes.extend_from_slice(&self.end.to_le_bytes());
-        Ok(URL_SAFE_NO_PAD.encode(bytes))
+        Ok(URL_SAFE_NO_PAD.encode(serde_json::to_vec(self)?))
     }
 
     fn decode(value: &str) -> Result<Self, RunnerError> {
-        let bytes = URL_SAFE_NO_PAD
+        let raw = URL_SAFE_NO_PAD
             .decode(value)
             .map_err(|_| RunnerError::InvalidOffset)?;
-        if bytes.len() != 26 || bytes[0] != 1 || bytes[1] != 5 {
-            return Err(RunnerError::InvalidOffset);
-        }
-        let uuid = uuid::Uuid::from_slice(&bytes[2..18]).map_err(|_| RunnerError::InvalidOffset)?;
-        let end = u64::from_le_bytes(
-            bytes[18..26]
-                .try_into()
-                .map_err(|_| RunnerError::InvalidOffset)?,
-        );
-        Ok(Self {
-            invocation_id: InvocationId::from_uuid(uuid),
-            end,
-        })
+        serde_json::from_slice(&raw).map_err(|_| RunnerError::InvalidOffset)
     }
 
-    fn decode_for(value: &str, invocation_id: InvocationId) -> Result<Self, RunnerError> {
+    fn decode_for(
+        value: &str,
+        invocation_id: InvocationId,
+        view: InspectView,
+        filter: Option<&str>,
+    ) -> Result<Self, RunnerError> {
         let cursor = Self::decode(value)?;
-        if cursor.invocation_id != invocation_id {
+        if cursor.invocation_id != invocation_id
+            || cursor.view != view
+            || cursor.filter.as_deref() != filter
+        {
             return Err(RunnerError::InvalidOffset);
         }
         Ok(cursor)
@@ -781,7 +784,8 @@ impl InvocationService {
                     request.workspace.as_deref(),
                     PageRequest {
                         cursor: request.cursor,
-                        limit: request.limit.min(1),
+                        limit: request.limit.clamp(1, 100),
+                        max_bytes: Some(request.max_bytes.saturating_sub(512)),
                     },
                 )
                 .await?;
@@ -805,7 +809,8 @@ impl InvocationService {
         let record = self.store.get_invocation(id).await?;
         let page_request = PageRequest {
             cursor: request.cursor.clone(),
-            limit: bounded_page_limit(request.view, request.limit, request.max_bytes),
+            limit: request.limit.clamp(1, 100),
+            max_bytes: Some(request.max_bytes.saturating_sub(512)),
         };
         let paths = self.store.paths_for(&record);
         let (items, total_count, filtered_count, next_cursor, truncated) = match request.view {
@@ -915,6 +920,7 @@ impl InvocationService {
                             PageRequest {
                                 cursor: None,
                                 limit: request.limit,
+                                max_bytes: Some(request.max_bytes.saturating_sub(512)),
                             },
                         )
                         .await?;
@@ -951,10 +957,26 @@ impl InvocationService {
                 )
             }
             InspectView::Log => {
-                let (content, truncated, next_cursor) =
-                    self.read_combined_log_page(&paths, &request).await?;
+                let (items, truncated, next_cursor) = self
+                    .read_evidence_page(&paths.evidence, &paths, &request)
+                    .await?;
                 (
-                    serde_json::json!([content]),
+                    serde_json::to_value(items)?,
+                    None,
+                    None,
+                    next_cursor,
+                    truncated,
+                )
+            }
+            InspectView::TestLog => {
+                let (items, truncated, next_cursor) = if paths.test_log_evidence.exists() {
+                    self.read_evidence_page(&paths.test_log_evidence, &paths, &request)
+                        .await?
+                } else {
+                    self.read_test_log_unavailable_page(id, &request).await?
+                };
+                (
+                    serde_json::to_value(items)?,
                     None,
                     None,
                     next_cursor,
@@ -1046,8 +1068,11 @@ impl InvocationService {
                     "--show_progress=false",
                     "--show_result=0",
                 ]);
-            if queued.request.command == BazelCommand::Test {
-                command.args(["--test_output=summary", "--test_summary=none"]);
+            if matches!(
+                queued.request.command,
+                BazelCommand::Test | BazelCommand::Coverage
+            ) {
+                command.args(["--test_output=errors", "--test_summary=none"]);
             }
         }
         command.args(&queued.request.arguments);
@@ -1176,6 +1201,7 @@ impl InvocationService {
                             PageRequest {
                                 cursor: None,
                                 limit: 3,
+                                max_bytes: None,
                             },
                             move |value| redactor.redact_bounded(value, 4 * 1024),
                         )
@@ -1198,13 +1224,28 @@ impl InvocationService {
             let stdout = capture::read_bounded_tail(&paths.stdout, log_limit).await?;
             let stderr = capture::read_bounded_tail(&paths.stderr, log_limit).await?;
             let exit_code = status.as_ref().and_then(ExitStatus::code);
+            self.persist_failure_evidence(
+                paths,
+                &queued.request.workspace,
+                &queued.request.command,
+                exit_code != Some(0),
+                &stdout,
+                &stderr,
+            )
+            .await?;
             let reduced = catch_unwind(AssertUnwindSafe(|| {
                 bep.finish(
                     &stdout,
                     &stderr,
                     exit_code,
                     bazel_wall_ms,
-                    Budget::result_default(),
+                    // Enrichment can add higher-value failed-test evidence.
+                    // Apply the public result budget only after that evidence
+                    // is present so ranking and aggregation precede limits.
+                    Budget {
+                        max_bytes: usize::MAX,
+                        max_items: usize::MAX,
+                    },
                 )
             }));
             let StreamReductionOutput {
@@ -1256,8 +1297,9 @@ impl InvocationService {
                     }
                 }
             }
-            self.enrich_tests(&queued.request.workspace, &mut summary, &artifacts)
+            self.enrich_tests(paths, &queued.request.workspace, &mut summary, &artifacts)
                 .await;
+            finalize_diagnostics(&mut summary, Budget::result_default());
             if queued.request.command == BazelCommand::Coverage {
                 summary.coverage = self
                     .load_coverage(&queued.request.workspace, &artifacts)
@@ -1265,8 +1307,9 @@ impl InvocationService {
             }
             self.sanitize_summary(queued.request.id, &queued.request.workspace, &mut summary);
             let metrics = InvocationMetrics {
-                raw_stdout_bytes: capture::file_size(&paths.stdout).await,
-                raw_stderr_bytes: capture::file_size(&paths.stderr).await,
+                raw_output_bytes: capture::file_size(&paths.stdout)
+                    .await
+                    .saturating_add(capture::file_size(&paths.stderr).await),
                 bep_bytes: capture::file_size(&paths.bep).await,
                 bep_events: u64::try_from(bep_outcome.event_count).unwrap_or(u64::MAX),
                 queue_ms,
@@ -1354,7 +1397,7 @@ impl InvocationService {
 
     fn sanitize_summary(
         &self,
-        id: InvocationId,
+        _id: InvocationId,
         workspace: &Path,
         summary: &mut bazel_mcp_types::InvocationSummary,
     ) {
@@ -1383,12 +1426,7 @@ impl InvocationService {
                 .as_deref()
                 .map(|action| sanitize(action, 1_000));
         }
-        if summary.diagnostics.len() > 20 {
-            summary.diagnostics.truncate(20);
-            summary.truncated = true;
-            summary.inspect_hint = Some("diagnostics".to_owned());
-        }
-        for (index, test) in summary.tests.iter_mut().enumerate() {
+        for test in &mut summary.tests {
             test.label = sanitize(&test.label, 1_000);
             for case in &mut test.cases {
                 case.name = sanitize(&case.name, 512);
@@ -1397,8 +1435,6 @@ impl InvocationService {
                     .as_deref()
                     .map(|message| sanitize(message, 1_000));
             }
-            test.log_uri = (test.status != TestStatus::Passed)
-                .then(|| format!("bazel://invocations/{id}/tests/{index}/failure-log"));
         }
         if let Some(coverage) = &mut summary.coverage {
             for file in &mut coverage.files {
@@ -1457,64 +1493,230 @@ impl InvocationService {
 
     async fn enrich_tests(
         &self,
+        paths: &InvocationPaths,
         workspace: &Path,
         summary: &mut bazel_mcp_types::InvocationSummary,
         artifacts: &[bazel_mcp_types::Artifact],
     ) {
-        let failed_test = summary
+        if !summary
             .tests
-            .iter_mut()
-            .find(|test| test.status != TestStatus::Passed);
-        let Some(test) = failed_test else {
+            .iter()
+            .any(|test| test.status != TestStatus::Passed)
+        {
+            return;
+        }
+
+        let raw_temporary = paths.test_logs_raw.with_extension("tmp");
+        let evidence_temporary = paths.test_log_evidence.with_extension("tmp");
+        if tokio::fs::try_exists(&paths.test_logs_raw)
+            .await
+            .unwrap_or(false)
+            || tokio::fs::try_exists(&paths.test_log_evidence)
+                .await
+                .unwrap_or(false)
+        {
+            for test in summary
+                .tests
+                .iter_mut()
+                .filter(|test| test.status != TestStatus::Passed)
+            {
+                test.test_log_available = false;
+                test.test_log_unavailable_reason =
+                    Some("test_log_snapshot_already_exists".to_owned());
+            }
+            return;
+        }
+
+        let raw = tokio::fs::OpenOptions::new()
+            .create_new(true)
+            .write(true)
+            .open(&raw_temporary)
+            .await;
+        let evidence = tokio::fs::OpenOptions::new()
+            .create_new(true)
+            .write(true)
+            .open(&evidence_temporary)
+            .await;
+        let (Ok(mut raw), Ok(mut evidence)) = (raw, evidence) else {
+            let _ = tokio::fs::remove_file(&raw_temporary).await;
+            let _ = tokio::fs::remove_file(&evidence_temporary).await;
+            set_test_log_unavailable(summary, "test_log_snapshot_failed");
             return;
         };
-        if let Some(xml) = artifacts.iter().find(|artifact| {
-            artifact.kind == ArtifactKind::TestLog && artifact.name.ends_with("test.xml")
-        }) && let Some(path) = self.validated_artifact_path(workspace, xml).await
+
+        let workspace_text = workspace.to_string_lossy();
+        let any_remote_test_log = artifacts.iter().any(|artifact| {
+            artifact.kind == ArtifactKind::TestLog
+                && artifact.name.ends_with("test.log")
+                && !artifact.locally_available
+        });
+        let mut diagnostics = Vec::new();
+        let mut copied_any = false;
+        for test in summary
+            .tests
+            .iter_mut()
+            .filter(|test| test.status != TestStatus::Passed)
         {
-            let small_enough = tokio::fs::metadata(&path)
-                .await
-                .is_ok_and(|metadata| metadata.len() <= 16 * 1024 * 1024);
-            if small_enough
-                && let Ok(contents) = tokio::fs::read_to_string(path).await
-                && let Ok(cases) = parse_test_xml(&contents)
+            if let Some(xml) = artifacts.iter().find(|artifact| {
+                artifact.kind == ArtifactKind::TestLog
+                    && artifact.name.ends_with("test.xml")
+                    && artifact_matches_test(artifact, &test.label)
+            }) && let Some(path) = self.validated_artifact_path(workspace, xml).await
             {
-                test.cases = cases
-                    .into_iter()
-                    .filter(|case| case.status != TestStatus::Passed)
-                    .take(20)
-                    .map(|mut case| {
-                        case.name = bounded_text(&case.name, 512);
-                        case.message = case.message.map(|message| bounded_text(&message, 1_000));
-                        case
-                    })
-                    .collect();
+                let small_enough = tokio::fs::metadata(&path)
+                    .await
+                    .is_ok_and(|metadata| metadata.len() <= 16 * 1024 * 1024);
+                if small_enough
+                    && let Ok(contents) = tokio::fs::read_to_string(path).await
+                    && let Ok(cases) = parse_test_xml(&contents)
+                {
+                    test.cases = cases
+                        .into_iter()
+                        .filter(|case| case.status != TestStatus::Passed)
+                        .take(20)
+                        .map(|mut case| {
+                            case.name = bounded_text(&case.name, 512);
+                            case.message =
+                                case.message.map(|message| bounded_text(&message, 1_000));
+                            case
+                        })
+                        .collect();
+                }
+            }
+
+            let matching_logs = artifacts.iter().filter(|artifact| {
+                artifact.kind == ArtifactKind::TestLog
+                    && artifact.name.ends_with("test.log")
+                    && artifact_matches_test(artifact, &test.label)
+            });
+            let mut saw_artifact = false;
+            let mut copied_for_test = false;
+            let mut saw_remote = false;
+            let mut actionable_excerpt = None::<String>;
+            for log in matching_logs {
+                saw_artifact = true;
+                if !log.locally_available {
+                    saw_remote = true;
+                    continue;
+                }
+                let Some(path) = self.validated_artifact_path(workspace, log).await else {
+                    continue;
+                };
+                let Ok(file) = tokio::fs::File::open(&path).await else {
+                    continue;
+                };
+                let marker = format!("\n===== {} :: {} =====\n", test.label, log.name);
+                if raw.write_all(marker.as_bytes()).await.is_err() {
+                    continue;
+                }
+                let mut reader = BufReader::new(file);
+                let mut line = Vec::new();
+                let mut complete = true;
+                loop {
+                    line.clear();
+                    let read = match reader.read_until(b'\n', &mut line).await {
+                        Ok(read) => read,
+                        Err(_) => {
+                            complete = false;
+                            break;
+                        }
+                    };
+                    if read == 0 {
+                        break;
+                    }
+                    if raw.write_all(&line).await.is_err() {
+                        complete = false;
+                        break;
+                    }
+                    for visible_line in normalize_terminal_text(&line).lines() {
+                        let visible_line = visible_line.trim();
+                        if visible_line.is_empty() {
+                            continue;
+                        }
+                        let text = self.redactor.redact_bounded(
+                            &visible_line.replace(workspace_text.as_ref(), "<workspace>"),
+                            4 * 1024,
+                        );
+                        if is_actionable_evidence(&text) {
+                            actionable_excerpt = Some(bounded_text(&text, 1_000));
+                        }
+                        let record = EvidenceRecord {
+                            label: Some(test.label.clone()),
+                            text: format!("[{}] {text}", test.label),
+                        };
+                        let Ok(mut encoded) = serde_json::to_vec(&record) else {
+                            complete = false;
+                            break;
+                        };
+                        encoded.push(b'\n');
+                        if evidence.write_all(&encoded).await.is_err() {
+                            complete = false;
+                            break;
+                        }
+                    }
+                    if !complete {
+                        break;
+                    }
+                }
+                if complete {
+                    copied_for_test = true;
+                    copied_any = true;
+                }
+            }
+            if copied_for_test {
+                test.test_log_available = true;
+                test.test_log_unavailable_reason = None;
+                if let Some(message) = actionable_excerpt {
+                    diagnostics.push(Diagnostic {
+                        severity: Severity::Error,
+                        category: DiagnosticCategory::Compilation,
+                        message,
+                        location: None,
+                        target: Some(test.label.clone()),
+                        action: None,
+                        repetition_count: 1,
+                    });
+                }
+            } else {
+                test.test_log_available = false;
+                test.test_log_unavailable_reason = Some(
+                    if saw_remote || (!saw_artifact && any_remote_test_log) {
+                        "remote_test_log_unavailable"
+                    } else if saw_artifact {
+                        "test_log_outside_allowed_roots_or_unreadable"
+                    } else {
+                        "test_log_not_found"
+                    }
+                    .to_owned(),
+                );
             }
         }
-        if test.cases.is_empty()
-            && let Some(log) = artifacts.iter().find(|artifact| {
-                artifact.kind == ArtifactKind::TestLog && artifact.name.ends_with("test.log")
-            })
-            && let Some(path) = self.validated_artifact_path(workspace, log).await
-            && let Ok(bytes) = capture::read_bounded_tail(&path, 64 * 1024).await
-        {
-            let text = normalize_terminal_text(&bytes);
-            if let Some(line) = text.lines().rev().find(|line| {
-                let lower = line.to_ascii_lowercase();
-                lower.contains("root_cause") || lower.contains("error:") || lower.contains("failed")
-            }) {
-                summary.diagnostics.push(Diagnostic {
-                    severity: Severity::Error,
-                    category: DiagnosticCategory::Test,
-                    message: bounded_text(line, 1_000),
-                    location: None,
-                    target: Some(test.label.clone()),
-                    action: None,
-                    repetition_count: 1,
-                });
+
+        let flushed = raw.flush().await.is_ok() && evidence.flush().await.is_ok();
+        drop(raw);
+        drop(evidence);
+        let committed = if copied_any {
+            flushed
+                && set_private_file(&raw_temporary).await.is_ok()
+                && set_private_file(&evidence_temporary).await.is_ok()
+                && tokio::fs::rename(&raw_temporary, &paths.test_logs_raw)
+                    .await
+                    .is_ok()
+                && tokio::fs::rename(&evidence_temporary, &paths.test_log_evidence)
+                    .await
+                    .is_ok()
+        } else {
+            false
+        };
+        if committed {
+            summary.diagnostics.extend(diagnostics);
+        } else {
+            let _ = tokio::fs::remove_file(&raw_temporary).await;
+            let _ = tokio::fs::remove_file(&evidence_temporary).await;
+            if copied_any {
+                set_test_log_unavailable(summary, "test_log_snapshot_failed");
             }
         }
-        test.log_uri = Some("bazel://invocation/tests/failure-log".to_owned());
     }
 
     async fn load_coverage(
@@ -1548,7 +1750,7 @@ impl InvocationService {
         artifact: &bazel_mcp_types::Artifact,
     ) -> Option<PathBuf> {
         let path = local_artifact_path(artifact)?;
-        let canonical = tokio::fs::canonicalize(path).await.ok()?;
+        let canonical = tokio::fs::canonicalize(&path).await.ok()?;
         let in_workspace = canonical.starts_with(workspace);
         let in_output_root = if let Some(root) = &self.config.output_user_root {
             tokio::fs::canonicalize(root)
@@ -1557,55 +1759,323 @@ impl InvocationService {
         } else {
             false
         };
-        (in_workspace || in_output_root).then_some(canonical)
+        let in_bazel_testlogs = if artifact.kind == ArtifactKind::TestLog {
+            match bazel_test_log_output_base(&path).zip(bazel_test_log_output_base(&canonical)) {
+                Some((lexical_root, canonical_root)) => tokio::fs::canonicalize(lexical_root)
+                    .await
+                    .is_ok_and(|lexical_root| {
+                        lexical_root == canonical_root && canonical.starts_with(&lexical_root)
+                    }),
+                None => false,
+            }
+        } else {
+            false
+        };
+        (in_workspace || in_output_root || in_bazel_testlogs).then_some(canonical)
     }
 
-    async fn read_combined_log_page(
+    async fn persist_failure_evidence(
         &self,
         paths: &InvocationPaths,
+        workspace: &Path,
+        command: &BazelCommand,
+        failed: bool,
+        stdout: &[u8],
+        stderr: &[u8],
+    ) -> Result<(), RunnerError> {
+        let records = failure_evidence_records(command, failed, stdout, stderr);
+        let workspace = workspace.to_string_lossy();
+        let mut bytes = Vec::new();
+        for mut record in records {
+            record.text = self.redactor.redact_bounded(
+                &record.text.replace(workspace.as_ref(), "<workspace>"),
+                4 * 1024,
+            );
+            serde_json::to_writer(&mut bytes, &record)?;
+            bytes.push(b'\n');
+        }
+        write_private_atomic(&paths.evidence, &bytes).await?;
+        Ok(())
+    }
+
+    async fn read_evidence_page(
+        &self,
+        path: &Path,
+        paths: &InvocationPaths,
         request: &InspectRequest,
-    ) -> Result<(Option<String>, bool, Option<String>), RunnerError> {
+    ) -> Result<(Vec<String>, bool, Option<String>), RunnerError> {
         let invocation_id = request.invocation_id.ok_or(StoreError::InvalidCursor)?;
-        let stderr_length = tokio::fs::metadata(&paths.stderr)
-            .await
-            .map_or(0, |metadata| metadata.len());
-        let path = if stderr_length > 0 {
-            &paths.stderr
-        } else {
-            &paths.stdout
-        };
-        let length = tokio::fs::metadata(path)
-            .await
-            .map_or(0, |metadata| metadata.len());
-        let end = request
+        let start = request
             .cursor
             .as_deref()
-            .map(|value| LogCursor::decode_for(value, invocation_id))
-            .transpose()?
-            .map_or(length, |cursor| cursor.end);
-        if end > length {
-            return Err(RunnerError::InvalidOffset);
-        }
-        let max_bytes = request.max_bytes.saturating_sub(512).clamp(1, 32 * 1024) as u64;
-        let start = end.saturating_sub(max_bytes);
-        let mut file = tokio::fs::File::open(path).await?;
-        file.seek(std::io::SeekFrom::Start(start)).await?;
-        let mut bytes = vec![0_u8; usize::try_from(end - start).unwrap_or(32 * 1024)];
-        file.read_exact(&mut bytes).await?;
-        let content = normalize_terminal_text(&bytes);
-        let content = self
-            .redactor
-            .redact_bounded(&content, usize::try_from(max_bytes).unwrap_or(32 * 1024));
-        let truncated = start > 0;
-        let next_cursor = truncated
-            .then_some(LogCursor {
-                invocation_id,
-                end: start,
+            .map(|value| {
+                LogCursor::decode_for(
+                    value,
+                    invocation_id,
+                    request.view,
+                    request.filter.as_deref(),
+                )
             })
-            .map(|cursor| cursor.encode())
-            .transpose()?;
-        Ok((Some(content), truncated, next_cursor))
+            .transpose()?
+            .map_or(0, |cursor| cursor.next_record);
+        let file = match tokio::fs::File::open(path).await {
+            Ok(file) => file,
+            Err(error)
+                if error.kind() == io::ErrorKind::NotFound && request.view == InspectView::Log =>
+            {
+                let stdout = capture::read_bounded_tail(&paths.stdout, 1024 * 1024).await?;
+                let stderr = capture::read_bounded_tail(&paths.stderr, 1024 * 1024).await?;
+                let records = failure_evidence_records(
+                    &BazelCommand::Custom("retained".to_owned()),
+                    true,
+                    &stdout,
+                    &stderr,
+                );
+                return page_evidence_records(records.into_iter(), start, request, invocation_id);
+            }
+            Err(error) => return Err(error.into()),
+        };
+        let mut lines = BufReader::new(file).lines();
+        let mut records = Vec::new();
+        while let Some(line) = lines.next_line().await? {
+            records.push(serde_json::from_str::<EvidenceRecord>(&line)?);
+        }
+        page_evidence_records(records.into_iter(), start, request, invocation_id)
     }
+
+    async fn read_test_log_unavailable_page(
+        &self,
+        invocation_id: InvocationId,
+        request: &InspectRequest,
+    ) -> Result<(Vec<String>, bool, Option<String>), RunnerError> {
+        let start = request
+            .cursor
+            .as_deref()
+            .map(|value| {
+                LogCursor::decode_for(
+                    value,
+                    invocation_id,
+                    request.view,
+                    request.filter.as_deref(),
+                )
+            })
+            .transpose()?
+            .map_or(0, |cursor| cursor.next_record);
+        let maximum_bytes = request.max_bytes.saturating_sub(512).max(1);
+        let maximum_items = usize::try_from(request.limit.clamp(1, 100)).unwrap_or(100);
+        let filter = request.filter.as_deref().map(str::to_ascii_lowercase);
+        let mut items = Vec::new();
+        let mut used_bytes = 2_usize;
+        let mut reason_index = 0_u64;
+        let mut storage_cursor = None;
+
+        loop {
+            let (page, _, _) = self
+                .store
+                .page_tests(
+                    invocation_id,
+                    None,
+                    PageRequest {
+                        cursor: storage_cursor,
+                        limit: 100,
+                        max_bytes: Some(128 * 1024),
+                    },
+                )
+                .await?;
+            for test in page.items {
+                let Some(reason) = test.test_log_unavailable_reason else {
+                    continue;
+                };
+                let index = reason_index;
+                reason_index = reason_index.saturating_add(1);
+                if index < start {
+                    continue;
+                }
+                let text = self
+                    .redactor
+                    .redact_bounded(&format!("{}: {reason}", test.label), 4 * 1024);
+                if !filter
+                    .as_ref()
+                    .is_none_or(|filter| text.to_ascii_lowercase().contains(filter))
+                {
+                    continue;
+                }
+                let item_bytes = serde_json::to_vec(&text)?.len();
+                let separator = usize::from(!items.is_empty());
+                if items.len() == maximum_items
+                    || (!items.is_empty()
+                        && used_bytes
+                            .saturating_add(separator)
+                            .saturating_add(item_bytes)
+                            > maximum_bytes)
+                {
+                    let next_cursor = LogCursor {
+                        invocation_id,
+                        view: request.view,
+                        next_record: index,
+                        filter: request.filter.clone(),
+                    }
+                    .encode()?;
+                    return Ok((items, true, Some(next_cursor)));
+                }
+                used_bytes = used_bytes
+                    .saturating_add(separator)
+                    .saturating_add(item_bytes);
+                items.push(text);
+            }
+            if !page.truncated {
+                return Ok((items, false, None));
+            }
+            storage_cursor = page.next_cursor;
+        }
+    }
+}
+
+fn page_evidence_records(
+    records: impl Iterator<Item = EvidenceRecord>,
+    start: u64,
+    request: &InspectRequest,
+    invocation_id: InvocationId,
+) -> Result<(Vec<String>, bool, Option<String>), RunnerError> {
+    let maximum_bytes = request.max_bytes.saturating_sub(512).max(1);
+    let maximum_items = usize::try_from(request.limit.clamp(1, 100)).unwrap_or(100);
+    let filter = request.filter.as_deref().map(str::to_ascii_lowercase);
+    let mut items = Vec::new();
+    let mut used_bytes = 2_usize;
+    let mut next_record = start;
+    let mut truncated = false;
+    for (index, record) in records.enumerate() {
+        let index = u64::try_from(index).unwrap_or(u64::MAX);
+        if index < start {
+            continue;
+        }
+        let matches = filter.as_ref().is_none_or(|filter| {
+            record.text.to_ascii_lowercase().contains(filter)
+                || record
+                    .label
+                    .as_deref()
+                    .is_some_and(|label| label.to_ascii_lowercase().contains(filter))
+        });
+        if !matches {
+            next_record = index.saturating_add(1);
+            continue;
+        }
+        let item_bytes = serde_json::to_vec(&record.text)?.len();
+        let separator = usize::from(!items.is_empty());
+        if items.len() == maximum_items
+            || (!items.is_empty()
+                && used_bytes
+                    .saturating_add(separator)
+                    .saturating_add(item_bytes)
+                    > maximum_bytes)
+        {
+            next_record = index;
+            truncated = true;
+            break;
+        }
+        used_bytes = used_bytes
+            .saturating_add(separator)
+            .saturating_add(item_bytes);
+        items.push(record.text);
+        next_record = index.saturating_add(1);
+    }
+    let next_cursor = truncated
+        .then_some(LogCursor {
+            invocation_id,
+            view: request.view,
+            next_record,
+            filter: request.filter.clone(),
+        })
+        .map(|cursor| cursor.encode())
+        .transpose()?;
+    Ok((items, truncated, next_cursor))
+}
+
+fn failure_evidence_records(
+    command: &BazelCommand,
+    failed: bool,
+    stdout: &[u8],
+    stderr: &[u8],
+) -> Vec<EvidenceRecord> {
+    let test_like = matches!(command, BazelCommand::Test | BazelCommand::Coverage);
+    let streams = if (failed && test_like) || (!failed && !stdout.is_empty()) {
+        [stdout, stderr]
+    } else {
+        [stderr, stdout]
+    };
+    let mut positions = BTreeMap::<String, usize>::new();
+    let mut lines = Vec::<(String, u32)>::new();
+    for stream in streams {
+        for line in normalize_terminal_text(stream).lines() {
+            let line = line.trim();
+            if line.is_empty() {
+                continue;
+            }
+            let line = bounded_text(line, 4 * 1024);
+            if let Some(index) = positions.get(&line).copied() {
+                lines[index].1 = lines[index].1.saturating_add(1);
+            } else {
+                positions.insert(line.clone(), lines.len());
+                lines.push((line, 1));
+            }
+        }
+    }
+    let mut actionable = Vec::new();
+    let mut fallback = Vec::new();
+    for (line, count) in lines {
+        let record = EvidenceRecord {
+            label: None,
+            text: if count > 1 {
+                format!("{line} [repeated {count} times]")
+            } else {
+                line
+            },
+        };
+        if is_actionable_evidence(&record.text) {
+            actionable.push(record);
+        } else {
+            fallback.push(record);
+        }
+    }
+    let fallback_start = fallback.len().saturating_sub(2_000);
+    actionable.truncate(1_000);
+    actionable.extend(fallback.into_iter().skip(fallback_start));
+    actionable.truncate(3_000);
+    actionable
+}
+
+fn is_actionable_evidence(line: &str) -> bool {
+    let lower = line.to_ascii_lowercase();
+    lower.contains("error:")
+        || lower.starts_with("error ")
+        || lower.contains("failed:")
+        || lower.contains("failure")
+        || lower.contains("fatal:")
+        || lower.contains("no such target")
+        || lower.contains("no such package")
+        || lower.contains("undefined reference")
+        || lower.contains("root_cause")
+}
+
+async fn write_private_atomic(path: &Path, bytes: &[u8]) -> Result<(), io::Error> {
+    let temporary = path.with_extension("tmp");
+    let mut file = tokio::fs::File::create(&temporary).await?;
+    file.write_all(bytes).await?;
+    file.flush().await?;
+    drop(file);
+    set_private_file(&temporary).await?;
+    tokio::fs::rename(temporary, path).await
+}
+
+#[cfg(unix)]
+async fn set_private_file(path: &Path) -> Result<(), io::Error> {
+    use std::os::unix::fs::PermissionsExt;
+    tokio::fs::set_permissions(path, std::fs::Permissions::from_mode(0o600)).await
+}
+
+#[cfg(not(unix))]
+async fn set_private_file(_path: &Path) -> Result<(), io::Error> {
+    Ok(())
 }
 
 fn local_artifact_path(artifact: &bazel_mcp_types::Artifact) -> Option<PathBuf> {
@@ -1619,6 +2089,57 @@ fn local_artifact_path(artifact: &bazel_mcp_types::Artifact) -> Option<PathBuf> 
     path.is_absolute().then_some(path)
 }
 
+fn artifact_matches_test(artifact: &bazel_mcp_types::Artifact, label: &str) -> bool {
+    let label = label.rsplit_once("//").map_or(label, |(_, label)| label);
+    let (package, target) = label
+        .split_once(':')
+        .map_or(("", label.trim_start_matches("//")), |(package, target)| {
+            (package.trim_start_matches("//"), target)
+        });
+    let fragment = if package.is_empty() {
+        format!("/testlogs/{target}/")
+    } else {
+        format!("/testlogs/{package}/{target}/")
+    };
+    artifact.uri.replace('\\', "/").contains(&fragment)
+}
+
+fn bazel_test_log_output_base(path: &Path) -> Option<PathBuf> {
+    let components = path.components().collect::<Vec<_>>();
+    let execroot = components
+        .iter()
+        .position(|component| component.as_os_str() == "execroot")?;
+    let bazel_out = components
+        .iter()
+        .enumerate()
+        .skip(execroot + 1)
+        .find(|(_, component)| component.as_os_str() == "bazel-out")?
+        .0;
+    components
+        .iter()
+        .enumerate()
+        .skip(bazel_out + 1)
+        .find(|(_, component)| component.as_os_str() == "testlogs")?;
+    if !matches!(
+        path.extension().and_then(|value| value.to_str()),
+        Some("log" | "xml")
+    ) {
+        return None;
+    }
+    Some(components[..execroot].iter().collect())
+}
+
+fn set_test_log_unavailable(summary: &mut bazel_mcp_types::InvocationSummary, reason: &str) {
+    for test in summary
+        .tests
+        .iter_mut()
+        .filter(|test| test.status != TestStatus::Passed)
+    {
+        test.test_log_available = false;
+        test.test_log_unavailable_reason = Some(reason.to_owned());
+    }
+}
+
 fn bounded_text(value: &str, maximum_bytes: usize) -> String {
     if value.len() <= maximum_bytes {
         return value.to_owned();
@@ -1628,21 +2149,6 @@ fn bounded_text(value: &str, maximum_bytes: usize) -> String {
         boundary -= 1;
     }
     format!("{}…", &value[..boundary])
-}
-
-fn bounded_page_limit(view: InspectView, requested: u32, max_bytes: usize) -> u32 {
-    let estimated_item_bytes = match view {
-        InspectView::Summary | InspectView::Tests | InspectView::Invocations => max_bytes.max(1),
-        InspectView::Diagnostics => 5_000,
-        InspectView::Coverage => 1_500,
-        InspectView::Artifacts => 2_500,
-        InspectView::QueryResults => 4_500,
-        InspectView::Log => max_bytes.max(1),
-    };
-    let budgeted = u32::try_from(max_bytes / estimated_item_bytes)
-        .unwrap_or(u32::MAX)
-        .max(1);
-    requested.clamp(1, 100).min(budgeted)
 }
 
 fn enforce_inspect_budget(
@@ -1868,6 +2374,140 @@ mod tests {
         assert_eq!(
             local_artifact_path(&artifact),
             Some(PathBuf::from("/tmp/bazel-out/test.xml"))
+        );
+    }
+
+    #[test]
+    fn log_evidence_is_automatic_deduplicated_and_encoding_neutral() {
+        let records = failure_evidence_records(
+            &BazelCommand::Test,
+            true,
+            b"TEST_ROOT_CAUSE\nordinary stdout\n",
+            b"ERROR: build wrapper\nTEST_ROOT_CAUSE\nordinary stderr\n",
+        );
+        assert_eq!(records[0].text, "TEST_ROOT_CAUSE [repeated 2 times]");
+        assert!(
+            records
+                .iter()
+                .any(|record| record.text == "ordinary stdout")
+        );
+        assert!(
+            records
+                .iter()
+                .any(|record| record.text == "ordinary stderr")
+        );
+        let public = records
+            .iter()
+            .map(|record| record.text.clone())
+            .collect::<Vec<_>>();
+        let value = serde_json::to_value(public).unwrap();
+        assert!(
+            value
+                .as_array()
+                .unwrap()
+                .iter()
+                .all(|item| item.is_string())
+        );
+        assert!(!value.to_string().contains("\"stdout\":"));
+        assert!(!value.to_string().contains("\"stderr\":"));
+    }
+
+    #[test]
+    fn evidence_cursor_advances_after_last_emitted_item_without_gaps() {
+        let id = InvocationId::new();
+        let records = (0..7)
+            .map(|index| EvidenceRecord {
+                label: None,
+                text: format!("ERROR: item {index}"),
+            })
+            .collect::<Vec<_>>();
+        let mut request = InspectRequest {
+            invocation_id: Some(id),
+            workspace: None,
+            view: InspectView::Log,
+            cursor: None,
+            filter: None,
+            limit: 2,
+            max_bytes: 8 * 1024,
+        };
+        let mut observed = Vec::new();
+        loop {
+            let start = request
+                .cursor
+                .as_deref()
+                .map(|cursor| LogCursor::decode_for(cursor, id, InspectView::Log, None).unwrap())
+                .map_or(0, |cursor| cursor.next_record);
+            let (items, truncated, cursor) =
+                page_evidence_records(records.clone().into_iter(), start, &request, id).unwrap();
+            observed.extend(items);
+            request.cursor = cursor;
+            if !truncated {
+                break;
+            }
+        }
+        assert_eq!(
+            observed,
+            (0..7)
+                .map(|index| format!("ERROR: item {index}"))
+                .collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn associates_test_artifacts_without_exposing_a_public_uri() {
+        let artifact = bazel_mcp_types::Artifact {
+            name: "test.log".into(),
+            kind: ArtifactKind::TestLog,
+            uri: "file:///tmp/output/execroot/ws/bazel-out/testlogs/pkg/failing/test.log".into(),
+            size_bytes: None,
+            locally_available: true,
+        };
+        assert!(artifact_matches_test(&artifact, "//pkg:failing"));
+        assert!(!artifact_matches_test(&artifact, "//pkg:passing"));
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn default_bazel_testlog_containment_accepts_real_paths_and_rejects_symlink_escapes() {
+        use std::os::unix::fs::symlink;
+
+        let root = tempdir().unwrap();
+        let store = Store::open(root.path().join("store")).await.unwrap();
+        let service = InvocationService::new(store, RunnerConfig::default()).unwrap();
+        let workspace = root.path().join("workspace");
+        let testlogs = root
+            .path()
+            .join("output-base/execroot/ws/bazel-out/config/testlogs/pkg/test");
+        tokio::fs::create_dir_all(&workspace).await.unwrap();
+        tokio::fs::create_dir_all(&testlogs).await.unwrap();
+        let safe = testlogs.join("test.log");
+        tokio::fs::write(&safe, "failure").await.unwrap();
+        let artifact = bazel_mcp_types::Artifact {
+            name: "test.log".into(),
+            kind: ArtifactKind::TestLog,
+            uri: format!("file://{}", safe.display()),
+            size_bytes: None,
+            locally_available: true,
+        };
+        let canonical_safe = tokio::fs::canonicalize(&safe).await.unwrap();
+        assert_eq!(
+            service.validated_artifact_path(&workspace, &artifact).await,
+            Some(canonical_safe)
+        );
+
+        let outside = root.path().join("outside.log");
+        tokio::fs::write(&outside, "secret").await.unwrap();
+        let escaped = testlogs.join("escaped.log");
+        symlink(&outside, &escaped).unwrap();
+        let escaped_artifact = bazel_mcp_types::Artifact {
+            uri: format!("file://{}", escaped.display()),
+            ..artifact
+        };
+        assert_eq!(
+            service
+                .validated_artifact_path(&workspace, &escaped_artifact)
+                .await,
+            None
         );
     }
 }

--- a/crates/bazel-mcp-runner/tests/process.rs
+++ b/crates/bazel-mcp-runner/tests/process.rs
@@ -6,6 +6,11 @@ use std::{
     time::{Duration, Instant},
 };
 
+use bazel_mcp_bep::proto::{
+    BuildEvent, BuildEventId, File, TestResult as BepTestResult, TestSummary as BepTestSummary,
+    build_event, build_event_id, file,
+};
+use bazel_mcp_bep::{encode_event_id, encode_frame};
 use bazel_mcp_policy::PolicyConfig;
 use bazel_mcp_runner::{InspectRequest, InspectView, InvocationService, RunnerConfig};
 use bazel_mcp_store::Store;
@@ -16,6 +21,53 @@ use bazel_mcp_types::{
 };
 use tempfile::TempDir;
 use tokio_util::sync::CancellationToken;
+
+fn failed_test_bep(log_uri: &str, xml_uri: &str) -> Vec<u8> {
+    let output = |name: &str, uri: &str| File {
+        name: name.to_owned(),
+        file: Some(file::File::Uri(uri.to_owned())),
+        ..Default::default()
+    };
+    let result = BuildEvent {
+        id: encode_event_id(&BuildEventId {
+            id: Some(build_event_id::Id::TestResult(Box::new(
+                build_event_id::TestResultId {
+                    label: "//pkg:failing".into(),
+                    run: 1,
+                    attempt: 1,
+                    ..Default::default()
+                },
+            ))),
+        }),
+        payload: Some(build_event::Payload::TestResult(Box::new(BepTestResult {
+            test_action_output: vec![output("test.log", log_uri), output("test.xml", xml_uri)],
+            status: 4,
+            ..Default::default()
+        }))),
+        ..Default::default()
+    };
+    let summary = BuildEvent {
+        id: encode_event_id(&BuildEventId {
+            id: Some(build_event_id::Id::TestSummary(Box::new(
+                build_event_id::TestSummaryId {
+                    label: "//pkg:failing".into(),
+                    ..Default::default()
+                },
+            ))),
+        }),
+        payload: Some(build_event::Payload::TestSummary(Box::new(
+            BepTestSummary {
+                failed: vec![output("test.log", log_uri)],
+                overall_status: 4,
+                total_run_duration_millis: 12,
+                attempt_count: 1,
+                ..Default::default()
+            },
+        ))),
+        ..Default::default()
+    };
+    [encode_frame(&result), encode_frame(&summary)].concat()
+}
 
 async fn wait_for_path(path: &Path) {
     for _ in 0..500 {
@@ -151,6 +203,19 @@ async fn redacts_secrets_from_metadata_normalized_rows_and_log_inspection() {
             .unwrap();
         assert!(!serde_json::to_string(&inspected).unwrap().contains(secret));
     }
+    let secret_filter = service
+        .inspect(InspectRequest {
+            invocation_id: Some(id),
+            workspace: None,
+            view: InspectView::Log,
+            cursor: None,
+            filter: Some("SUPERSECRET".into()),
+            limit: 20,
+            max_bytes: 8 * 1024,
+        })
+        .await
+        .unwrap();
+    assert!(secret_filter.items.as_array().unwrap().is_empty());
 
     service
         .store()
@@ -262,6 +327,134 @@ async fn log_inspection_uses_bounded_opaque_cursors() {
         })
         .await;
     assert!(invalid.is_err());
+
+    let filtered = service
+        .inspect(InspectRequest {
+            invocation_id: Some(id),
+            workspace: None,
+            view: InspectView::Log,
+            cursor: None,
+            filter: Some("LINE-150".into()),
+            limit: 20,
+            max_bytes: 1024,
+        })
+        .await
+        .unwrap();
+    assert_eq!(filtered.items.as_array().unwrap().len(), 1);
+    assert!(filtered.items[0].as_str().unwrap().contains("line-150"));
+
+    let unmatched = service
+        .inspect(InspectRequest {
+            invocation_id: Some(id),
+            workspace: None,
+            view: InspectView::Log,
+            cursor: None,
+            filter: Some("not-present".into()),
+            limit: 20,
+            max_bytes: 1024,
+        })
+        .await
+        .unwrap();
+    assert!(unmatched.items.as_array().unwrap().is_empty());
+}
+
+#[tokio::test]
+async fn failed_test_logs_are_snapshotted_and_retrieved_without_a_public_uri() {
+    let root = tempfile::tempdir().unwrap();
+    let workspace = root.path().join("workspace");
+    let output_root = root.path().join("output-user-root");
+    let test_directory = output_root.join("execroot/ws/bazel-out/testlogs/pkg/failing");
+    tokio::fs::create_dir_all(&workspace).await.unwrap();
+    tokio::fs::create_dir_all(&test_directory).await.unwrap();
+    let test_log = test_directory.join("test.log");
+    let test_xml = test_directory.join("test.xml");
+    tokio::fs::write(
+        &test_log,
+        "setup\nassertion error: SNAPSHOT_TEST_ROOT_CAUSE\n",
+    )
+    .await
+    .unwrap();
+    tokio::fs::write(
+        &test_xml,
+        r#"<testsuites><testsuite><testcase name="failing_case" time="0.01"><failure message="expected true"/></testcase></testsuite></testsuites>"#,
+    )
+    .await
+    .unwrap();
+    let bep = root.path().join("failed-test.bep");
+    tokio::fs::write(
+        &bep,
+        failed_test_bep(
+            &format!("file://{}", test_log.display()),
+            &format!("file://{}", test_xml.display()),
+        ),
+    )
+    .await
+    .unwrap();
+    let flag_marker = root.path().join("saw-test-output-errors");
+    let failed_once = root.path().join("failed-once");
+    let script = format!(
+        "#!/bin/sh\nif [ \"${{1:-}}\" = --version ]; then echo 'bazel 9.1.0'; exit 0; fi\nfor arg in \"$@\"; do\n  case \"$arg\" in\n    --build_event_binary_file=*) bep_path=${{arg#*=}} ;;\n    --test_output=errors) touch '{}' ;;\n  esac\ndone\nif [ -f '{}' ]; then : > \"$bep_path\"; exit 0; fi\ncp '{}' \"$bep_path\"\ntouch '{}'\necho 'SNAPSHOT_TEST_ROOT_CAUSE'\nexit 1\n",
+        flag_marker.display(),
+        failed_once.display(),
+        bep.display(),
+        failed_once.display(),
+    );
+    let service = configured_service(&root, &workspace, &script, |_| {}).await;
+
+    let failed = service
+        .run(InvocationRequest::new(
+            workspace.clone(),
+            BazelCommand::Test,
+            vec!["//pkg:failing".into()],
+        ))
+        .await
+        .unwrap();
+    assert_eq!(failed.state, InvocationState::Failed);
+    assert!(flag_marker.exists());
+    let summary = failed.summary.as_ref().unwrap();
+    assert!(summary.headline.contains("SNAPSHOT_TEST_ROOT_CAUSE"));
+    assert!(summary.tests[0].test_log_available);
+    assert_eq!(summary.tests[0].cases[0].name, "failing_case");
+    assert!(!serde_json::to_string(summary).unwrap().contains("log_uri"));
+
+    let inspected = service
+        .inspect(InspectRequest {
+            invocation_id: Some(failed.request.id),
+            workspace: None,
+            view: InspectView::TestLog,
+            cursor: None,
+            filter: Some("//PKG:FAILING".into()),
+            limit: 20,
+            max_bytes: 8 * 1024,
+        })
+        .await
+        .unwrap();
+    let items = inspected.items.as_array().unwrap();
+    assert!(items.iter().all(serde_json::Value::is_string));
+    assert!(
+        items
+            .iter()
+            .any(|item| item.as_str().unwrap().contains("SNAPSHOT_TEST_ROOT_CAUSE"))
+    );
+
+    let failed_paths = service.store().paths_for(&failed);
+    let retained_before = tokio::fs::read(&failed_paths.test_logs_raw).await.unwrap();
+    assert!(String::from_utf8_lossy(&retained_before).contains("SNAPSHOT_TEST_ROOT_CAUSE"));
+    tokio::fs::remove_file(&flag_marker).await.unwrap();
+    let passing = service
+        .run(InvocationRequest::new(
+            workspace,
+            BazelCommand::Coverage,
+            vec!["//pkg:failing".into()],
+        ))
+        .await
+        .unwrap();
+    assert_eq!(passing.state, InvocationState::Succeeded);
+    assert!(flag_marker.exists());
+    assert_eq!(
+        tokio::fs::read(&failed_paths.test_logs_raw).await.unwrap(),
+        retained_before
+    );
 }
 
 #[tokio::test]
@@ -721,7 +914,7 @@ async fn query_and_informational_commands_return_bounded_initial_evidence() {
             .headline
             .contains("//pkg:first")
     );
-    assert!(informational.metrics.raw_stdout_bytes > 0);
+    assert!(informational.metrics.raw_output_bytes > 0);
 }
 
 #[tokio::test]
@@ -775,7 +968,8 @@ async fn inspect_shrinks_nested_results_to_the_hard_byte_budget() {
             attempts: 1,
             shard: None,
             cases,
-            log_uri: None,
+            test_log_available: false,
+            test_log_unavailable_reason: Some("test_log_not_found".into()),
         }],
         ..InvocationSummary::default()
     };
@@ -806,6 +1000,22 @@ async fn inspect_shrinks_nested_results_to_the_hard_byte_budget() {
         assert!(result.truncated);
         assert!(serde_json::to_vec(&result).unwrap().len() <= 8 * 1024);
     }
+    let unavailable = service
+        .inspect(InspectRequest {
+            invocation_id: Some(id),
+            workspace: None,
+            view: InspectView::TestLog,
+            cursor: None,
+            filter: Some("//PKG:TEST".into()),
+            limit: 20,
+            max_bytes: 8 * 1024,
+        })
+        .await
+        .unwrap();
+    assert_eq!(
+        unavailable.items,
+        serde_json::json!(["//pkg:test: test_log_not_found"])
+    );
 }
 
 #[tokio::test]

--- a/crates/bazel-mcp-server/src/handler.rs
+++ b/crates/bazel-mcp-server/src/handler.rs
@@ -62,7 +62,7 @@ pub struct RunParams {
 pub struct InspectParams {
     /// UUID returned by bazel.run.
     pub invocation_id: String,
-    /// summary, diagnostics, tests, coverage, artifacts, query_results, or log.
+    /// summary, diagnostics, tests, coverage, artifacts, query_results, log, or test_log.
     pub view: String,
     /// Optional literal substring or label glob filter.
     pub filter: Option<String>,
@@ -87,8 +87,6 @@ struct RunResult<'a> {
     command: &'a str,
     exit_code: Option<i32>,
     duration_ms: u64,
-    stdout_bytes: u64,
-    stderr_bytes: u64,
     headline: &'a str,
     targets: TargetCounts,
     tests: TestCounts,
@@ -228,6 +226,7 @@ impl BazelMcpServer {
             "diagnostics" => InspectView::Diagnostics,
             "tests" => InspectView::Tests,
             "log" => InspectView::Log,
+            "test_log" => InspectView::TestLog,
             "coverage" => InspectView::Coverage,
             "artifacts" => InspectView::Artifacts,
             "query_results" => InspectView::QueryResults,
@@ -323,8 +322,6 @@ impl BazelMcpServer {
                 command: record.request.command.as_str(),
                 exit_code,
                 duration_ms: record.metrics.bazel_wall_ms,
-                stdout_bytes: record.metrics.raw_stdout_bytes,
-                stderr_bytes: record.metrics.raw_stderr_bytes,
                 headline: &summary.headline,
                 targets: summary.target_counts.clone(),
                 tests: summary.test_counts.clone(),
@@ -339,6 +336,7 @@ impl BazelMcpServer {
                     "summary",
                     "diagnostics",
                     "tests",
+                    "test_log",
                     "coverage",
                     "artifacts",
                     "query_results",
@@ -1100,7 +1098,11 @@ impl Service<RoleServer> for BazelMcpServer {
                     .runner
                     .list_deferred_results(
                         DeferredRetrieval::SeparateResult,
-                        PageRequest { cursor, limit: 100 },
+                        PageRequest {
+                            cursor,
+                            limit: 100,
+                            max_bytes: None,
+                        },
                     )
                     .await
                     .map_err(|error| ErrorData::invalid_params(error.to_string(), None))?;
@@ -1214,12 +1216,25 @@ mod tests {
             RunnerConfig::default(),
         )
         .unwrap();
-        let value = serde_json::json!({"message": "hello"});
+        let value = serde_json::json!({
+            "view": "log",
+            "items": ["ERROR: first", "ERROR: second"],
+            "next_cursor": null,
+            "truncated": false
+        });
         let one = serde_json::to_vec(&value).unwrap().len();
 
         let text = BazelMcpServer::new(runner.clone(), ResultEncoding::Text);
         assert_eq!(text.model_visible_bytes(&value).unwrap(), one);
         assert_eq!(text.single_representation_budget(8_192), 8_192);
+        let text_result = text.encode(value.clone()).unwrap();
+        let Some(ContentBlock::Text(content)) = text_result.content.first() else {
+            panic!("text result did not contain one text block");
+        };
+        assert_eq!(
+            serde_json::from_str::<serde_json::Value>(&content.text).unwrap(),
+            value
+        );
 
         let toon = BazelMcpServer::new(runner.clone(), ResultEncoding::Toon);
         let toon_text = BazelMcpServer::encode_toon(&value).unwrap();
@@ -1235,9 +1250,19 @@ mod tests {
         };
         assert_eq!(content.text, toon_text);
 
+        let structured = BazelMcpServer::new(runner.clone(), ResultEncoding::Structured);
+        assert_eq!(
+            structured.encode(value.clone()).unwrap().structured_content,
+            Some(value.clone())
+        );
+
         let both = BazelMcpServer::new(runner, ResultEncoding::Both);
         assert_eq!(both.model_visible_bytes(&value).unwrap(), one * 2);
         assert_eq!(both.single_representation_budget(8_192), 4_096);
+        assert_eq!(
+            both.encode(value.clone()).unwrap().structured_content,
+            Some(value)
+        );
     }
 
     #[tokio::test]

--- a/crates/bazel-mcp-store/src/files.rs
+++ b/crates/bazel-mcp-store/src/files.rs
@@ -16,8 +16,15 @@ pub struct InvocationPaths {
     pub details: PathBuf,
     pub stdout: PathBuf,
     pub stderr: PathBuf,
+    /// Redacted, normalized, encoding-neutral failure evidence used by the
+    /// public `log` inspection view.
+    pub evidence: PathBuf,
     pub bep: PathBuf,
     pub artifacts: PathBuf,
+    /// Immutable raw snapshot of failed-test logs.
+    pub test_logs_raw: PathBuf,
+    /// Redacted line records used by the `test_log` inspection view.
+    pub test_log_evidence: PathBuf,
 }
 
 impl InvocationPaths {
@@ -39,8 +46,11 @@ impl InvocationPaths {
             details: directory.join("details.json"),
             stdout: directory.join("stdout.log"),
             stderr: directory.join("stderr.log"),
+            evidence: directory.join("failure-evidence.jsonl"),
             bep: directory.join("events.bep"),
             artifacts: directory.join("artifacts.json"),
+            test_logs_raw: directory.join("failed-test-logs.raw"),
+            test_log_evidence: directory.join("failed-test-evidence.jsonl"),
             directory,
         }
     }

--- a/crates/bazel-mcp-store/src/storage.rs
+++ b/crates/bazel-mcp-store/src/storage.rs
@@ -1141,6 +1141,7 @@ impl Store {
         let path = self.paths_for_id(id).stdout;
         let filter = filter.map(str::to_owned);
         let limit = page.limit.clamp(1, 100) as usize;
+        let maximum_bytes = page.max_bytes.unwrap_or(usize::MAX);
         tokio::task::spawn_blocking(move || {
             page_query_file(
                 &path,
@@ -1150,6 +1151,7 @@ impl Store {
                     start_offset,
                     start_ordinal,
                     limit,
+                    maximum_bytes,
                     known_total,
                 },
                 transform,
@@ -1351,8 +1353,11 @@ async fn evidence_payload_size(paths: &InvocationPaths) -> Result<u64, StoreErro
         &paths.details,
         &paths.stdout,
         &paths.stderr,
+        &paths.evidence,
         &paths.bep,
         &paths.artifacts,
+        &paths.test_logs_raw,
+        &paths.test_log_evidence,
     ] {
         match tokio::fs::symlink_metadata(path).await {
             Ok(metadata) if metadata.file_type().is_file() => {
@@ -1373,8 +1378,11 @@ async fn evidence_size(paths: &InvocationPaths) -> Result<u64, StoreError> {
         &paths.details,
         &paths.stdout,
         &paths.stderr,
+        &paths.evidence,
         &paths.bep,
         &paths.artifacts,
+        &paths.test_logs_raw,
+        &paths.test_log_evidence,
     ] {
         match tokio::fs::symlink_metadata(path).await {
             Ok(metadata) if metadata.file_type().is_file() => {
@@ -1464,6 +1472,9 @@ fn load_index_blocking(cache_root: &Path) -> Result<(Index, StoreStartupStats), 
                     expected.manifest.with_extension("tmp"),
                     expected.details.with_extension("tmp"),
                     expected.artifacts.with_extension("tmp"),
+                    expected.evidence.with_extension("tmp"),
+                    expected.test_logs_raw.with_extension("tmp"),
+                    expected.test_log_evidence.with_extension("tmp"),
                 ] {
                     let _ = std::fs::remove_file(temporary);
                 }
@@ -1529,8 +1540,11 @@ fn evidence_payload_size_blocking(paths: &InvocationPaths) -> Result<u64, StoreE
         &paths.details,
         &paths.stdout,
         &paths.stderr,
+        &paths.evidence,
         &paths.bep,
         &paths.artifacts,
+        &paths.test_logs_raw,
+        &paths.test_log_evidence,
     ] {
         match std::fs::symlink_metadata(path) {
             Ok(metadata) if metadata.file_type().is_file() => {
@@ -1612,7 +1626,15 @@ async fn stage_raw_evidence(
     }
     tokio::fs::create_dir(&trash).await?;
     set_private_directory(&trash).await?;
-    for source in [&paths.stdout, &paths.stderr, &paths.bep, &paths.artifacts] {
+    for source in [
+        &paths.stdout,
+        &paths.stderr,
+        &paths.evidence,
+        &paths.bep,
+        &paths.artifacts,
+        &paths.test_logs_raw,
+        &paths.test_log_evidence,
+    ] {
         let Some(name) = source.file_name() else {
             continue;
         };
@@ -1665,9 +1687,11 @@ fn page_records<T, F>(
     searchable: F,
 ) -> Result<(Page<T>, u64, u64), StoreError>
 where
+    T: Serialize,
     F: Fn(&T) -> String,
 {
     let limit = page.limit.clamp(1, 100) as usize;
+    let maximum_bytes = page.max_bytes.unwrap_or(usize::MAX);
     let invocation_id = id.to_string();
     let after = page
         .cursor
@@ -1675,41 +1699,57 @@ where
         .map(|value| OrdinalCursor::decode_for(value, scope, &invocation_id, filter))
         .transpose()?
         .map_or(-1, |cursor| cursor.ordinal);
+    let normalized_filter = filter.map(str::to_ascii_lowercase);
     let total = records.len() as u64;
     let filtered = records
         .iter()
-        .filter(|record| filter.is_none_or(|filter| searchable(record).contains(filter)))
-        .count() as u64;
-    let mut selected: Vec<_> = records
-        .into_iter()
-        .enumerate()
-        .filter(|(ordinal, record)| {
-            i64::try_from(*ordinal).unwrap_or(i64::MAX) > after
-                && filter.is_none_or(|filter| searchable(record).contains(filter))
+        .filter(|record| {
+            normalized_filter
+                .as_ref()
+                .is_none_or(|filter| searchable(record).to_ascii_lowercase().contains(filter))
         })
-        .take(limit + 1)
-        .collect();
-    let truncated = selected.len() > limit;
-    selected.truncate(limit);
+        .count() as u64;
+    let mut selected = Vec::new();
+    let mut used_bytes = 2_usize;
+    let mut last_ordinal = None;
+    let mut truncated = false;
+    for (ordinal, record) in records.into_iter().enumerate() {
+        let ordinal = i64::try_from(ordinal).unwrap_or(i64::MAX);
+        if ordinal <= after
+            || !normalized_filter
+                .as_ref()
+                .is_none_or(|filter| searchable(&record).to_ascii_lowercase().contains(filter))
+        {
+            continue;
+        }
+        let item_bytes = serde_json::to_vec(&record)?.len();
+        let separator = usize::from(!selected.is_empty());
+        if selected.len() == limit
+            || (!selected.is_empty()
+                && used_bytes
+                    .saturating_add(separator)
+                    .saturating_add(item_bytes)
+                    > maximum_bytes)
+        {
+            truncated = true;
+            break;
+        }
+        used_bytes = used_bytes
+            .saturating_add(separator)
+            .saturating_add(item_bytes);
+        last_ordinal = Some(ordinal);
+        selected.push(record);
+    }
     let next_cursor = if truncated {
-        selected
-            .last()
-            .map(|(ordinal, _)| {
-                OrdinalCursor::new(
-                    scope,
-                    &invocation_id,
-                    filter,
-                    i64::try_from(*ordinal).unwrap_or(i64::MAX),
-                )
-                .encode()
-            })
+        last_ordinal
+            .map(|ordinal| OrdinalCursor::new(scope, &invocation_id, filter, ordinal).encode())
             .transpose()?
     } else {
         None
     };
     Ok((
         Page {
-            items: selected.into_iter().map(|(_, record)| record).collect(),
+            items: selected,
             next_cursor,
             truncated,
         },
@@ -1722,6 +1762,7 @@ struct QueryFilePage {
     start_offset: u64,
     start_ordinal: u64,
     limit: usize,
+    maximum_bytes: usize,
     known_total: Option<u64>,
 }
 
@@ -1756,33 +1797,47 @@ where
         } else {
             count_query_rows(&file)?
         };
-        return page_unfiltered_query_file(
-            file,
-            invocation_id,
-            request.start_offset,
-            request.start_ordinal,
-            request.limit,
-            total,
-            transform,
-        );
+        return page_unfiltered_query_file(file, invocation_id, request, total, transform);
     }
     let mut reader = BoundedLineReader::new(BufReader::new(file), QUERY_LINE_LIMIT);
     let mut total = 0_u64;
     let mut filtered = 0_u64;
-    let mut selected = Vec::with_capacity(request.limit + 1);
+    let normalized_filter = filter.map(str::to_ascii_lowercase);
+    let mut selected = Vec::with_capacity(request.limit);
+    let mut used_bytes = 2_usize;
+    let mut truncated = false;
     while let Some(mut line) = reader.next_line()? {
         total = total.saturating_add(1);
         line.value = transform(&line.value);
-        let matches = filter.is_none_or(|filter| line.value.contains(filter));
+        let matches = normalized_filter
+            .as_ref()
+            .is_none_or(|filter| line.value.to_ascii_lowercase().contains(filter));
         if matches {
             filtered = filtered.saturating_add(1);
-            if line.start_offset >= request.start_offset && selected.len() <= request.limit {
-                selected.push(line);
+            if line.start_offset >= request.start_offset && !truncated {
+                let item_bytes = serde_json::to_vec(&QueryRow {
+                    ordinal: line.ordinal,
+                    value: line.value.clone(),
+                })?
+                .len();
+                let separator = usize::from(!selected.is_empty());
+                if selected.len() == request.limit
+                    || (!selected.is_empty()
+                        && used_bytes
+                            .saturating_add(separator)
+                            .saturating_add(item_bytes)
+                            > request.maximum_bytes)
+                {
+                    truncated = true;
+                } else {
+                    used_bytes = used_bytes
+                        .saturating_add(separator)
+                        .saturating_add(item_bytes);
+                    selected.push(line);
+                }
             }
         }
     }
-    let truncated = selected.len() > request.limit;
-    selected.truncate(request.limit);
     let next_cursor = if truncated {
         selected
             .last()
@@ -1845,9 +1900,7 @@ fn count_query_rows(mut file: &File) -> Result<u64, StoreError> {
 fn page_unfiltered_query_file<F>(
     mut file: File,
     invocation_id: &str,
-    start_offset: u64,
-    start_ordinal: u64,
-    limit: usize,
+    request: QueryFilePage,
     total: u64,
     transform: F,
 ) -> Result<(Page<QueryRow>, u64, u64), StoreError>
@@ -1856,23 +1909,39 @@ where
 {
     use std::io::{Seek, SeekFrom};
 
-    file.seek(SeekFrom::Start(start_offset))?;
+    file.seek(SeekFrom::Start(request.start_offset))?;
     let mut reader = BoundedLineReader::with_position(
         BufReader::new(file),
         QUERY_LINE_LIMIT,
-        start_offset,
-        start_ordinal,
+        request.start_offset,
+        request.start_ordinal,
     );
-    let mut selected = Vec::with_capacity(limit + 1);
-    while selected.len() <= limit {
-        let Some(mut line) = reader.next_line()? else {
-            break;
-        };
+    let mut selected = Vec::with_capacity(request.limit);
+    let mut used_bytes = 2_usize;
+    let mut truncated = false;
+    while let Some(mut line) = reader.next_line()? {
         line.value = transform(&line.value);
+        let item_bytes = serde_json::to_vec(&QueryRow {
+            ordinal: line.ordinal,
+            value: line.value.clone(),
+        })?
+        .len();
+        let separator = usize::from(!selected.is_empty());
+        if selected.len() == request.limit
+            || (!selected.is_empty()
+                && used_bytes
+                    .saturating_add(separator)
+                    .saturating_add(item_bytes)
+                    > request.maximum_bytes)
+        {
+            truncated = true;
+            break;
+        }
+        used_bytes = used_bytes
+            .saturating_add(separator)
+            .saturating_add(item_bytes);
         selected.push(line);
     }
-    let truncated = selected.len() > limit;
-    selected.truncate(limit);
     let next_cursor = if truncated {
         selected
             .last()
@@ -2171,6 +2240,7 @@ mod tests {
                 PageRequest {
                     cursor: None,
                     limit: 10,
+                    max_bytes: None,
                 },
             )
             .await
@@ -2220,6 +2290,7 @@ mod tests {
                 PageRequest {
                     cursor: None,
                     limit: 1,
+                    max_bytes: None,
                 },
             )
             .await
@@ -2234,11 +2305,79 @@ mod tests {
                 PageRequest {
                     cursor: first.0.next_cursor,
                     limit: 1,
+                    max_bytes: None,
                 },
             )
             .await
             .unwrap();
         assert_eq!(second.0.items[0].ordinal, 2);
+    }
+
+    #[tokio::test]
+    async fn serialized_byte_packing_preserves_limit_filter_and_cursor_continuity() {
+        let root = TempDir::new().unwrap();
+        let store = Store::open(root.path()).await.unwrap();
+        let record = record(root.path());
+        let id = record.request.id;
+        let paths = store.create_invocation(&record).await.unwrap();
+        let contents = (0..5)
+            .map(|ordinal| format!("ROW_{ordinal}_{}\n", "x".repeat(80)))
+            .collect::<String>();
+        tokio::fs::write(&paths.stdout, contents).await.unwrap();
+
+        let mut cursor = None;
+        let mut ordinals = Vec::new();
+        loop {
+            let (page, _, _) = store
+                .page_query_rows(
+                    id,
+                    None,
+                    PageRequest {
+                        cursor,
+                        limit: 100,
+                        max_bytes: Some(120),
+                    },
+                )
+                .await
+                .unwrap();
+            assert_eq!(page.items.len(), 1);
+            ordinals.extend(page.items.iter().map(|row| row.ordinal));
+            cursor = page.next_cursor;
+            if !page.truncated {
+                break;
+            }
+        }
+        assert_eq!(ordinals, vec![0, 1, 2, 3, 4]);
+
+        let (requested, _, _) = store
+            .page_query_rows(
+                id,
+                None,
+                PageRequest {
+                    cursor: None,
+                    limit: 3,
+                    max_bytes: Some(8 * 1024),
+                },
+            )
+            .await
+            .unwrap();
+        assert_eq!(requested.items.len(), 3);
+        assert!(requested.truncated);
+
+        let (filtered, _, filtered_count) = store
+            .page_query_rows(
+                id,
+                Some("row_3"),
+                PageRequest {
+                    cursor: None,
+                    limit: 100,
+                    max_bytes: Some(8 * 1024),
+                },
+            )
+            .await
+            .unwrap();
+        assert_eq!(filtered_count, 1);
+        assert_eq!(filtered.items[0].ordinal, 3);
     }
 
     #[tokio::test]
@@ -2261,6 +2400,7 @@ mod tests {
                 PageRequest {
                     cursor: None,
                     limit: 3,
+                    max_bytes: None,
                 },
                 move |value| {
                     observed.fetch_add(1, AtomicOrdering::Relaxed);
@@ -2291,6 +2431,7 @@ mod tests {
                 PageRequest {
                     cursor: None,
                     limit: 2,
+                    max_bytes: None,
                 },
             )
             .await
@@ -2305,6 +2446,7 @@ mod tests {
                 PageRequest {
                     cursor: first.next_cursor,
                     limit: 2,
+                    max_bytes: None,
                 },
             )
             .await
@@ -2347,7 +2489,8 @@ mod tests {
                 attempts: 1,
                 shard: None,
                 cases: Vec::new(),
-                log_uri: None,
+                test_log_available: false,
+                test_log_unavailable_reason: None,
             }],
             test_counts: TestCounts {
                 passed: 1,
@@ -2791,6 +2934,58 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn retention_removes_invocation_owned_failed_test_snapshots() {
+        let root = TempDir::new().unwrap();
+        let store = Store::open(root.path()).await.unwrap();
+        let record = InvocationRecord::queued(InvocationRequest::new(
+            root.path().to_owned(),
+            BazelCommand::Test,
+            vec!["//pkg:failing".into()],
+        ));
+        let id = record.request.id;
+        let paths = store.create_invocation(&record).await.unwrap();
+        store
+            .transition(id, InvocationState::Starting, None, None)
+            .await
+            .unwrap();
+        store
+            .transition(id, InvocationState::Running, None, None)
+            .await
+            .unwrap();
+        tokio::fs::write(&paths.test_logs_raw, b"complete private failure log")
+            .await
+            .unwrap();
+        tokio::fs::write(
+            &paths.test_log_evidence,
+            b"{\"label\":\"//pkg:failing\",\"text\":\"assertion failed\"}\n",
+        )
+        .await
+        .unwrap();
+        store
+            .transition(
+                id,
+                InvocationState::Failed,
+                Some(Termination::Exit { code: 1 }),
+                Some(InvocationSummary::default()),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(
+            store
+                .enforce_retention(Duration::ZERO, u64::MAX)
+                .await
+                .unwrap(),
+            1
+        );
+        assert!(!paths.directory.exists());
+        assert!(matches!(
+            store.get_invocation(id).await,
+            Err(StoreError::NotFound(_))
+        ));
+    }
+
+    #[tokio::test]
     async fn corrupt_committed_records_fail_closed_without_overwriting_evidence() {
         let root = TempDir::new().unwrap();
         let store = Store::open(root.path()).await.unwrap();
@@ -2835,7 +3030,8 @@ mod tests {
                             attempts: 1,
                             shard: None,
                             cases: Vec::new(),
-                            log_uri: None,
+                            test_log_available: false,
+                            test_log_unavailable_reason: None,
                         }],
                         ..InvocationSummary::default()
                     },
@@ -2904,6 +3100,7 @@ mod tests {
                 PageRequest {
                     cursor: None,
                     limit: 3,
+                    max_bytes: None,
                 },
             )
             .await

--- a/crates/bazel-mcp-store/src/storage.rs
+++ b/crates/bazel-mcp-store/src/storage.rs
@@ -910,7 +910,7 @@ impl Store {
         let mut reclaimed = 0;
         let mut processed = BTreeSet::new();
         for (id, finished, protected) in &candidates {
-            if *finished < cutoff {
+            if retention_age_elapsed(*finished, cutoff) {
                 if self.reclaim_terminal(*id, *protected).await? {
                     reclaimed += 1;
                 }
@@ -1594,6 +1594,10 @@ async fn recover_interrupted(cache_root: &Path, index: &mut Index) -> Result<(),
         replace_index_entry(index, id, durable.index_entry(outcome.retained_bytes));
     }
     Ok(())
+}
+
+fn retention_age_elapsed(finished_at_ms: i64, cutoff_ms: i64) -> bool {
+    finished_at_ms <= cutoff_ms
 }
 
 async fn rename_to_trash(
@@ -2983,6 +2987,13 @@ mod tests {
             store.get_invocation(id).await,
             Err(StoreError::NotFound(_))
         ));
+    }
+
+    #[test]
+    fn retention_age_cutoff_is_inclusive() {
+        assert!(retention_age_elapsed(42, 42));
+        assert!(retention_age_elapsed(41, 42));
+        assert!(!retention_age_elapsed(43, 42));
     }
 
     #[tokio::test]

--- a/crates/bazel-mcp-types/src/diagnostic.rs
+++ b/crates/bazel-mcp-types/src/diagnostic.rs
@@ -8,7 +8,7 @@ pub enum Severity {
     Note,
 }
 
-#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum DiagnosticCategory {
     Workspace,

--- a/crates/bazel-mcp-types/src/invocation.rs
+++ b/crates/bazel-mcp-types/src/invocation.rs
@@ -151,8 +151,8 @@ pub enum Termination {
 
 #[derive(Clone, Debug, Default, Eq, PartialEq, Serialize, Deserialize)]
 pub struct InvocationMetrics {
-    pub raw_stdout_bytes: u64,
-    pub raw_stderr_bytes: u64,
+    #[serde(default)]
+    pub raw_output_bytes: u64,
     pub bep_bytes: u64,
     pub bep_events: u64,
     pub model_visible_bytes: u64,

--- a/crates/bazel-mcp-types/src/pagination.rs
+++ b/crates/bazel-mcp-types/src/pagination.rs
@@ -4,6 +4,10 @@ use serde::{Deserialize, Serialize};
 pub struct PageRequest {
     pub cursor: Option<String>,
     pub limit: u32,
+    /// Optional serialized item-array budget. The storage layer packs complete
+    /// records up to this limit and advances cursors only past emitted records.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub max_bytes: Option<usize>,
 }
 
 impl Default for PageRequest {
@@ -11,6 +15,7 @@ impl Default for PageRequest {
         Self {
             cursor: None,
             limit: 50,
+            max_bytes: None,
         }
     }
 }

--- a/crates/bazel-mcp-types/src/test.rs
+++ b/crates/bazel-mcp-types/src/test.rs
@@ -28,5 +28,8 @@ pub struct TestResult {
     pub attempts: u32,
     pub shard: Option<u32>,
     pub cases: Vec<TestCase>,
-    pub log_uri: Option<String>,
+    #[serde(default)]
+    pub test_log_available: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub test_log_unavailable_reason: Option<String>,
 }

--- a/specs/001-product-requirements.md
+++ b/specs/001-product-requirements.md
@@ -244,13 +244,14 @@ The logical result contains:
   },
   "diagnostics": [
     {
+      "severity": "error",
+      "category": "test",
+      "message": "expected 3, received 4",
       "target": "//foo:foo_test",
-      "kind": "test_failure",
-      "summary": "expected 3, received 4",
-      "source": "bazel://invocations/019.../tests/foo_test"
+      "repetition_count": 1
     }
   ],
-  "available_views": ["diagnostics", "tests", "artifacts", "log"],
+  "available_views": ["diagnostics", "tests", "test_log", "artifacts", "log"],
   "more_available": true
 }
 ```
@@ -280,7 +281,7 @@ Read a filtered, paginated view of one invocation.
 | Field | Required | Type | Requirements |
 | --- | --- | --- | --- |
 | `invocation_id` | Yes | UUID string | Must identify a retained invocation. |
-| `view` | Yes | Enum | One of `summary`, `diagnostics`, `tests`, `coverage`, `artifacts`, `query_results`, or `log`. |
+| `view` | Yes | Enum | One of `summary`, `diagnostics`, `tests`, `test_log`, `coverage`, `artifacts`, `query_results`, or `log`. |
 | `filter` | No | String | Label glob or literal substring, depending on view; not an arbitrary regular expression. |
 | `limit` | No | Integer | Defaults to 20; range 1 through 100. |
 | `cursor` | No | Opaque string | Continues a prior view using stable server-side ordering. |
@@ -302,15 +303,18 @@ View requirements:
 - `diagnostics` returns reduced analysis, loading, action, and compiler failures.
 - `tests` returns target, run, shard, attempt, status, duration, cache status, and
   bounded failure details.
+- `test_log` returns redacted strings from invocation-owned snapshots of failed
+  test logs. A label filter selects a test without exposing a filesystem URI.
 - `coverage` returns per-file LCOV summaries when a local coverage artifact is
   available and otherwise returns artifact references plus an explicit
   availability reason.
 - `artifacts` resolves BEP `NamedSetOfFiles` references and returns bounded file
   metadata without reading artifact contents.
 - `query_results` returns stored query rows using stable pagination.
-- `log` returns a bounded logical page of captured stdout or stderr. It MUST NOT
-  return an entire unbounded file. The default is the combined failure-oriented
-  tail.
+- `log` returns `items` as a bounded array of redacted strings selected from
+  normalized failure evidence. Stream choice, sequencing, and cursors are
+  internal; the public MCP shape has no stdout/stderr selector or source field.
+  Actionable, deduplicated lines precede a bounded fallback tail.
 
 ### 8.3 `bazel.cancel`
 
@@ -339,8 +343,9 @@ Cancel a queued or running invocation.
 
 ### 8.4 MCP resources
 
-Tools MAY return `bazel://` resource links for stored details. Resource links are
-references, not a mechanism for bypassing response limits. Any `read_resource`
+Tools MAY return `bazel://` resource links for stored details. Failed-test logs
+use the `test_log` inspect view instead of a synthetic or local-file URI.
+Resource links are references, not a mechanism for bypassing response limits. Any `read_resource`
 implementation MUST enforce the same filtering, pagination, permissions, and
 byte ceilings as `bazel.inspect`.
 
@@ -442,7 +447,7 @@ For test-like commands, the server additionally applies terminal-output policy
 equivalent to:
 
 ```text
---test_output=summary
+--test_output=errors
 --test_summary=none
 ```
 
@@ -596,16 +601,18 @@ The parser MUST tolerate:
 
 ### 14.1 Diagnostic priority
 
-The default failure response selects evidence in this order:
+The default failure response selects evidence in this order, before applying
+item or byte limits:
 
 1. Loading or analysis `Aborted` events and structured failure details.
-2. Failed root-cause actions and their target labels.
-3. The first actionable compiler or tool error from each failed root-cause
-   action.
-4. Failed test cases or bounded failed-test log excerpts.
-5. A bounded stderr tail when structured evidence is absent.
+2. Concrete actionable compiler, tool, and loading errors.
+3. Failed test cases or bounded failed-test log excerpts.
+4. Other failure text and structured Bazel failures.
+5. Aggregated action-failure summaries.
 
-The response SHOULD favor root causes over cascading target failures.
+Equivalent action failures across targets are one diagnostic with `target: null`
+and an incremented `repetition_count`. The response SHOULD favor root causes
+over cascading target failures.
 
 ### 14.2 Text normalization
 
@@ -625,7 +632,6 @@ diagnostics that may refer to different source locations.
 ### 14.3 Default diagnostic limits
 
 - At most 20 diagnostics per `bazel.run` response.
-- At most two text diagnostics per failed action before global selection.
 - At most 1,000 UTF-8 bytes per diagnostic item.
 - At most two lines of leading and trailing context unless necessary to include
   a source location or explicit cause.
@@ -638,8 +644,12 @@ diagnostics that may refer to different source locations.
 - Aggregate passed, failed, flaky, skipped, incomplete, and cached test counts.
 - Preserve run, shard, and attempt identity.
 - Prefer structured `test.xml` failure names and messages when locally
-  available.
-- Fall back to a bounded `test.log` excerpt.
+  available, accepting both `<testsuite>` and `<testsuites>` roots.
+- Fall back to a bounded, deterministic `test.log` excerpt and always emit an
+  actionable diagnostic for a failed, timed-out, or incomplete test.
+- Snapshot complete failed-test logs into private invocation storage before
+  workspace output paths can be reused. Expose only redacted, paginated strings
+  through `view=test_log`, with explicit unavailability reasons.
 - Never include logs for passing tests in the default result.
 - `include_all_results` is intentionally not part of `bazel.run`; callers use
   the paginated `tests` view instead.
@@ -678,6 +688,9 @@ All limits apply to the serialized model-visible tool result, before MCP framing
 - Byte ceilings take precedence over item limits.
 - Every response stopped by a ceiling sets `truncated: true` and, when possible,
   returns a continuation cursor.
+- `limit` is a maximum, not a target. Page packing measures serialized records;
+  a continuation cursor encodes the last emitted record so a smaller byte
+  budget cannot create duplicates or gaps.
 - No default result includes base64 data, artifact contents, a complete BEP
   event, or a complete raw log.
 - Tool descriptions and JSON schemas SHOULD remain concise because tool
@@ -700,8 +713,11 @@ There is no embedded or hosted database.
       details.json
       stdout.log
       stderr.log
+      failure-evidence.jsonl
       events.bep
       artifacts.json
+      failed-test-logs.raw
+      failed-test-evidence.jsonl
 ```
 
 The exact platform cache root is configurable. It defaults to an OS-appropriate
@@ -853,8 +869,7 @@ may use the generic bounded-text adapter only when explicitly configured.
 
 For every invocation, record:
 
-- Raw stdout bytes
-- Raw stderr bytes
+- Aggregate raw process-output bytes (stream identity remains internal)
 - BEP bytes and event count
 - Model-visible result bytes
 - Number of progress notifications

--- a/specs/004-outcome-aware-evidence-retention.md
+++ b/specs/004-outcome-aware-evidence-retention.md
@@ -147,8 +147,9 @@ logs and BEP.
 4. Policy-driven unavailability is a normal domain result, not an MCP protocol
    error.
 5. BEP is never retained by default because no advertised view reads raw BEP.
-6. Stdout and stderr are retained or purged together as the backing evidence
-   for `log`.
+6. The raw stdout and stderr captures are retained or purged together. The
+   public `log` view reads an encoding-neutral, normalized evidence file and
+   never exposes stream identity.
 7. No GC operation deletes a nonterminal invocation.
 8. An unexpired deferred task may protect metadata and the compact summary but
    never extends a follow-up view TTL.
@@ -160,7 +161,7 @@ logs and BEP.
 
 ## View inventory and backing evidence
 
-The per-invocation manifest contains exactly the seven public inspection views
+The per-invocation manifest contains exactly the eight public inspection views
 from specification 001. An internal invocation-listing operation, if present,
 is not a per-invocation view and has no manifest row.
 
@@ -169,10 +170,11 @@ is not a per-invocation view and has no manifest row.
 | `summary` | Compact summary in the invocation record | Invocation metadata |
 | `diagnostics` | Redacted diagnostic rows | All diagnostic rows for the invocation |
 | `tests` | Redacted test-result rows and bounded failure detail | All test rows for the invocation |
+| `test_log` | Private failed-test snapshots plus redacted line evidence | All failed-test evidence for the invocation |
 | `coverage` | Redacted coverage summary and per-file rows | All coverage rows for the invocation |
 | `artifacts` | Bounded artifact metadata rows | All artifact rows for the invocation |
 | `query_results` | Redacted query rows | All query rows for the invocation |
-| `log` | Raw stdout and stderr files | Both files together |
+| `log` | Redacted normalized failure-evidence strings, derived from both raw captures | The evidence file and raw captures together |
 
 Target-result rows that are not exposed by a public view are working evidence.
 After their contribution to the compact summary is committed, they are purged
@@ -185,12 +187,18 @@ lifetime of Bazel outputs in the workspace or remote cache. If an artifact
 reference later cannot be resolved, the available artifact view returns an
 item-level availability reason as required by specification 001.
 
-The `log` view is a deterministic virtual view of both streams. It MUST NOT
-silently choose stderr and omit nonempty stdout. Pages identify their source
-stream and prioritize the failure-oriented stderr tail before the stdout tail;
-they do not claim to reconstruct cross-stream interleaving that was not
-captured. Existing byte ceilings, redaction, and backward pagination continue
-to apply.
+The `log` view is a deterministic, encoding-neutral view derived from both
+streams. It MUST NOT silently omit a nonempty stream, but stdout/stderr choice
+and failure sequencing remain internal implementation details. The public shape
+is always `items: [string]`; there is no source field or stream selector.
+Normalization, redaction, exact deduplication, actionable-line ranking, a
+bounded fallback tail, and opaque forward pagination apply before return.
+
+The `test_log` view uses the same public string shape. Complete failed-test logs
+are first copied into private invocation storage so a later Bazel invocation
+cannot mutate prior evidence. Redacted line records provide bounded filtering
+and pagination; missing, remote, rejected-by-containment, and expired evidence
+have explicit reasons.
 
 ## Default retention policy
 
@@ -239,6 +247,7 @@ by the existing lifecycle rules and therefore belongs to one of those classes.
 | Compact metadata and summary | 7 days | 7 days |
 | Nonempty normalized follow-up view | 1 hour | 24 hours |
 | `log` | 1 hour only when selected as an explicit fallback | 24 hours when either stream contains bytes |
+| `test_log` | Not retained | 24 hours when a failed-test snapshot exists |
 | BEP | Purge after reduction attempt | Purge after reduction attempt |
 | Non-view normalized/intermediate data | Purge after summary commit | Purge after summary commit |
 
@@ -258,7 +267,7 @@ examples are:
 | Invocation | Expected available views at completion |
 | --- | --- |
 | Successful build | `summary`, plus nonempty `artifacts` or other normalized views |
-| Successful test | `summary`, plus nonempty `tests`, `diagnostics`, and `artifacts` |
+| Successful test | `summary`, plus nonempty `tests`, `diagnostics`, and `artifacts`; `test_log` only when a flaky/failing snapshot exists |
 | Successful coverage | `summary`, plus nonempty `coverage`, `diagnostics`, and `artifacts` |
 | Successful query | `summary`, `query_results` when rows exist |
 | Successful truncated informational command | `summary`, `log` |
@@ -283,6 +292,7 @@ pub enum InvocationView {
     Summary,
     Diagnostics,
     Tests,
+    TestLog,
     Coverage,
     Artifacts,
     QueryResults,
@@ -370,7 +380,7 @@ CREATE INDEX invocation_views_expiry
 ```
 
 The implementation uses the conservative SQL subset supported and tested by
-the pinned Turso version. Every terminal invocation has exactly seven manifest
+the pinned Turso version. Every terminal invocation has exactly eight manifest
 rows. A terminal invocation missing any row is an integrity error and is
 reconciled during recovery; the server does not infer availability from file
 existence.
@@ -382,7 +392,8 @@ check makes TTL behavior correct even when the periodic GC worker is delayed.
 
 `logical_bytes` is computed when backing data is committed:
 
-- for `log`, it is the sum of stdout and stderr file lengths;
+- for `log`, it is the sum of the evidence file and raw capture lengths;
+- for `test_log`, it is the private snapshot plus redacted evidence length;
 - for normalized views, it is the sum of the redacted serialized record byte
   lengths before database insertion; and
 - for `summary`, it is the compact serialized summary and metadata size.
@@ -403,7 +414,7 @@ The runner performs terminal processing in this order:
    manifest commit.
 5. Compute the compact summary, item/byte counts, and retention plan.
 6. Atomically commit terminal invocation state, termination information,
-   compact summary, normalized-row visibility, and all seven manifest rows.
+   compact summary, normalized-row visibility, and all eight manifest rows.
 7. Purge nonretained view evidence and working evidence.
 8. Notify the GC worker and build the model-visible result from the latest
    manifest snapshot.
@@ -673,7 +684,7 @@ specification does not silently truncate raw capture needed by reduction.
 
 Add counters and histograms for:
 
-- capture bytes by `stdout`, `stderr`, and `bep`;
+- aggregate process-output capture bytes and BEP capture bytes;
 - logical retained bytes by view and outcome class;
 - purged bytes by evidence kind and reason;
 - view decisions by availability, view, and outcome class;
@@ -718,7 +729,8 @@ filter values, cursor contents, raw text, or other unbounded cardinality.
 - Replace string inspect hints with `InvocationView`.
 - Commit terminal state and the complete manifest at one visibility point.
 - Gate inspection before cursor decoding or evidence access.
-- Return structured availability and fix `log` to cover both streams.
+- Return structured availability and derive encoding-neutral `log` evidence
+  from both streams without exposing stream identity.
 - Notify GC after terminal transitions without owning storage policy.
 
 ### `bazel-mcp-server`
@@ -744,7 +756,7 @@ crates. No reducer becomes nondeterministic or filesystem-aware.
 
 ### Policy tests
 
-- Every command family and terminal state produces exactly seven decisions.
+- Every command family and terminal state produces exactly eight decisions.
 - Successful log retention requires a typed deterministic fallback fact.
 - Empty normalized views are never advertised.
 - Zero successful or unsuccessful TTL produces `not_retained`.
@@ -755,10 +767,12 @@ crates. No reducer becomes nondeterministic or filesystem-aware.
 ### Store integration tests
 
 - Migration 0006 upgrades databases containing migrations 0001 through 0005.
-- Terminal state and all seven manifest rows become visible atomically.
+- Terminal state and all eight manifest rows become visible atomically.
 - An available manifest row always has complete backing evidence.
 - Each normalized view purge deletes only its own rows.
-- Log purge removes both streams and leaves summary metadata intact.
+- Log purge removes both raw streams and normalized log evidence while leaving
+  summary metadata and failed-test snapshots intact.
+- Test-log purge removes both its private raw snapshot and redacted evidence.
 - BEP and duplicate intermediate files are purged after terminal reduction.
 - `expired`, `evicted`, and `not_retained` survive restart.
 - A crash after the logical manifest transition but before file deletion is
@@ -789,7 +803,10 @@ crates. No reducer becomes nondeterministic or filesystem-aware.
   structured availability, never a missing-file error.
 - An unexpectedly deleted retained file returns `unavailable` and records an
   integrity metric.
-- `log` inspection includes both nonempty streams with source identification.
+- `log` inspection incorporates both nonempty streams but returns only strings,
+  with no source identification or selector.
+- Failed-test snapshots remain immutable across later invocations and
+  `test_log` pagination never reads mutable workspace output paths.
 - Text, TOON, structured, and both result encodings have the same logical
   availability fields and byte ceilings.
 - Synchronous, legacy-task, and extension-task result builders derive identical
@@ -864,7 +881,7 @@ This specification is complete when:
 
 - Specification 001's blanket raw-evidence and BEP-retention language is
   amended as described here.
-- Every terminal invocation has exactly seven durable view-manifest rows.
+- Every terminal invocation has exactly eight durable view-manifest rows.
 - `bazel.run` advertises only currently available, actually backed views.
 - `more_available` and `inspect_hint` agree with the manifest.
 - Expected view unavailability returns the specified normal structured result.


### PR DESCRIPTION
## Summary

- rank concrete loading, analysis, compiler, linker, and test causes ahead of generic BEP action failures
- aggregate equivalent high-fanout action failures with `target: null` and `repetition_count`
- make failed tests actionable with `--test_output=errors`, support both Bazel XML root shapes, and retain immutable private failed-test evidence
- expose simple encoding-neutral `log` and `test_log` views as `items: [string]` with automatic evidence selection, filtering, redaction, deduplication, and opaque cursors
- pack inspection pages by actual serialized size while preserving exact-once traversal
- update the public types, storage behavior, reducer goldens, product specs, and documentation

## Why

The retained MCP-only agentic benchmark solved all tasks, but failure cases required expensive follow-up inspection because generic BEP action failures displaced the concrete root cause. Failed tests could also return no actionable diagnostic, and the advertised failure-log URI was not consumable or durable.

This change returns the smallest useful failure evidence first while preserving complete private capture and bounded model-visible responses.

## Impact

The server still exposes exactly `bazel.run`, `bazel.inspect`, and `bazel.cancel`. MCP callers do not need to understand stdout or stderr: stream identity remains an internal capture detail, and both text and TOON-compatible inspection shapes remain simple string arrays.

Failed-test evidence is snapshotted into invocation-owned private storage before mutable Bazel output can be overwritten. Missing, remote, or unreadable logs return explicit availability reasons.

## Validation

- `make build`
- `make test` for the full workspace with all features
- `cargo fmt --all -- --check`
- strict workspace Clippy with `-D warnings`
- direct Bazel compatibility matrix on Bazel 7.6.1, 8.4.2, and 9.1.0, including test, coverage, pagination, and remote-cache smoke cases
- reviewed reducer goldens for Bazel 7, 8, and 9
- focused containment, retention, cursor, encoding, redaction, XML-root, fanout, and failed-test snapshot regressions

The final `cargo shear` step of `make check` could not run because Nix is not installed in the validation environment. The paid live agentic benchmark was intentionally not rerun.
