### PR TITLE
fix(release): support virtual Cargo workspace

### DIFF
--- a/.release-please-config.json
+++ b/.release-please-config.json
@@ -1,14 +1,20 @@
 {
   "packages": {
     ".": {
-      "release-type": "rust",
+      "release-type": "bazel",
       "package-name": "bazel-mcp",
       "changelog-path": "CHANGELOG.md",
       "include-component-in-tag": false,
       "extra-files": [
         {
-          "type": "generic",
-          "path": "MODULE.bazel"
+          "type": "toml",
+          "path": "Cargo.toml",
+          "jsonpath": "$.workspace.package.version"
+        },
+        {
+          "type": "toml",
+          "path": "Cargo.lock",
+          "jsonpath": "$.package[?(@.name.value==\"bazel-mcp-benchmark\" || @.name.value==\"bazel-mcp-bep\" || @.name.value==\"bazel-mcp-policy\" || @.name.value==\"bazel-mcp-reducer\" || @.name.value==\"bazel-mcp-runner\" || @.name.value==\"bazel-mcp-server\" || @.name.value==\"bazel-mcp-store\" || @.name.value==\"bazel-mcp-types\")].version"
         },
         {
           "type": "generic",


### PR DESCRIPTION
## Summary

- Switch Release Please from the Rust strategy to the Bazel strategy.
- Update the shared Cargo workspace version and all eight workspace entries in Cargo.lock with targeted TOML extra files.
- Preserve the existing server BUILD metadata update.

## Root cause

The Release Please Rust strategy treats the repository root Cargo.toml as a package manifest. This repository has a virtual Cargo workspace, so the action fails with:

> is not a package manifest (might be a cargo workspace)

Observed in [Release Please run 29472832153](https://github.com/ewhauser/bazel-mcp/actions/runs/29472832153/job/87539320826).

## Validation

- `make test`
- `make build`
- `cargo metadata --locked`
- Release Please 17.1.2 updater simulation: exactly the expected 11 version updates
- `make check` formatting and Clippy stages passed; cargo shear could not run locally because nix is unavailable
