### PR TITLE
docs: require Bazel MCP usage

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,3 +16,10 @@ Use `make build`, `make test`, `make check`, `make test-bazel-matrix`,
 `make fuzz-smoke`, and the explicit token benchmark targets. Do not run the long
 Abseil benchmark as an ordinary unit test. Use Conventional Commits; Release
 Please owns versions and the changelog.
+
+Always use the Bazel MCP tools instead of invoking Bazel or Bazelisk directly.
+When work involves Bazel, create or update the repository-root `LEARNINGS.md`
+with concrete potential improvements and opportunities to use the Bazel MCP
+server more token-efficiently. Keep entries concise, actionable, and grounded
+in observations from the current work; do not record secrets or raw sensitive
+output.

--- a/LEARNINGS.md
+++ b/LEARNINGS.md
@@ -1,0 +1,11 @@
+# Bazel MCP learnings
+
+Track concrete opportunities discovered while using Bazel MCP in this
+repository. Add concise, actionable entries under the current date, including
+the observed workflow or result and the improvement it suggests. Focus on MCP
+server behavior, result reduction, inspection patterns, and model-visible token
+efficiency. Do not include secrets or raw sensitive output.
+
+## Entries
+
+No observations recorded yet.


### PR DESCRIPTION
## Summary

- require agents to use Bazel MCP instead of invoking Bazel or Bazelisk directly
- require Bazel-related work to capture actionable token-efficiency opportunities in `LEARNINGS.md`
- add the initial repository-root `LEARNINGS.md` scaffold

## Why

This makes the repository dogfood its own MCP server and creates a durable feedback loop for improving result reduction, inspection patterns, and model-visible token efficiency.

## User and developer impact

Codex and other agents following `AGENTS.md` will route Bazel work through the three supported MCP tools and record concrete optimization opportunities without retaining secrets or raw sensitive output.

## Validation

- `git diff --cached --check`
- installed and started `bazel-mcp 0.1.0`
- verified the MCP handshake and exact tool list: `bazel.cancel`, `bazel.inspect`, and `bazel.run`
