### PR TITLE
ci: cache Bazel artifacts in GitHub Actions

### DIFF
--- a/.github/workflows/ci.bazelrc
+++ b/.github/workflows/ci.bazelrc
@@ -1,0 +1,3 @@
+# These directories are persisted by actions/cache in Bazel CI jobs.
+common --disk_cache=~/.cache/bazel-disk
+common --repository_cache=~/.cache/bazel-repo

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,19 @@ jobs:
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with: { persist-credentials: false }
+      - name: Configure Bazel caches
+        run: cp .github/workflows/ci.bazelrc "$HOME/.bazelrc"
+      # Cache keys are immutable, so an input change creates a new cache while
+      # restore-keys loads the most recent compatible cache as a warm baseline.
+      - name: Mount Bazel caches
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        with:
+          path: |
+            ~/.cache/bazel-disk
+            ~/.cache/bazel-repo
+          key: bazel-cache-${{ runner.os }}-${{ runner.arch }}-${{ github.job }}-${{ hashFiles('.bazelversion', '.bazelrc', '.github/workflows/ci.bazelrc', 'MODULE.bazel', 'MODULE.bazel.lock', 'Cargo.toml', 'Cargo.lock', '**/BUILD.bazel', '**/*.bzl', '**/*.rs') }}
+          restore-keys: |
+            bazel-cache-${{ runner.os }}-${{ runner.arch }}-${{ github.job }}-
       - run: go install github.com/bazelbuild/bazelisk@v1.26.0
       - run: PATH="$HOME/go/bin:$PATH" make build BAZEL_BUILD_FLAGS=--lockfile_mode=error
   cargo-test-linux:
@@ -88,6 +101,17 @@ jobs:
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with: { persist-credentials: false }
+      - name: Configure Bazel caches
+        run: cp .github/workflows/ci.bazelrc "$HOME/.bazelrc"
+      - name: Mount Bazel caches
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        with:
+          path: |
+            ~/.cache/bazel-disk
+            ~/.cache/bazel-repo
+          key: bazel-cache-${{ runner.os }}-${{ runner.arch }}-${{ github.job }}-${{ hashFiles('.bazelversion', '.bazelrc', '.github/workflows/ci.bazelrc', 'MODULE.bazel', 'MODULE.bazel.lock', 'Cargo.toml', 'Cargo.lock', '**/BUILD.bazel', '**/*.bzl', '**/*.rs') }}
+          restore-keys: |
+            bazel-cache-${{ runner.os }}-${{ runner.arch }}-${{ github.job }}-
       - run: go install github.com/bazelbuild/bazelisk@v1.26.0
       - run: PATH="$HOME/go/bin:$PATH" ./scripts/test-bazel-matrix.sh
   mcp-conformance:


### PR DESCRIPTION
## Summary

- add a CI-only Bazel rc that directs the disk and repository caches to persistent paths
- restore and save those paths in the `bazel-build` and `bazel-matrix` jobs with a pinned `actions/cache` release
- key caches by runner, architecture, job, and Bazel/Rust inputs, with restore prefixes for warm incremental baselines

## Why

GitHub-hosted runners currently start Bazel jobs without reusable local build or repository artifacts. This follows the immutable-key plus restore-prefix pattern used by `hermeticbuild/rules_rs`, while keeping the cache configuration scoped to CI.

## Impact

Repeated Bazel CI runs can reuse external downloads and action outputs. Job-specific namespaces avoid concurrent cache-save collisions between the build and version-matrix jobs.

## Validation

- `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.7 .github/workflows/ci.yml`
- `uvx zizmor .github/workflows/ci.yml` (no findings)
- Bazel 9.2.0 parsed both CI cache flags successfully
- clean-output-root `make build` completed successfully
- a second independent output root completed with 1,381 disk-cache hits in 12.8s (versus 73s for the populating build)
- `git diff --check`
