### PR TITLE
feat(server): make TOON the default result encoding

### DIFF
--- a/LEARNINGS.md
+++ b/LEARNINGS.md
@@ -38,3 +38,7 @@ efficiency. Do not include secrets or raw sensitive output.
 - Release Please created the Bazel-strategy tag with `GITHUB_TOKEN`, so the
   tag-push cargo-dist workflow never ran; call artifact publication directly
   from the release output and retain a manual tag backfill path.
+- Add result encoding as an explicit agentic adapter dimension so JSON and TOON runs share identical MCP tools, prompts, task snapshots, and verifier controls.
+- TOON reduced retained MCP result bytes by 35.69% and total provider tokens by 11.99% with 20/20 verified solves; keep encoding comparisons end-to-end because payload savings do not translate directly to provider-token savings.
+- Report command-output outliers separately from MCP result bytes; one unbounded source search added 472,157 bytes and materially inflated the active-token comparison despite leaving the total-token direction unchanged.
+- Keep production-default benchmark targets aligned with the server serialization default; retain explicit encoding adapters for controlled format comparisons.

--- a/LEARNINGS.md
+++ b/LEARNINGS.md
@@ -42,3 +42,5 @@ efficiency. Do not include secrets or raw sensitive output.
 - TOON reduced retained MCP result bytes by 35.69% and total provider tokens by 11.99% with 20/20 verified solves; keep encoding comparisons end-to-end because payload savings do not translate directly to provider-token savings.
 - Report command-output outliers separately from MCP result bytes; one unbounded source search added 472,157 bytes and materially inflated the active-token comparison despite leaving the total-token direction unchanged.
 - Keep production-default benchmark targets aligned with the server serialization default; retain explicit encoding adapters for controlled format comparisons.
+- Pin representation-sensitive protocol harnesses to an explicit result
+  encoding so changing the production default does not invalidate their parser.

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 	setup-oss-corpus test-token-integration run check bench bench-save \
 	bench-compare bench-storage bench-storage-compare bench-token bench-token-live bench-agentic \
 	bench-agentic-smoke bench-agentic-live bench-agentic-presentation \
-	bench-agentic-control-smoke publish-token-benchmark \
+	bench-agentic-control-smoke bench-agentic-toon publish-token-benchmark \
 	generate-bep-goldens fuzz-setup fuzz-list fuzz-smoke \
 	fuzz-run harden-release check-release-security \
 	mcp-conformance test-claude-code test-claude-code-live generate-sbom
@@ -105,7 +105,7 @@ bench-agentic-presentation:
 		--project $(OSS_PROJECT) --samples $(AGENTIC_PRESENTATION_SAMPLES) \
 		--model $(AGENTIC_MODEL) --reasoning-effort $(AGENTIC_REASONING_EFFORT) \
 		--task fix-noisy-normalizer --task fix-fanout-macro \
-		--adapter shell-default --adapter bazel-mcp $(AGENTIC_ARGS)
+		--adapter shell-default --adapter bazel-mcp-toon $(AGENTIC_ARGS)
 
 bench-agentic-control-smoke:
 	$(NIX_DEVELOP) ./scripts/benchmarks/run-agentic-benchmark.sh \
@@ -113,7 +113,14 @@ bench-agentic-control-smoke:
 		--model $(AGENTIC_MODEL) --reasoning-effort $(AGENTIC_REASONING_EFFORT) \
 		--task fix-noisy-normalizer --task fix-fanout-macro \
 		--adapter shell-default --adapter shell-mcp-loaded \
-		--adapter bazel-mcp $(AGENTIC_ARGS)
+		--adapter bazel-mcp-toon $(AGENTIC_ARGS)
+
+bench-agentic-toon:
+	$(NIX_DEVELOP) ./scripts/benchmarks/run-agentic-benchmark.sh \
+		--project $(OSS_PROJECT) --samples $(AGENTIC_PRESENTATION_SAMPLES) \
+		--model $(AGENTIC_MODEL) --reasoning-effort $(AGENTIC_REASONING_EFFORT) \
+		--task fix-noisy-normalizer --task fix-fanout-macro \
+		--adapter bazel-mcp --adapter bazel-mcp-toon $(AGENTIC_ARGS)
 
 publish-token-benchmark:
 	python3 ./scripts/benchmarks/publish-token-report.py \

--- a/README.md
+++ b/README.md
@@ -181,7 +181,7 @@ A basic call is an ordinary MCP tool request:
 ```
 
 Without a compatible task opt-in, the request remains attached and returns a
-normal `CallToolResult`. The default `text` encoding places the bounded logical
+normal `CallToolResult`. The default `toon` encoding places the bounded logical
 result in one text content block:
 
 ```json
@@ -191,7 +191,7 @@ result in one text content block:
   "result": {
     "content": [{
       "type": "text",
-      "text": "{\"invocation_id\":\"019f...\",\"state\":\"succeeded\",\"command\":\"build\",\"exit_code\":0,\"headline\":\"Build succeeded\",\"more_available\":true}"
+      "text": "invocation_id: \"019f...\"\nstate: succeeded\ncommand: build\nexit_code: 0\nheadline: Build succeeded\nmore_available: true"
     }],
     "isError": false
   }
@@ -381,6 +381,26 @@ roots or override the cache directory.
 See the [configuration reference](docs/configuration.md) for all settings and
 their defaults.
 
+### Result formats
+
+TOON is the default model-visible result format. Select a different format in
+the server configuration when required by an MCP host:
+
+```toml
+result_encoding = "toon"
+```
+
+| Value | Representation | When to use it |
+| --- | --- | --- |
+| `toon` | One token-oriented TOON text block. | Default; use for compact model context. |
+| `text` | One compact JSON text block. | Use when a host or downstream tool expects JSON text. |
+| `structured` | MCP `structuredContent` only. | Use with hosts verified to consume structured content without duplicating it into model context. |
+| `both` | Structured content plus compact JSON text. | Compatibility mode for hosts that need both representations; it has the largest model-visible footprint. |
+
+The setting applies to the server, not individual tool calls. Restart the MCP
+server after changing it. All four choices carry the same logical result,
+redaction, and byte ceilings; they only change its model-visible representation.
+
 ## Compatibility
 
 | Component | Supported |
@@ -416,10 +436,10 @@ corpus, acceptance gates, and reproduction commands.
 ### Agentic coding benchmark
 
 In a five-sample run over two high-output Abseil coding tasks,
-`gpt-5.6-luna` at `xhigh` reasoning solved all 10 attempts with both adapters.
-Compared with direct shell Bazel, `bazel-mcp` reduced provider-reported total
-tokens by **36.88%** and active tokens by **41.77%** when cached input was
-assigned zero weight.
+`gpt-5.6-luna` at `xhigh` reasoning solved all 10 attempts with both the direct
+shell and compact-JSON MCP adapters. The JSON MCP arm reduced
+provider-reported total tokens by **36.88%** and active tokens by **41.77%**
+when cached input was assigned zero weight.
 
 | Metric | Shell Bazel | `bazel-mcp` | Reduction |
 | --- | ---: | ---: | ---: |
@@ -428,9 +448,21 @@ assigned zero weight.
 | Active tokens, 0% cached-input weight | 479,593 | 279,254 | 41.77% |
 | Agent time | 653.2s | 637.1s | 2.46% |
 
+A second five-sample run compared the same MCP tools using compact JSON and
+TOON. Both encodings again solved every attempt, while TOON reduced total
+provider tokens by **11.99%** and the retained MCP result payload by **35.69%**.
+
+| Metric | Compact JSON | TOON | Reduction |
+| --- | ---: | ---: | ---: |
+| Verified solves | 10/10 | 10/10 | parity |
+| Total tokens | 1,624,930 | 1,430,032 | 11.99% |
+| MCP result bytes | 48,785 | 31,375 | 35.69% |
+
 The comparison includes MCP schema and tool-call overhead. See the
 [checked-in agentic benchmark report](docs/agentic-benchmark-report.md) for
 task-level results, cache sensitivity, integrity checks, and limitations, or
+the [TOON comparison report](docs/toon-agentic-benchmark-report.md) for the
+format-specific run. See
 the [agentic benchmark methodology](docs/benchmarks.md#agentic-coding-benchmark)
 to reproduce it.
 

--- a/crates/bazel-mcp-benchmark/src/agentic.rs
+++ b/crates/bazel-mcp-benchmark/src/agentic.rs
@@ -30,6 +30,7 @@ pub enum AgenticAdapter {
     ShellOptimized,
     ShellMcpLoaded,
     BazelMcp,
+    BazelMcpToon,
 }
 
 impl AgenticAdapter {
@@ -39,15 +40,28 @@ impl AgenticAdapter {
             Self::ShellOptimized => "shell-optimized",
             Self::ShellMcpLoaded => "shell-mcp-loaded",
             Self::BazelMcp => "bazel-mcp",
+            Self::BazelMcpToon => "bazel-mcp-toon",
         }
     }
 
     const fn loads_mcp(self) -> bool {
-        matches!(self, Self::ShellMcpLoaded | Self::BazelMcp)
+        matches!(
+            self,
+            Self::ShellMcpLoaded | Self::BazelMcp | Self::BazelMcpToon
+        )
     }
 
     const fn uses_shell_bazel(self) -> bool {
-        !matches!(self, Self::BazelMcp)
+        !matches!(self, Self::BazelMcp | Self::BazelMcpToon)
+    }
+
+    const fn result_encoding(self) -> &'static str {
+        match self {
+            Self::BazelMcpToon => "toon",
+            Self::ShellDefault | Self::ShellOptimized | Self::ShellMcpLoaded | Self::BazelMcp => {
+                "text"
+            }
+        }
     }
 }
 
@@ -322,8 +336,8 @@ impl AgenticReport {
             ));
         }
         output.push_str("\n## Task-level paired deltas\n\n");
-        output.push_str("Positive reductions mean MCP used less than the named baseline. Active tokens count uncached input plus output; tool output combines shell-command and MCP-result bytes.\n\n");
-        output.push_str("| Task | Baseline | Pairs | Verified (base/MCP) | Total-token reduction | Active-token reduction | Tool-output reduction | Agent-time reduction |\n");
+        output.push_str("Positive reductions mean the candidate used less than the named baseline. Active tokens count uncached input plus output; tool output combines shell-command and MCP-result bytes.\n\n");
+        output.push_str("| Task | Baseline | Pairs | Verified (base/candidate) | Total-token reduction | Active-token reduction | Tool-output reduction | Agent-time reduction |\n");
         output.push_str("| --- | --- | ---: | ---: | ---: | ---: | ---: | ---: |\n");
         for comparison in &self.task_comparisons {
             output.push_str(&format!(
@@ -413,6 +427,7 @@ struct ServerConfig {
     bazel_executable: PathBuf,
     output_user_root: PathBuf,
     environment_allowlist: BTreeSet<String>,
+    result_encoding: String,
 }
 
 #[derive(Debug)]
@@ -730,6 +745,7 @@ async fn run_codex(
             bazel_executable: bazel.to_owned(),
             output_user_root: output_root.join("mcp-output-user-root"),
             environment_allowlist: BTreeSet::from(["USE_BAZEL_VERSION".to_owned()]),
+            result_encoding: adapter.result_encoding().to_owned(),
         };
         tokio::fs::write(&path, toml::to_string_pretty(&server_config)?).await?;
         Some((server, path))
@@ -862,7 +878,9 @@ async fn run_codex(
         .context("parse Codex agentic final response")?;
     let shell_bazel_calls = count_wrapper_calls(&wrapper_log)?;
     let used_expected_bazel_path = match adapter {
-        AgenticAdapter::BazelMcp => parsed.mcp_bazel_run_calls > 0 && shell_bazel_calls == 0,
+        AgenticAdapter::BazelMcp | AgenticAdapter::BazelMcpToon => {
+            parsed.mcp_bazel_run_calls > 0 && shell_bazel_calls == 0
+        }
         AgenticAdapter::ShellDefault
         | AgenticAdapter::ShellOptimized
         | AgenticAdapter::ShellMcpLoaded => {
@@ -1258,19 +1276,19 @@ fn compare_weighted(
     samples: &[AgenticSample],
     adapters: &[AgenticAdapter],
 ) -> anyhow::Result<Vec<AgenticWeightedComparison>> {
-    if !adapters.contains(&AgenticAdapter::BazelMcp) {
+    let Some(candidate) = comparison_candidate(adapters) else {
         return Ok(Vec::new());
-    }
+    };
     adapters
         .iter()
         .copied()
-        .filter(|adapter| *adapter != AgenticAdapter::BazelMcp)
+        .filter(|adapter| *adapter != candidate)
         .flat_map(|baseline| CACHE_WEIGHT_PERCENTAGES.map(move |weight| (baseline, weight)))
         .map(|(baseline, weight)| {
-            let pairs = paired_samples(samples, baseline)?;
+            let pairs = paired_samples(samples, baseline, candidate)?;
             Ok(AgenticWeightedComparison {
                 baseline_adapter: baseline.name().to_owned(),
-                candidate_adapter: AgenticAdapter::BazelMcp.name().to_owned(),
+                candidate_adapter: candidate.name().to_owned(),
                 cached_input_weight_percent: weight,
                 weighted_token_reduction_percent: cluster_bootstrap_reduction(
                     &pairs,
@@ -1300,19 +1318,19 @@ fn compare(
     summaries: &[AgenticSummary],
     adapters: &[AgenticAdapter],
 ) -> anyhow::Result<Vec<AgenticComparison>> {
-    if !adapters.contains(&AgenticAdapter::BazelMcp) {
+    let Some(candidate) = comparison_candidate(adapters) else {
         return Ok(Vec::new());
-    }
+    };
     let candidate_summary = summaries
         .iter()
-        .find(|summary| summary.adapter == AgenticAdapter::BazelMcp.name())
+        .find(|summary| summary.adapter == candidate.name())
         .context("agentic MCP summary is missing")?;
     adapters
         .iter()
         .copied()
-        .filter(|adapter| *adapter != AgenticAdapter::BazelMcp)
+        .filter(|adapter| *adapter != candidate)
         .map(|baseline| {
-            let pairs = paired_samples(samples, baseline)?;
+            let pairs = paired_samples(samples, baseline, candidate)?;
             let concordant: Vec<_> = pairs
                 .iter()
                 .copied()
@@ -1334,7 +1352,7 @@ fn compare(
             let prefix = baseline.name();
             Ok(AgenticComparison {
                 baseline_adapter: baseline.name().to_owned(),
-                candidate_adapter: AgenticAdapter::BazelMcp.name().to_owned(),
+                candidate_adapter: candidate.name().to_owned(),
                 paired_attempts: pairs.len(),
                 concordant_verified_solves: concordant.len(),
                 solve_rate_delta_percentage_points: candidate_summary.solve_rate_percent
@@ -1366,15 +1384,15 @@ fn compare_tasks(
     samples: &[AgenticSample],
     adapters: &[AgenticAdapter],
 ) -> anyhow::Result<Vec<AgenticTaskComparison>> {
-    if !adapters.contains(&AgenticAdapter::BazelMcp) {
+    let Some(candidate) = comparison_candidate(adapters) else {
         return Ok(Vec::new());
-    }
+    };
     let tasks: BTreeSet<_> = samples.iter().map(|sample| sample.task.as_str()).collect();
     let mut comparisons = Vec::new();
     for baseline in adapters
         .iter()
         .copied()
-        .filter(|adapter| *adapter != AgenticAdapter::BazelMcp)
+        .filter(|adapter| *adapter != candidate)
     {
         for task in &tasks {
             let baseline_samples: Vec<_> = samples
@@ -1383,9 +1401,7 @@ fn compare_tasks(
                 .collect();
             let candidate_samples: Vec<_> = samples
                 .iter()
-                .filter(|sample| {
-                    sample.adapter == AgenticAdapter::BazelMcp.name() && sample.task == *task
-                })
+                .filter(|sample| sample.adapter == candidate.name() && sample.task == *task)
                 .collect();
             ensure!(
                 !baseline_samples.is_empty() && baseline_samples.len() == candidate_samples.len(),
@@ -1397,7 +1413,7 @@ fn compare_tasks(
             comparisons.push(AgenticTaskComparison {
                 task: (*task).to_owned(),
                 baseline_adapter: baseline.name().to_owned(),
-                candidate_adapter: AgenticAdapter::BazelMcp.name().to_owned(),
+                candidate_adapter: candidate.name().to_owned(),
                 paired_attempts: baseline_samples.len(),
                 baseline_verified_solves: baseline_samples
                     .iter()
@@ -1453,10 +1469,11 @@ fn sample_end_to_end_ms(sample: &AgenticSample) -> u64 {
 fn paired_samples(
     samples: &[AgenticSample],
     baseline: AgenticAdapter,
+    candidate: AgenticAdapter,
 ) -> anyhow::Result<Vec<(&AgenticSample, &AgenticSample)>> {
     let candidate: BTreeMap<_, _> = samples
         .iter()
-        .filter(|sample| sample.adapter == AgenticAdapter::BazelMcp.name())
+        .filter(|sample| sample.adapter == candidate.name())
         .map(|sample| ((sample.task.as_str(), sample.sample), sample))
         .collect();
     let baseline_samples: Vec<_> = samples
@@ -1483,6 +1500,16 @@ fn paired_samples(
             Ok((sample, candidate))
         })
         .collect()
+}
+
+fn comparison_candidate(adapters: &[AgenticAdapter]) -> Option<AgenticAdapter> {
+    if adapters.contains(&AgenticAdapter::BazelMcpToon) {
+        Some(AgenticAdapter::BazelMcpToon)
+    } else if adapters.contains(&AgenticAdapter::BazelMcp) {
+        Some(AgenticAdapter::BazelMcp)
+    } else {
+        None
+    }
 }
 
 fn cluster_bootstrap_reduction(
@@ -1535,7 +1562,7 @@ fn agent_prompt(
         AgenticAdapter::ShellMcpLoaded => {
             "Use the shell for every Bazel command. The bazel MCP server is configured only to measure its fixed context overhead; do not call any MCP tool."
         }
-        AgenticAdapter::BazelMcp => {
+        AgenticAdapter::BazelMcp | AgenticAdapter::BazelMcpToon => {
             "Use the shell for repository inspection, Git, and file edits. Use only the bazel MCP server for every Bazel build, test, coverage, or query invocation. Never invoke bazel, bazelisk, tools/bazel, or a command that transitively launches Bazel through the shell. The server owns Bazel presentation flags such as --color, --curses, --show_progress, --show_result, --test_output, and --test_summary; do not pass those flags to MCP. You may call bazel.run as often as the coding task requires and use bazel.inspect only when a bounded result omits evidence needed for the fix."
         }
     };
@@ -1973,6 +2000,18 @@ mod tests {
         assert_eq!(AgenticAdapter::ShellMcpLoaded.name(), "shell-mcp-loaded");
     }
 
+    #[test]
+    fn toon_adapter_changes_only_the_result_encoding() {
+        assert!(AgenticAdapter::BazelMcpToon.loads_mcp());
+        assert!(!AgenticAdapter::BazelMcpToon.uses_shell_bazel());
+        assert_eq!(AgenticAdapter::BazelMcp.result_encoding(), "text");
+        assert_eq!(AgenticAdapter::BazelMcpToon.result_encoding(), "toon");
+        assert_eq!(
+            comparison_candidate(&[AgenticAdapter::BazelMcp, AgenticAdapter::BazelMcpToon,]),
+            Some(AgenticAdapter::BazelMcpToon)
+        );
+    }
+
     #[tokio::test]
     async fn snapshot_is_a_clean_root_and_patch_captures_new_files() {
         let temporary = tempfile::tempdir().unwrap();
@@ -2113,7 +2152,7 @@ mod tests {
             protected_path_violations: Vec::new(),
             used_expected_bazel_path: true,
             shell_bazel_calls: u64::from(adapter.starts_with("shell")),
-            mcp_bazel_run_calls: u64::from(adapter == "bazel-mcp"),
+            mcp_bazel_run_calls: u64::from(adapter.starts_with("bazel-mcp")),
             model_events: 1,
             agent_message_events: 1,
             tool_calls: 1,

--- a/crates/bazel-mcp-benchmark/src/bin/agentic-benchmark.rs
+++ b/crates/bazel-mcp-benchmark/src/bin/agentic-benchmark.rs
@@ -57,7 +57,7 @@ async fn main() -> anyhow::Result<()> {
         .proxy_executable
         .unwrap_or_else(|| repository_root.join("target/debug/bazel-agentic-shell"));
     let adapters = if args.adapters.is_empty() {
-        vec![AgenticAdapter::ShellDefault, AgenticAdapter::BazelMcp]
+        vec![AgenticAdapter::ShellDefault, AgenticAdapter::BazelMcpToon]
     } else {
         args.adapters
     };

--- a/crates/bazel-mcp-server/src/config.rs
+++ b/crates/bazel-mcp-server/src/config.rs
@@ -11,8 +11,8 @@ use serde::{Deserialize, Serialize};
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum ResultEncoding {
-    #[default]
     Text,
+    #[default]
     Toon,
     Structured,
     Both,
@@ -97,7 +97,7 @@ impl Default for ServerConfig {
             progress_interval_seconds: 60,
             retention_days: 7,
             maximum_storage_bytes: 10 * 1024 * 1024 * 1024,
-            result_encoding: ResultEncoding::Text,
+            result_encoding: ResultEncoding::default(),
             supported_bazel_major_versions: [7, 8, 9].into_iter().collect(),
             allow_unsupported_bazel_versions: false,
             version_check_timeout_seconds: 30,
@@ -393,6 +393,15 @@ mod tests {
             let config = ServerConfig::load(&cli(path)).unwrap();
             assert_eq!(config.result_encoding, expected);
         }
+    }
+
+    #[test]
+    fn toon_is_the_default_result_encoding() {
+        assert_eq!(ResultEncoding::default(), ResultEncoding::Toon);
+        assert_eq!(
+            ServerConfig::default().result_encoding,
+            ResultEncoding::Toon
+        );
     }
 
     #[test]

--- a/docs/agentic-benchmark-report.md
+++ b/docs/agentic-benchmark-report.md
@@ -14,6 +14,7 @@ with otherwise equivalent attempts using `bazel-mcp`.
 | Project | `abseil-cpp` |
 | Corpus commit | `5650e9cf76d3be4318d5fa3af38ee483ddfd5e4a` |
 | Bazel | `9.1.0` |
+| MCP result encoding | compact JSON text |
 | Samples | 5 per task and adapter |
 | Run identifier | `agentic-1784163133577` |
 | Adapter order | cyclic task/sample counterbalancing |

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -98,6 +98,8 @@ often as needed, and returns a structured final response. A host-side verifier
 then tests the patch without exposing its additional test package to the agent.
 The latest presentation run is preserved in the
 [checked-in agentic benchmark report](agentic-benchmark-report.md).
+The compact-JSON versus TOON comparison is preserved in the
+[checked-in TOON agentic benchmark report](toon-agentic-benchmark-report.md).
 
 Every task and sample is run against identical snapshots with these adapters:
 
@@ -105,8 +107,10 @@ Every task and sample is run against identical snapshots with these adapters:
 - `shell-optimized`: Codex uses the shell with output and polling guidance;
 - `shell-mcp-loaded`: Codex uses the shell while the Bazel MCP schemas are
   loaded but prohibited, isolating fixed MCP context overhead;
-- `bazel-mcp`: Codex uses the shell for inspection and editing, but every Bazel
-  invocation must use `bazel.run` or `bazel.inspect`.
+- `bazel-mcp`: compact-JSON control; Codex uses the shell for inspection and
+  editing, but every Bazel invocation must use `bazel.run` or `bazel.inspect`;
+- `bazel-mcp-toon`: production-default TOON encoding with the same MCP-only
+  Bazel policy.
 
 The shell adapters find an instrumented executable on `PATH` that launches
 Bazel directly with an isolated output user root and preserves stdout and
@@ -177,6 +181,13 @@ launches six paid attempts:
 
 ```sh
 make bench-agentic-control-smoke
+```
+
+Compare the compact-JSON MCP result encoding with TOON on the two
+high-output tasks. At five samples it launches twenty paid attempts:
+
+```sh
+make bench-agentic-toon
 ```
 
 Agentic Make targets pin `gpt-5.6-luna` with `xhigh` reasoning by default.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -94,15 +94,15 @@ Raw evidence remains local and should still be treated as sensitive.
 ### Choose a result encoding
 
 ```toml
-result_encoding = "text"
+result_encoding = "toon"
 ```
 
 Available values are:
 
 | Value | MCP result |
 | --- | --- |
-| `text` | Compact JSON in one text content block. This is the default. |
-| `toon` | Token-oriented TOON text in one content block. |
+| `text` | Compact JSON in one text content block. |
+| `toon` | Token-oriented TOON text in one content block. This is the default. |
 | `structured` | MCP structured content only. |
 | `both` | Structured content plus backwards-compatible JSON text. |
 
@@ -156,7 +156,7 @@ and must be between 100 and 60,000 milliseconds.
 | `retention_days` | `7` | Maximum age of retained invocation evidence. |
 | `maximum_storage_bytes` | `10737418240` | Maximum cache size before older evidence is removed. |
 | `retention_cleanup_interval_seconds` | `3600` | Interval between retention sweeps. |
-| `result_encoding` | `text` | Model-visible result representation. |
+| `result_encoding` | `toon` | Model-visible result representation. |
 | `supported_bazel_major_versions` | `[7, 8, 9]` | Bazel major versions accepted by default. |
 | `allow_unsupported_bazel_versions` | `false` | Allow majors outside `supported_bazel_major_versions`. |
 | `version_check_timeout_seconds` | `30` | Timeout for the pre-invocation Bazel version check. |

--- a/docs/toon-agentic-benchmark-report.md
+++ b/docs/toon-agentic-benchmark-report.md
@@ -1,0 +1,115 @@
+# TOON agentic benchmark report
+
+This is the checked-in result of the TOON comparison recorded on 2026-07-16.
+It compares complete Codex coding attempts using the then-default compact-JSON
+MCP result encoding with otherwise equivalent attempts using TOON. TOON became
+the production default after this run.
+
+## Configuration
+
+| Setting | Value |
+| --- | --- |
+| Provider | `codex-cli 0.144.4` |
+| Model | `gpt-5.6-luna` |
+| Reasoning effort | `xhigh` |
+| Project | `abseil-cpp` |
+| Corpus commit | `5650e9cf76d3be4318d5fa3af38ee483ddfd5e4a` |
+| Bazel | `9.1.0` |
+| Samples | 5 per task and encoding |
+| Run identifier | `agentic-1784182634748` |
+| Adapter order | cyclic task/sample counterbalancing |
+
+Both arms loaded exactly `bazel.run`, `bazel.inspect`, and `bazel.cancel`, used
+the same MCP-only Bazel policy and agent prompt, and ran against clean snapshots
+of the pinned corpus. Apart from their isolated per-attempt paths, their server
+configurations differed only in `result_encoding`: `text` for the default arm
+and `toon` for the candidate.
+
+## Headline results
+
+Both encodings solved all ten attempts. TOON used 11.99% fewer total tokens,
+with a task-clustered 95% interval of 8.00% to 15.29%.
+
+| Encoding | Attempts | Verified | Solve rate | Input | Cached input | Uncached input | Output | Total | Tokens / solve |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| Default JSON text | 10 | 10 | 100.00% | 1,599,017 | 1,264,640 | 334,377 | 25,913 | 1,624,930 | 162,493 |
+| TOON text | 10 | 10 | 100.00% | 1,405,163 | 1,155,072 | 250,091 | 24,869 | 1,430,032 | 143,003 |
+
+| Paired metric | Result | Task-clustered 95% interval |
+| --- | ---: | ---: |
+| Solve-rate delta | 0.00 pp | n/a |
+| Total-token reduction | 11.99% | 8.00–15.29% |
+| Uncached-input reduction | 25.21% | 0.65–40.03% |
+| Concordant-solve token reduction | 11.99% | 8.00–15.29% |
+
+TOON reduced the retained MCP result payloads from 48,785 to 31,375 bytes, a
+35.69% reduction. Provider token savings are smaller because result payloads
+are only part of the complete multi-turn agent context.
+
+## Task-level results
+
+Positive reductions mean TOON used less than default. Active tokens count
+uncached input plus output. Tool output combines command and MCP-result bytes.
+
+| Task | Pairs | Verified (default/TOON) | Total-token reduction | Active-token reduction | Tool-output reduction | Agent-time reduction |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: |
+| 48-action compile fan-out | 5 | 5/5 | 15.29% | 38.04% | 85.61% | 4.14% |
+| 512-case failing test | 5 | 5/5 | 8.00% | 0.62% | 2.53% | 1.07% |
+
+TOON used fewer total tokens in eight of the ten matched pairs. Both task
+families had positive aggregate reductions.
+
+## Cached-input sensitivity
+
+These scenarios count uncached input and output at full weight, then vary the
+weight assigned to cached input. They are sensitivity analyses rather than
+pricing assumptions.
+
+| Cached-input weight | Default weighted tokens | TOON weighted tokens | Reduction | Task-clustered 95% interval |
+| ---: | ---: | ---: | ---: | ---: |
+| 0% | 360,290 | 274,960 | 23.68% | 0.62–38.04% |
+| 25% | 676,450 | 563,728 | 16.66% | 5.33–25.02% |
+| 100% | 1,624,930 | 1,430,032 | 11.99% | 8.00–15.29% |
+
+The direction is unchanged across all three cache-weight scenarios.
+
+## Agent behavior and evidence
+
+| Encoding | Agent messages | Tool calls | Command output | MCP output | Agent time |
+| --- | ---: | ---: | ---: | ---: | ---: |
+| Default JSON text | 46 | 66 | 569,173 bytes | 48,785 bytes | 732.6s |
+| TOON text | 45 | 70 | 93,257 bytes | 31,375 bytes | 713.0s |
+
+One default fan-out attempt ran an unbounded repository-wide source search that
+produced 472,157 bytes of command output. The attempt remains in every canonical
+aggregate above. As a non-canonical sensitivity check, dropping that entire
+matched pair leaves 9/9 solves per arm, a 10.96% total-token reduction, and a
+12.40% active-token reduction. This supports the total-token direction while
+showing that the headline active-token result is sensitive to agent behavior
+outside MCP result encoding.
+
+## Integrity audit
+
+- All 20 attempts completed and passed the independent hidden verifier.
+- All attempts changed exactly the intended implementation or macro file.
+- No protected path or `.bazelversion` changed.
+- Each arm made 20 successful `bazel.run` calls: one pre-fix reproduction and
+  one post-fix validation per attempt.
+- The default arm made five `bazel.inspect` calls and the TOON arm made three;
+  none of the 48 completed MCP calls had a protocol error.
+- Neither arm invoked Bazel through the shell.
+- Ten retained server configurations used `text`; ten used `toon`.
+- Adapter binaries were snapshotted before the first attempt, and adapter order
+  was counterbalanced by task and sample.
+
+## Interpretation and limitations
+
+This run supports TOON for the tested high-output Bazel failure classes: solve
+rate was unchanged, direct MCP output was smaller, and total provider tokens
+fell under every cache-weight scenario. It does not establish the same effect
+for low-output results, deeply nested or irregular responses, other models, or
+other repositories. The confidence interval clusters over two independent task
+families, and provider behavior can change independently of this repository.
+
+See the [benchmark methodology](benchmarks.md#agentic-coding-benchmark) for the
+harness controls, reproduction commands, and artifact layout.

--- a/examples/config.toml
+++ b/examples/config.toml
@@ -17,9 +17,10 @@ task_poll_interval_ms = 2000
 redaction_patterns = ["(?i)token=[^\\s]+"]
 retention_days = 7
 maximum_storage_bytes = 10737418240
-# Model-visible tool results: "text" (compact JSON), "toon", "structured", or "both".
+# Model-visible tool results: "toon" (the default), "text" (compact JSON),
+# "structured", or "both".
 retention_cleanup_interval_seconds = 3600
-result_encoding = "text"
+result_encoding = "toon"
 supported_bazel_major_versions = [7, 8, 9]
 # Set only to explicitly accept an untested Bazel major version.
 allow_unsupported_bazel_versions = false

--- a/scripts/test-mcp-conformance.py
+++ b/scripts/test-mcp-conformance.py
@@ -160,6 +160,7 @@ def write_config(path, workspace, cache, wrapper, policy):
         f"cache_root = {json.dumps(str(cache))}\n"
         f"bazel_executable = {json.dumps(str(wrapper))}\n"
         f"mcp_execution_policy = {json.dumps(policy)}\n"
+        'result_encoding = "text"\n'
         "task_ttl_seconds = 3600\n"
         "task_poll_interval_ms = 100\n"
         "progress_initial_seconds = 1\n"

--- a/specs/001-product-requirements.md
+++ b/specs/001-product-requirements.md
@@ -357,9 +357,9 @@ workspace or the invocation store.
 The server supports four deployment-level result encodings:
 
 - `text`: one compact JSON `TextContent` block and no duplicate
-  `structuredContent`; this is the default.
-- `toon`: one TOON-encoded `TextContent` block and no duplicate
   `structuredContent`.
+- `toon`: one TOON-encoded `TextContent` block and no duplicate
+  `structuredContent`; this is the default.
 - `structured`: structured content for hosts proven to handle it without placing
   a duplicate representation in model context.
 - `both`: structured content plus the backwards-compatible text representation.


### PR DESCRIPTION
## Summary

- add a controlled `bazel-mcp-toon` agentic adapter and JSON-versus-TOON benchmark target
- make TOON the default server result encoding and align the standard agentic targets with the production default
- document all four result formats in the README and configuration reference
- check in the benchmark methodology, integrity audit, results, and Bazel MCP learnings

## Why

The paired agentic benchmark found that TOON preserved solve quality while reducing complete provider context and model-visible MCP payloads. Making it the default applies those measured savings without changing the logical Bazel result, evidence retention, redaction, or public tool surface.

## Benchmark results

| Metric | Compact JSON | TOON | Reduction |
| --- | ---: | ---: | ---: |
| Verified solves | 10/10 | 10/10 | parity |
| Total tokens | 1,624,930 | 1,430,032 | 11.99% |
| MCP result bytes | 48,785 | 31,375 | 35.69% |

The total-token reduction has a task-clustered 95% interval of 8.00%–15.29%. One JSON fan-out attempt emitted 472,157 bytes from an unbounded source search; excluding that entire matched pair still yields a 10.96% total-token reduction.

## User impact

Unconfigured servers now return TOON text. Existing deployments can retain compact JSON with:

```toml
result_encoding = "text"
```

`structured` and `both` remain available for host compatibility.

## Validation

- `cargo fmt --all -- --check`
- `make test`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- 20-attempt agentic benchmark on pinned Abseil/Bazel 9.1.0 corpus
- benchmark integrity audit: 20/20 hidden-verifier passes, 48 completed MCP calls without protocol errors, and zero shell Bazel calls
