### PR TITLE
fix(release): publish platform artifacts from Release Please

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -3,8 +3,7 @@ on:
   push:
     branches: [main]
 permissions:
-  contents: write
-  pull-requests: write
+  contents: read
 concurrency:
   group: release-please
   cancel-in-progress: false
@@ -12,8 +11,26 @@ jobs:
   release:
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    permissions:
+      contents: write
+      pull-requests: write
+    outputs:
+      release_created: ${{ steps.release.outputs.release_created }}
+      tag_name: ${{ steps.release.outputs.tag_name }}
     steps:
-      - uses: googleapis/release-please-action@c2a5a2bd6a758a0937f1ddb1e8950609867ed15c # v4.3.0
+      - id: release
+        uses: googleapis/release-please-action@c2a5a2bd6a758a0937f1ddb1e8950609867ed15c # v4.3.0
         with:
           config-file: .release-please-config.json
           manifest-file: .release-please-manifest.json
+
+  publish-artifacts:
+    needs: release
+    if: ${{ needs.release.outputs.release_created == 'true' }}
+    permissions:
+      contents: write
+    uses: ./.github/workflows/release.yml
+    with:
+      tag: ${{ needs.release.outputs.tag_name }}
+    secrets:
+      HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,11 +17,16 @@ name: Release
 permissions:
   "contents": "read"
 concurrency:
-  group: release-${{ github.ref }}
+  group: release-${{ inputs.tag || github.ref }}
   cancel-in-progress: false
 
-# This task will run whenever you push a git tag that looks like a version
-# like "1.0.0", "v0.1.0-prerelease.1", "my-app/0.1.0", "releases/v1.0.0", etc.
+env:
+  RELEASE_TAG: ${{ inputs.tag || github.ref_name }}
+
+# Release Please calls this workflow with the tag it created. Maintainers can
+# also backfill an existing tag manually, and independently pushed release tags
+# remain supported. Accepted version tags look like "1.0.0",
+# "v0.1.0-prerelease.1", "my-app/0.1.0", "releases/v1.0.0", etc.
 # Various formats will be parsed into a VERSION and an optional PACKAGE_NAME, where
 # PACKAGE_NAME must be the name of a Cargo package in your workspace, and VERSION
 # must be a Cargo-style SemVer Version (must have at least major.minor.patch).
@@ -42,6 +47,22 @@ concurrency:
 # If there's a prerelease-style suffix to the version, then the release(s)
 # will be marked as a prerelease.
 on:
+  workflow_call:
+    inputs:
+      tag:
+        description: Existing release tag to build and publish
+        required: true
+        type: string
+    secrets:
+      HOMEBREW_TAP_TOKEN:
+        description: Token used to update the Homebrew tap
+        required: true
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: Existing release tag to build and publish
+        required: true
+        type: string
   push:
     tags:
       - '**[0-9]+.[0-9]+.[0-9]+*'
@@ -62,17 +83,18 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           persist-credentials: false
+          ref: ${{ env.RELEASE_TAG }}
           submodules: recursive
       - name: Install dist
         # we specify bash to get pipefail; it guards against the `curl` command
         # failing. otherwise `sh` won't catch that `curl` returned non-0
         shell: bash
         run: "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/v0.31.0/cargo-dist-installer.sh | sh"
-      # This workflow only runs for release tags, so pass the tag through GitHub's
-      # environment instead of expanding event data directly into shell source.
+      # Pass the validated tag input through the environment instead of expanding
+      # event data directly into shell source.
       - id: plan
         run: |
-          dist host --steps=create "--tag=$GITHUB_REF_NAME" --output-format=json > plan-dist-manifest.json
+          dist host --steps=create "--tag=$RELEASE_TAG" --output-format=json > plan-dist-manifest.json
           echo "dist ran successfully"
           cat plan-dist-manifest.json
           echo "manifest=$(jq -c "." plan-dist-manifest.json)" >> "$GITHUB_OUTPUT"
@@ -111,6 +133,7 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           persist-credentials: false
+          ref: ${{ env.RELEASE_TAG }}
           submodules: recursive
       - name: Install dist
         # Install a native binary for this matrix runner. Reusing the plan
@@ -134,7 +157,7 @@ jobs:
           DIST_TARGET: ${{ join(matrix.targets, ',') }}
         run: |
           # Actually do builds and make zips and whatnot
-          dist build "--tag=$GITHUB_REF_NAME" --print=linkage --output-format=json "--artifacts=local" "--target=$DIST_TARGET" > dist-manifest.json
+          dist build "--tag=$RELEASE_TAG" --print=linkage --output-format=json "--artifacts=local" "--target=$DIST_TARGET" > dist-manifest.json
           echo "dist ran successfully"
       - id: cargo-dist
         name: Post-build
@@ -171,6 +194,7 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           persist-credentials: false
+          ref: ${{ env.RELEASE_TAG }}
           submodules: recursive
       - name: Install dist
         shell: bash
@@ -185,7 +209,7 @@ jobs:
       - id: cargo-dist
         shell: bash
         run: |
-          dist build "--tag=$GITHUB_REF_NAME" --output-format=json "--artifacts=global" > dist-manifest.json
+          dist build "--tag=$RELEASE_TAG" --output-format=json "--artifacts=global" > dist-manifest.json
           echo "dist ran successfully"
 
           # Parse out what we just built and upload it to scratch storage
@@ -226,6 +250,7 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           persist-credentials: false
+          ref: ${{ env.RELEASE_TAG }}
           submodules: recursive
       - name: Install dist
         shell: bash
@@ -240,8 +265,8 @@ jobs:
       - id: host
         shell: bash
         run: |
-          dist host "--tag=$GITHUB_REF_NAME" --steps=upload --steps=release --output-format=json > dist-manifest.json
-          echo "artifacts uploaded and released successfully"
+          dist host "--tag=$RELEASE_TAG" --steps=upload --steps=release --output-format=json > dist-manifest.json
+          echo "release manifest generated successfully"
           cat dist-manifest.json
           echo "manifest=$(jq -c "." dist-manifest.json)" >> "$GITHUB_OUTPUT"
       - name: "Upload dist-manifest.json"
@@ -250,7 +275,8 @@ jobs:
           # Overwrite the previous copy
           name: artifacts-dist-manifest
           path: dist-manifest.json
-      # Create a GitHub Release while uploading all files to it
+      # Upload all files to the GitHub Release created by Release Please. Keep a
+      # create fallback for tags pushed independently of Release Please.
       - name: "Download GitHub Artifacts"
         uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7
         with:
@@ -261,17 +287,19 @@ jobs:
         run: |
           # Remove the granular manifests
           rm -f artifacts/*-dist-manifest.json
-      - name: Create GitHub Release
+      - name: Publish GitHub release artifacts
         env:
           PRERELEASE_FLAG: "${{ fromJson(steps.host.outputs.manifest).announcement_is_prerelease && '--prerelease' || '' }}"
           ANNOUNCEMENT_TITLE: "${{ fromJson(steps.host.outputs.manifest).announcement_title }}"
           ANNOUNCEMENT_BODY: "${{ fromJson(steps.host.outputs.manifest).announcement_github_body }}"
-          RELEASE_COMMIT: "${{ github.sha }}"
         run: |
-          # Write and read notes from a file to avoid quoting breaking things
-          echo "$ANNOUNCEMENT_BODY" > $RUNNER_TEMP/notes.txt
-
-          gh release create "$GITHUB_REF_NAME" --target "$RELEASE_COMMIT" $PRERELEASE_FLAG --title "$ANNOUNCEMENT_TITLE" --notes-file "$RUNNER_TEMP/notes.txt" artifacts/*
+          if gh release view "$RELEASE_TAG" >/dev/null 2>&1; then
+            gh release upload "$RELEASE_TAG" artifacts/* --clobber
+          else
+            # Write and read notes from a file to avoid quoting breaking things.
+            echo "$ANNOUNCEMENT_BODY" > "$RUNNER_TEMP/notes.txt"
+            gh release create "$RELEASE_TAG" $PRERELEASE_FLAG --title "$ANNOUNCEMENT_TITLE" --notes-file "$RUNNER_TEMP/notes.txt" artifacts/*
+          fi
 
   publish-homebrew-formula:
     needs:
@@ -337,4 +365,5 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           persist-credentials: false
+          ref: ${{ env.RELEASE_TAG }}
           submodules: recursive

--- a/LEARNINGS.md
+++ b/LEARNINGS.md
@@ -35,3 +35,6 @@ efficiency. Do not include secrets or raw sensitive output.
 - The Cargo process integration test passed while its Bazel target lacked a
   direct BEP dependency; keep standalone `rust_test` deps aligned with imports
   and include repository-wide Bazel tests in pre-merge validation.
+- Release Please created the Bazel-strategy tag with `GITHUB_TOKEN`, so the
+  tag-push cargo-dist workflow never ran; call artifact publication directly
+  from the release output and retain a manual tag backfill path.

--- a/scripts/check-release-please-config.py
+++ b/scripts/check-release-please-config.py
@@ -8,7 +8,7 @@ manifest = json.loads((root / ".release-please-manifest.json").read_text())
 cargo = (root / "Cargo.toml").read_text()
 module = (root / "MODULE.bazel").read_text()
 server_build = (root / "crates/bazel-mcp-server/BUILD.bazel").read_text()
-assert config["packages"]["."]["release-type"] == "rust"
+assert config["packages"]["."]["release-type"] == "bazel"
 assert manifest["."] in cargo
 assert manifest["."] in module
 assert manifest["."] in server_build

--- a/scripts/check-release-security.py
+++ b/scripts/check-release-security.py
@@ -12,7 +12,9 @@ for workflow in (root / ".github/workflows").glob("*.yml"):
     for line in source.splitlines():
         if "uses:" in line:
             reference = line.split("uses:", 1)[1].split("#", 1)[0].strip()
-            if not re.search(r"@[0-9a-f]{40}$", reference):
+            if not reference.startswith("./") and not re.search(
+                r"@[0-9a-f]{40}$", reference
+            ):
                 errors.append(f"{workflow.name}: action is not pinned: {reference}")
     if "actions/checkout" in source and "persist-credentials: false" not in source:
         errors.append(f"{workflow.name}: checkout credentials are not disabled")


### PR DESCRIPTION
## Summary

- invoke the reusable cargo-dist release workflow directly when Release Please creates a release
- pass the emitted tag through every checkout and dist command
- upload artifacts into an existing Release Please release, while retaining tag-push and manual backfill paths
- narrow workflow permissions and update the release configuration/security validators
- record the Bazel MCP release observation in `LEARNINGS.md`

## Root cause

Release Please creates its release tag with the repository `GITHUB_TOKEN`. GitHub suppresses follow-on workflow runs for events created by that token, so the tag-push-only cargo-dist workflow did not run for `v0.2.0`. The release was created with zero binary assets even though six macOS/Linux targets remain configured.

## Impact

Future Release Please releases will build and attach all configured platform archives, checksums, installers, the SBOM, and manifest without requiring a PAT. Existing tags can be backfilled through the manual `workflow_dispatch` input; after this lands, run:

```bash
gh workflow run release.yml -f tag=v0.2.0
```

## Validation

- `python3 scripts/check-release-please-config.py`
- `make harden-release`
- `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.7 .github/workflows/*.yml`
- `uvx zizmor .github/workflows`
- `git diff --check`
