### PR TITLE
feat(release): publish Windows binaries

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,6 +65,15 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with: { persist-credentials: false }
       - run: cargo check --workspace --all-targets --all-features
+      - name: Install dist
+        shell: pwsh
+        run: irm https://github.com/axodotdev/cargo-dist/releases/download/v0.31.0/cargo-dist-installer.ps1 | iex
+      - name: Build Windows release archive
+        shell: pwsh
+        run: dist build --print=linkage --output-format=json --artifacts=local --target=x86_64-pc-windows-msvc > dist-manifest.json
+      - name: Smoke test Windows release archive
+        shell: pwsh
+        run: ./scripts/smoke-windows-release.ps1
   cargo-deny:
     runs-on: ubuntu-latest
     timeout-minutes: 20

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -135,11 +135,16 @@ jobs:
           persist-credentials: false
           ref: ${{ env.RELEASE_TAG }}
           submodules: recursive
-      - name: Install dist
+      - name: Install dist (Unix)
+        if: ${{ runner.os != 'Windows' }}
         # Install a native binary for this matrix runner. Reusing the plan
         # job's binary breaks on ARM Linux and macOS runners.
         shell: bash
         run: "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/v0.31.0/cargo-dist-installer.sh | sh"
+      - name: Install dist (Windows)
+        if: ${{ runner.os == 'Windows' }}
+        shell: pwsh
+        run: irm https://github.com/axodotdev/cargo-dist/releases/download/v0.31.0/cargo-dist-installer.ps1 | iex
       # Get the dist-manifest
       - name: Fetch local artifacts
         uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7
@@ -152,13 +157,27 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install --yes musl-tools
-      - name: Build artifacts
+      - name: Build artifacts (Unix)
+        if: ${{ runner.os != 'Windows' }}
         env:
           DIST_TARGET: ${{ join(matrix.targets, ',') }}
+        shell: bash
         run: |
           # Actually do builds and make zips and whatnot
           dist build "--tag=$RELEASE_TAG" --print=linkage --output-format=json "--artifacts=local" "--target=$DIST_TARGET" > dist-manifest.json
           echo "dist ran successfully"
+      - name: Build artifacts (Windows)
+        if: ${{ runner.os == 'Windows' }}
+        env:
+          DIST_TARGET: ${{ join(matrix.targets, ',') }}
+        shell: pwsh
+        run: |
+          dist build "--tag=$env:RELEASE_TAG" --print=linkage --output-format=json "--artifacts=local" "--target=$env:DIST_TARGET" > dist-manifest.json
+          Write-Output "dist ran successfully"
+      - name: Smoke test Windows archive
+        if: ${{ runner.os == 'Windows' }}
+        shell: pwsh
+        run: ./scripts/smoke-windows-release.ps1
       - id: cargo-dist
         name: Post-build
         # We force bash here just because github makes it really hard to get values up

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -84,7 +84,7 @@ lto = "thin"
 [workspace.metadata.dist]
 cargo-dist-version = "0.31.0"
 ci = "github"
-installers = ["shell", "homebrew"]
+installers = ["shell", "powershell", "homebrew"]
 tap = "ewhauser/homebrew-tap"
 publish-jobs = ["homebrew"]
 targets = [
@@ -92,6 +92,7 @@ targets = [
   "aarch64-unknown-linux-gnu",
   "aarch64-unknown-linux-musl",
   "x86_64-apple-darwin",
+  "x86_64-pc-windows-msvc",
   "x86_64-unknown-linux-gnu",
   "x86_64-unknown-linux-musl",
 ]

--- a/LEARNINGS.md
+++ b/LEARNINGS.md
@@ -38,6 +38,9 @@ efficiency. Do not include secrets or raw sensitive output.
 - Release Please created the Bazel-strategy tag with `GITHUB_TOKEN`, so the
   tag-push cargo-dist workflow never ran; call artifact publication directly
   from the release output and retain a manual tag backfill path.
+- The Unix-only release matrix hid hard-coded shell assumptions; keep
+  platform-specific install/build steps explicit and smoke-test packaged
+  Windows executables before upload.
 - Add result encoding as an explicit agentic adapter dimension so JSON and TOON runs share identical MCP tools, prompts, task snapshots, and verifier controls.
 - TOON reduced retained MCP result bytes by 35.69% and total provider tokens by 11.99% with 20/20 verified solves; keep encoding comparisons end-to-end because payload savings do not translate directly to provider-token savings.
 - Report command-output outliers separately from MCP result bytes; one unbounded source search added 472,157 bytes and materially inflated the active-token comparison despite leaving the total-token direction unchanged.

--- a/LEARNINGS.md
+++ b/LEARNINGS.md
@@ -16,6 +16,9 @@ efficiency. Do not include secrets or raw sensitive output.
 
 ### 2026-07-16
 
+- A persistent CI disk cache can bypass an embedded remote-cache smoke server
+  even with isolated output bases; disable unrelated cache layers when testing
+  transport-specific reads and writes, and report observed request counts.
 - Listing full durable invocation records exhausted 8 KiB and destructive byte
   shrinking erased IDs and states; keep ledger rows compact and direct users to
   per-invocation views for canonical arguments and detailed diagnostics.

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ toolchains, and remote execution settings.
 
 ### Requirements
 
-- macOS or Linux
+- macOS, Linux, or Windows x86_64 (preview)
 - Bazel 8 or 9, Bazelisk, or an executable workspace-local `tools/bazel`
 - an MCP-compatible client
 - Bazelisk when building from source (the repository pins Bazel and Rust)
@@ -50,7 +50,13 @@ or run the shell installer on macOS or Linux:
 
 ```sh
 curl --proto '=https' --tlsv1.2 -LsSf \
-  https://github.com/ewhauser/bazel-mcp/releases/latest/download/bazel-mcp-installer.sh | sh
+  https://github.com/ewhauser/bazel-mcp/releases/latest/download/bazel-mcp-server-installer.sh | sh
+```
+
+On Windows, run the PowerShell installer:
+
+```powershell
+irm https://github.com/ewhauser/bazel-mcp/releases/latest/download/bazel-mcp-server-installer.ps1 | iex
 ```
 
 ### Build from source
@@ -406,7 +412,7 @@ redaction, and byte ceilings; they only change its model-visible representation.
 | Component | Supported |
 | --- | --- |
 | Bazel | Major versions 8 and 9 |
-| Platforms | macOS and Linux |
+| Platforms | macOS and Linux; Windows x86_64 preview |
 | Transport | Local MCP over stdio |
 | Bazel discovery | `tools/bazel`, then Bazelisk, then Bazel on `PATH` |
 | Task execution | Synchronous fallback, MCP `2025-11-25` legacy tasks, and the SEP-2663 Tasks extension |

--- a/scripts/smoke-windows-release.ps1
+++ b/scripts/smoke-windows-release.ps1
@@ -1,0 +1,28 @@
+param(
+    [string]$DistribDir = "target/distrib"
+)
+
+$ErrorActionPreference = "Stop"
+
+$archives = @(Get-ChildItem $DistribDir -Filter "*-pc-windows-msvc.zip")
+if ($archives.Count -ne 1) {
+    throw "expected exactly one Windows release archive, found $($archives.Count)"
+}
+
+$smokeRoot = Join-Path ([System.IO.Path]::GetTempPath()) "bazel-mcp-windows-smoke"
+if (Test-Path $smokeRoot) {
+    Remove-Item $smokeRoot -Recurse -Force
+}
+Expand-Archive -Path $archives[0].FullName -DestinationPath $smokeRoot
+
+$binaries = @(Get-ChildItem $smokeRoot -Recurse -Filter "bazel-mcp.exe")
+if ($binaries.Count -ne 1) {
+    throw "expected exactly one bazel-mcp.exe in the Windows archive, found $($binaries.Count)"
+}
+
+$version = & $binaries[0].FullName --version
+if ($LASTEXITCODE -ne 0 -or $version -notmatch '^bazel-mcp [0-9]+\.[0-9]+\.[0-9]+') {
+    throw "packaged Windows binary did not report a valid version: $version"
+}
+
+Write-Output $version

--- a/scripts/test-mcp-smoke.py
+++ b/scripts/test-mcp-smoke.py
@@ -214,6 +214,7 @@ def main():
     try:
         remote_args = [
             "//:remote_cache_target", f"--remote_cache={cache_url}",
+            "--disk_cache=",
             "--remote_upload_local_results=true", "--remote_timeout=10",
         ]
         first = call(
@@ -227,7 +228,10 @@ def main():
         if first["state"] != "succeeded" or second["state"] != "succeeded":
             raise RuntimeError(f"remote cache builds failed: {first} {second}")
         if CacheHandler.puts == 0 or CacheHandler.gets == 0:
-            raise RuntimeError("remote cache did not observe both uploads and reads")
+            raise RuntimeError(
+                "remote cache did not observe both uploads and reads "
+                f"(puts={CacheHandler.puts}, gets={CacheHandler.gets})"
+            )
         print("remote_cache\tsucceeded\t0")
     finally:
         cache_server.shutdown()

--- a/specs/001-product-requirements.md
+++ b/specs/001-product-requirements.md
@@ -112,8 +112,9 @@ The first production release will not:
 - Implement a distributed scheduler across machines.
 - Use TOON or another non-standard serialization as a prerequisite for token
   savings.
-- Support Windows in the MVP. Windows process cancellation and job-object support
-  are a later compatibility milestone.
+- Provide full Windows runtime parity in the MVP. A Windows x86_64 preview
+  binary is released, while process-tree cancellation and job-object support
+  remain a later compatibility milestone.
 
 ## 6. Users and primary workflows
 
@@ -1105,7 +1106,8 @@ blocking BEP and filesystem work uses bounded blocking tasks.
 - Filesystem filtering, atomic-record recovery, and stable pagination.
 - Retention and crash recovery.
 - Token, diagnostic-fidelity, performance, and security acceptance gates.
-- macOS/Linux and Bazel-version compatibility matrix.
+- macOS/Linux and Bazel-version compatibility matrix, plus a Windows x86_64
+  release-binary smoke check.
 
 ### Phase 3: Hardening and integrations
 

--- a/specs/002-project-architecture.md
+++ b/specs/002-project-architecture.md
@@ -63,7 +63,8 @@ clean-room, or crates.io publishing setup in the initial architecture.
 - Provide one supported command for each common developer operation.
 - Make the Bazel-version matrix, BEP fixtures, token benchmark, and MCP
   conformance suite first-class repository assets.
-- Produce reproducible macOS and Linux release binaries with an SBOM.
+- Produce reproducible macOS, Linux, and Windows x86_64 release binaries with
+  an SBOM.
 - Preserve the ability to add HTTP transport and remote artifact adapters
   without restructuring the core.
 
@@ -75,8 +76,8 @@ clean-room, or crates.io publishing setup in the initial architecture.
   of truth for this repository.
 - A plugin system for reducers or storage backends.
 - A second async runtime.
-- Windows runtime support in the MVP. Windows compilation remains a useful CI
-  guard, but process cancellation is implemented later.
+- Full Windows process-tree cancellation in the MVP. A Windows x86_64 preview
+  binary uses direct-child termination until job-object support is implemented.
 - Copying Shuck's Python, npm, website, oracle, or large shell-corpus workflows.
 
 ## Repository layout
@@ -1241,13 +1242,14 @@ cargo-dist builds the `bazel-mcp` binary for:
 
 - `aarch64-apple-darwin`
 - `x86_64-apple-darwin`
+- `x86_64-pc-windows-msvc` (preview)
 - `aarch64-unknown-linux-gnu`
 - `aarch64-unknown-linux-musl`
 - `x86_64-unknown-linux-gnu`
 - `x86_64-unknown-linux-musl`
 
-Initial installers are shell and Homebrew. Windows targets and PowerShell are
-added when Windows runtime support meets specification 001.
+Installers are shell, PowerShell, and Homebrew. Windows process-tree
+cancellation remains a later compatibility milestone in specification 001.
 
 The release includes:
 


### PR DESCRIPTION
## Summary

- add the cargo-dist `x86_64-pc-windows-msvc` target and PowerShell installer
- add Windows-specific cargo-dist installation and build commands to the release matrix
- build, extract, and smoke-test the packaged Windows archive in ordinary CI
- reuse the packaged-binary smoke test during release publication
- document Windows x86_64 as preview support while job-object process-tree cancellation remains a later milestone
- correct the existing Unix installer asset name in the README

## Release outputs

The cargo-dist plan now includes:

- `bazel-mcp-server-x86_64-pc-windows-msvc.zip`
- `bazel-mcp-server-x86_64-pc-windows-msvc.zip.sha256`
- `bazel-mcp-server-installer.ps1`

The Windows build runs on `windows-2022`.

## Windows support boundary

The packaged executable compiles and is smoke-tested natively on Windows. Windows x86_64 remains marked preview because cancellation currently terminates the direct Bazel client process; complete descendant-process cleanup with Windows job objects is still a later compatibility milestone.

## Validation

- cargo-dist 0.31.0 plan contains the expected Windows runner, archive, checksum, and PowerShell installer
- `python3 scripts/check-release-please-config.py`
- `make harden-release`
- `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.7 .github/workflows/*.yml`
- `uvx zizmor .github/workflows`
- `cargo metadata --no-deps --format-version 1`
- `git diff --check`

Native packaged-binary execution is enforced by the updated `cargo-check-windows` job.
