### PR TITLE
docs: focus MCP learnings on bugs and performance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,8 +18,11 @@ Abseil benchmark as an ordinary unit test. Use Conventional Commits; Release
 Please owns versions and the changelog.
 
 Always use the Bazel MCP tools instead of invoking Bazel or Bazelisk directly.
-When work involves Bazel, create or update the repository-root `LEARNINGS.md`
-with concrete potential improvements and opportunities to use the Bazel MCP
-server more token-efficiently. Keep entries concise, actionable, and grounded
-in observations from the current work; do not record secrets or raw sensitive
-output.
+When using Bazel MCP reveals a performance issue, bug, or agent-workflow
+inefficiency caused by MCP behavior, create or update the repository-root
+`LEARNINGS.md`. Record the concrete MCP symptom, its impact on tool calls or
+model-visible tokens when applicable, and an actionable follow-up.
+Agent-workflow observations are especially valuable when they expose
+inefficient protocol behavior, result reduction, or inspection flows. Do not
+add general project, Bazel, CI, release, or unrelated workflow learnings. Do not
+record secrets or raw sensitive output.

--- a/LEARNINGS.md
+++ b/LEARNINGS.md
@@ -1,67 +1,37 @@
-# Bazel MCP learnings
+# Bazel MCP performance issues and bugs
 
-Track concrete opportunities discovered while using Bazel MCP in this
-repository. Add concise, actionable entries under the current date, including
-the observed workflow or result and the improvement it suggests. Focus on MCP
-server behavior, result reduction, inspection patterns, and model-visible token
-efficiency. Do not include secrets or raw sensitive output.
+Track concrete performance issues and bugs observed in the MCP server,
+especially MCP behavior that makes agents spend extra tokens or make avoidable
+tool calls. Each entry must identify the server or protocol symptom, its agent
+workflow impact when applicable, and an actionable follow-up. Do not record
+general project knowledge, successful behavior, Bazel usage, CI or release
+issues, or workflow advice unrelated to MCP efficiency. Do not include secrets
+or raw sensitive output.
 
 ## Entries
 
 ### 2026-07-15
 
-- CI diagnosis required scanning a full job log to isolate one failed Rust test;
-  prioritize the failing test name and assertion in initial Bazel MCP evidence so
-  agents can avoid fetching unrelated successful-test output.
+- The initial `bazel.run` evidence did not isolate one failed Rust test, forcing
+  a follow-up tool call and a scan of the full job log; prioritize the failing
+  test name and assertion so agents avoid fetching unrelated successful-test
+  output.
 
 ### 2026-07-16
 
-- A persistent CI disk cache can bypass an embedded remote-cache smoke server
-  even with isolated output bases; disable unrelated cache layers when testing
-  transport-specific reads and writes, and report observed request counts.
 - Listing full durable invocation records exhausted 8 KiB and destructive byte
   shrinking erased IDs and states; keep ledger rows compact and direct users to
   per-invocation views for canonical arguments and detailed diagnostics.
 - A 250 ms telemetry debounce coalesced writes efficiently but short-lived stdio
   clients exited first; flush pending counters during graceful service shutdown.
-- The Rust compiler summary retained only `aborting due to 1 previous error`, so
-  diagnosing E0308 required a log inspection; rank the primary compiler message
-  and location into the initial failure summary when available.
-- A misspelled BUILD target produced an actionable loading diagnostic including
-  Bazel's suggested label in the initial response; preserve that evidence shape.
+- The `bazel.run` summary retained only `aborting due to 1 previous error`, so
+  diagnosing E0308 required another tool call to retrieve the full log; rank the
+  primary compiler message and location into the initial failure summary when
+  available.
 - Encoding and byte-accounting the same MCP result separately duplicated JSON
   work; one-pass encoding improved warm summary inspection by 6.74% and a larger
   query-results view by 8.66% in alternating exact-deliverable comparisons.
-- Matrix workspaces under repository `.cache` were traversed by a later `//...`
-  and surfaced unrelated nested-workspace loading failures; create Bazel MCP
-  integration scratch roots outside the source workspace by default.
-- The Cargo process integration test passed while its Bazel target lacked a
-  direct BEP dependency; keep standalone `rust_test` deps aligned with imports
-  and include repository-wide Bazel tests in pre-merge validation.
-- Release Please created the Bazel-strategy tag with `GITHUB_TOKEN`, so the
-  tag-push cargo-dist workflow never ran; call artifact publication directly
-  from the release output and retain a manual tag backfill path.
-- The Unix-only release matrix hid hard-coded shell assumptions; keep
-  platform-specific install/build steps explicit and smoke-test packaged
-  Windows executables before upload.
-- Add result encoding as an explicit agentic adapter dimension so JSON and TOON runs share identical MCP tools, prompts, task snapshots, and verifier controls.
-- TOON reduced retained MCP result bytes by 35.69% and total provider tokens by 11.99% with 20/20 verified solves; keep encoding comparisons end-to-end because payload savings do not translate directly to provider-token savings.
-- Report command-output outliers separately from MCP result bytes; one unbounded source search added 472,157 bytes and materially inflated the active-token comparison despite leaving the total-token direction unchanged.
-- Keep production-default benchmark targets aligned with the server serialization default; retain explicit encoding adapters for controlled format comparisons.
-- Pin representation-sensitive protocol harnesses to an explicit result
-  encoding so changing the production default does not invalidate their parser.
-- Supported Bazel majors are repeated across runtime defaults, matrix scripts,
-  golden generation, and docs; define one canonical source so compatibility
-  updates require less repository-wide discovery and cannot drift silently.
-- The matrix consumed smoke output through process substitution and hid producer
-  failures; complete the MCP client first so encoding regressions fail CI.
-- A real BES-backed `bazel.run build //:bazel-mcp` retained hundreds of events,
-  but transport counts were available only in stderr tracing. Add transport,
-  event-count, and retained-byte metrics to an opt-in diagnostic view so future
-  investigations avoid reading raw evidence.
-- Warm `bazel.run` responses expose millisecond invocation duration, which was
-  enough to show tail/BES parity but not isolated capture costs. Keep the
-  repeatable BEP transport benchmark for microsecond-resolution regressions.
-- Exercise both `tail` and `bes` across the Bazel version matrix; the same
-  reducer fixtures can validate identical summaries without model-visible raw
-  BEP output.
+- TOON reduced retained MCP result bytes by 35.69% and total provider tokens by
+  11.99% versus JSON across 20 verified solves; keep measuring the production
+  encoding end to end because payload savings do not map directly to token
+  savings.


### PR DESCRIPTION
## Summary

- Narrow `LEARNINGS.md` to Bazel MCP performance issues, bugs, and efficiency findings.
- Explicitly prioritize agent-workflow observations when MCP behavior causes avoidable tool calls or excess model-visible tokens.
- Remove unrelated CI, release, build, and general project learnings.
- Update `AGENTS.md` with the same qualification criteria.

## Why

`LEARNINGS.md` had become a general project log. Its highest-value purpose is to capture concrete MCP server and protocol behavior that makes agent workflows less efficient, such as incomplete compiler summaries that force a second tool call to retrieve a full log.

## Impact

Future entries will connect an MCP symptom or measurement to its token/tool-call impact when applicable and include an actionable follow-up. General workflow advice remains out of scope unless it exposes MCP inefficiency.

## Validation

- `git diff --check origin/main..HEAD`
- Documentation-only change; code tests were not run.
