### PR TITLE
docs: require Codex Thread IDs in learnings

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,7 +21,8 @@ Always use the Bazel MCP tools instead of invoking Bazel or Bazelisk directly.
 When using Bazel MCP reveals a performance issue, bug, or agent-workflow
 inefficiency caused by MCP behavior, create or update the repository-root
 `LEARNINGS.md`. Record the concrete MCP symptom, its impact on tool calls or
-model-visible tokens when applicable, and an actionable follow-up.
+model-visible tokens when applicable, an actionable follow-up, and the Codex
+Thread ID where the observation occurred.
 Agent-workflow observations are especially valuable when they expose
 inefficient protocol behavior, result reduction, or inspection flows. Do not
 add general project, Bazel, CI, release, or unrelated workflow learnings. Do not

--- a/LEARNINGS.md
+++ b/LEARNINGS.md
@@ -3,10 +3,10 @@
 Track concrete performance issues and bugs observed in the MCP server,
 especially MCP behavior that makes agents spend extra tokens or make avoidable
 tool calls. Each entry must identify the server or protocol symptom, its agent
-workflow impact when applicable, and an actionable follow-up. Do not record
-general project knowledge, successful behavior, Bazel usage, CI or release
-issues, or workflow advice unrelated to MCP efficiency. Do not include secrets
-or raw sensitive output.
+workflow impact when applicable, an actionable follow-up, and the Codex Thread
+ID where the observation occurred. Do not record general project knowledge,
+successful behavior, Bazel usage, CI or release issues, or workflow advice
+unrelated to MCP efficiency. Do not include secrets or raw sensitive output.
 
 ## Entries
 


### PR DESCRIPTION
## Summary

- require every new `LEARNINGS.md` entry to include the originating Codex Thread ID
- document the requirement in both `AGENTS.md` and `LEARNINGS.md`

## Why

The existing guidance captured the MCP symptom, workflow impact, and follow-up, but did not require a durable link back to the Codex task where the behavior was observed. Adding the Thread ID makes future learnings traceable to their source context.

## Impact

Future MCP performance and bug observations will identify the originating Codex task. Existing historical entries are unchanged.

## Validation

- `git diff --check`
