### PR TITLE
fix(reducer): preserve Go failure diagnostics

### DIFF
--- a/LEARNINGS.md
+++ b/LEARNINGS.md
@@ -35,3 +35,15 @@ or raw sensitive output.
   11.99% versus JSON across 20 verified solves; keep measuring the production
   encoding end to end because payload savings do not map directly to token
   savings.
+- Ordinary rules_go compiler messages use `file.go:line:column: message`
+  without an `error:` marker; parsing that form into a structured location made
+  the exact type error the initial `bazel.run` headline in Bazelisk.
+- Collapsing rules_go's multi-line `missing strict dependencies` block into the
+  offending source import and a deps hint made the initial response sufficient
+  to update the BUILD target without a log inspection.
+- A failed Go test can repeat the same assertion in stderr and `test.log`;
+  prefer the test-scoped diagnostic, deduplicate the compilation copy, and
+  return `inspect_hint=test_log` for optional supporting context.
+- Gazelle self-bootstrap failures wrap Go errors in repository-loading output;
+  ranking the parsed inner Go location kept the wrapper as supporting evidence
+  while making the actionable compiler error the headline.

--- a/crates/bazel-mcp-reducer/src/build.rs
+++ b/crates/bazel-mcp-reducer/src/build.rs
@@ -3,8 +3,8 @@ use bazel_mcp_bep::{
     view::{BuildEventIdView, FileView, NamedSetOfFilesView, build_event, build_event_id, file},
 };
 use bazel_mcp_types::{
-    Artifact, ArtifactKind, Diagnostic, DiagnosticCategory, InvocationSummary, Severity,
-    TargetCounts, TargetResult, TestCounts, TestResult, TestStatus,
+    Artifact, ArtifactKind, Diagnostic, DiagnosticCategory, DiagnosticLocation, InvocationSummary,
+    Severity, TargetCounts, TargetResult, TestCounts, TestResult, TestStatus,
 };
 use std::collections::{BTreeMap, BTreeSet};
 
@@ -456,6 +456,7 @@ fn deduplicate_diagnostics(diagnostics: Vec<Diagnostic>) -> Vec<Diagnostic> {
             Severity,
             DiagnosticCategory,
             String,
+            Option<(String, Option<u32>, Option<u32>)>,
             Option<String>,
             Option<String>,
         ),
@@ -468,6 +469,10 @@ fn deduplicate_diagnostics(diagnostics: Vec<Diagnostic>) -> Vec<Diagnostic> {
             diagnostic.severity,
             diagnostic.category,
             diagnostic.message.clone(),
+            diagnostic
+                .location
+                .as_ref()
+                .map(|location| (location.path.clone(), location.line, location.column)),
             (!aggregate_actions)
                 .then(|| diagnostic.target.clone())
                 .flatten(),
@@ -533,7 +538,9 @@ fn diagnostic_priority(diagnostic: &Diagnostic) -> (Severity, u8, u8) {
         DiagnosticCategory::Action => 5,
     };
     let lower = diagnostic.message.to_ascii_lowercase();
-    let evidence_quality = if lower.starts_with("test failed:")
+    let evidence_quality = if diagnostic.location.is_some() {
+        0
+    } else if lower.starts_with("test failed:")
         || lower.starts_with("test timed out:")
         || lower.starts_with("test was incomplete:")
         || lower.starts_with("test result was unavailable:")
@@ -698,10 +705,48 @@ fn bounded_text(value: &str, maximum_bytes: usize) -> String {
 fn add_text_diagnostics(input: &[u8], diagnostics: &mut Vec<Diagnostic>) {
     let normalized = normalize_terminal_text(input);
     let candidates = deduplicate_lines(&normalized);
-    for (line, count) in candidates
-        .into_iter()
-        .filter(|(line, _)| is_actionable(line))
-    {
+    let has_strict_dependency_block = candidates.iter().any(|(line, _)| {
+        line.to_ascii_lowercase()
+            .contains("missing strict dependencies")
+    });
+    let strict_dependency_count = candidates
+        .iter()
+        .filter(|(line, _)| strict_dependency_diagnostic(line).is_some())
+        .count();
+
+    for (line, count) in candidates {
+        if has_strict_dependency_block
+            && let Some(mut diagnostic) = strict_dependency_diagnostic(&line)
+        {
+            diagnostic.repetition_count = count;
+            diagnostics.push(diagnostic);
+            continue;
+        }
+        if let Some(mut diagnostic) = parse_go_diagnostic(&line) {
+            diagnostic.repetition_count = count;
+            diagnostics.push(diagnostic);
+            continue;
+        }
+        if has_strict_dependency_block
+            && strict_dependency_count == 0
+            && line
+                .to_ascii_lowercase()
+                .contains("missing strict dependencies")
+        {
+            diagnostics.push(Diagnostic {
+                severity: Severity::Error,
+                category: DiagnosticCategory::Compilation,
+                message: line,
+                location: None,
+                target: None,
+                action: None,
+                repetition_count: count,
+            });
+            continue;
+        }
+        if !is_actionable(&line) {
+            continue;
+        }
         diagnostics.push(Diagnostic {
             severity: if line.to_ascii_lowercase().contains("warning:") {
                 Severity::Warning
@@ -716,6 +761,91 @@ fn add_text_diagnostics(input: &[u8], diagnostics: &mut Vec<Diagnostic>) {
             repetition_count: count,
         });
     }
+}
+
+/// Parses the standard Go compiler location form without depending on a
+/// particular diagnostic message or language setting.
+#[must_use]
+pub fn parse_go_diagnostic(line: &str) -> Option<Diagnostic> {
+    let marker = line.rfind(".go:")?;
+    let path_end = marker + ".go".len();
+    let path = line[..path_end]
+        .trim()
+        .strip_prefix("ERROR: ")
+        .unwrap_or_else(|| line[..path_end].trim());
+    let (line_number, remainder) = split_u32_prefix(&line[path_end + 1..])?;
+    let (column, message) = split_u32_prefix(remainder)
+        .map_or((None, remainder), |(column, message)| {
+            (Some(column), message)
+        });
+    let message = message.trim();
+    if message.is_empty() {
+        return None;
+    }
+    Some(Diagnostic {
+        severity: if message.to_ascii_lowercase().contains("warning:") {
+            Severity::Warning
+        } else {
+            Severity::Error
+        },
+        category: DiagnosticCategory::Compilation,
+        message: message.to_owned(),
+        location: Some(DiagnosticLocation {
+            path: compact_go_path(path),
+            line: Some(line_number),
+            column,
+        }),
+        target: None,
+        action: None,
+        repetition_count: 1,
+    })
+}
+
+fn split_u32_prefix(value: &str) -> Option<(u32, &str)> {
+    let (number, remainder) = value.split_once(':')?;
+    let number = number.trim();
+    (!number.is_empty() && number.bytes().all(|byte| byte.is_ascii_digit()))
+        .then(|| number.parse::<u32>().ok().map(|number| (number, remainder)))
+        .flatten()
+}
+
+fn strict_dependency_diagnostic(line: &str) -> Option<Diagnostic> {
+    const MARKER: &str = ": import of \"";
+    let marker = line.find(MARKER)?;
+    let path = line[..marker].trim();
+    if !path.ends_with(".go") {
+        return None;
+    }
+    let import = line[marker + MARKER.len()..].split('"').next()?.trim();
+    if import.is_empty() {
+        return None;
+    }
+    let path = compact_go_path(path);
+    Some(Diagnostic {
+        severity: Severity::Error,
+        category: DiagnosticCategory::Compilation,
+        message: format!(
+            "missing strict dependency: {path} imports \"{import}\"; add its target to deps"
+        ),
+        location: Some(DiagnosticLocation {
+            path,
+            line: None,
+            column: None,
+        }),
+        target: None,
+        action: None,
+        repetition_count: 1,
+    })
+}
+
+fn compact_go_path(path: &str) -> String {
+    let path = path.trim_matches('"').replace('\\', "/");
+    if let Some((_, after_execroot)) = path.rsplit_once("/execroot/")
+        && let Some((_, relative)) = after_execroot.split_once('/')
+    {
+        return relative.to_owned();
+    }
+    path
 }
 
 fn is_actionable(line: &str) -> bool {
@@ -922,6 +1052,92 @@ mod tests {
                         || diagnostic.message.contains("visibility"))
             }));
         }
+    }
+
+    #[test]
+    fn recognizes_go_compiler_diagnostics_without_error_markers() {
+        let summary = reduce_invocation(ReductionInput {
+            events: &[],
+            stdout: b"",
+            stderr: b"ERROR: Build did NOT complete successfully\nconfig/config.go:12:40: cannot use 42 (untyped int constant) as string value in variable declaration\n",
+            exit_code: Some(1),
+            elapsed_ms: 1,
+            budget: Budget::result_default(),
+        });
+
+        let diagnostic = &summary.diagnostics[0];
+        assert_eq!(diagnostic.category, DiagnosticCategory::Compilation);
+        assert_eq!(
+            diagnostic.message,
+            "cannot use 42 (untyped int constant) as string value in variable declaration"
+        );
+        assert_eq!(
+            diagnostic.location,
+            Some(DiagnosticLocation {
+                path: "config/config.go".into(),
+                line: Some(12),
+                column: Some(40),
+            })
+        );
+        assert!(summary.headline.contains("cannot use 42"));
+    }
+
+    #[test]
+    fn reduces_rules_go_strict_dependency_blocks_to_the_offending_import() {
+        let stderr = br#"ERROR: GoCompilePkg config/config.a failed
+compilepkg: missing strict dependencies:
+/private/tmp/_bazel_user/hash/sandbox/darwin-sandbox/4/execroot/_main/config/config.go: import of "github.com/hashicorp/go-version"
+No dependencies were provided.
+Check that imports in Go sources match importpath attributes in deps.
+ERROR: Build did NOT complete successfully
+"#;
+        let summary = reduce_invocation(ReductionInput {
+            events: &[],
+            stdout: b"",
+            stderr,
+            exit_code: Some(1),
+            elapsed_ms: 1,
+            budget: Budget::result_default(),
+        });
+
+        let diagnostic = &summary.diagnostics[0];
+        assert_eq!(diagnostic.category, DiagnosticCategory::Compilation);
+        assert_eq!(
+            diagnostic.message,
+            "missing strict dependency: config/config.go imports \"github.com/hashicorp/go-version\"; add its target to deps"
+        );
+        assert_eq!(
+            diagnostic.location,
+            Some(DiagnosticLocation {
+                path: "config/config.go".into(),
+                line: None,
+                column: None,
+            })
+        );
+        assert!(summary.headline.contains("missing strict dependency"));
+    }
+
+    #[test]
+    fn keeps_identical_go_messages_at_distinct_locations() {
+        let summary = reduce_invocation(ReductionInput {
+            events: &[],
+            stdout: b"",
+            stderr: b"first.go:3:2: undefined: missing\nsecond.go:7:4: undefined: missing\n",
+            exit_code: Some(1),
+            elapsed_ms: 1,
+            budget: Budget::result_default(),
+        });
+
+        assert_eq!(summary.diagnostics.len(), 2);
+        assert_eq!(
+            summary
+                .diagnostics
+                .iter()
+                .filter_map(|diagnostic| diagnostic.location.as_ref())
+                .map(|location| location.path.as_str())
+                .collect::<Vec<_>>(),
+            vec!["first.go", "second.go"]
+        );
     }
 
     #[test]

--- a/crates/bazel-mcp-reducer/src/lib.rs
+++ b/crates/bazel-mcp-reducer/src/lib.rs
@@ -10,7 +10,7 @@ mod text;
 pub use budget::{Budget, Budgeted};
 pub use build::{
     BepAccumulator, ReductionInput, StreamReductionOutput, extract_canonical_arguments,
-    finalize_diagnostics, reduce_artifacts, reduce_invocation,
+    finalize_diagnostics, parse_go_diagnostic, reduce_artifacts, reduce_invocation,
 };
 pub use coverage::{CoverageError, parse_lcov, parse_lcov_reader};
 pub use query::reduce_query;

--- a/crates/bazel-mcp-runner/src/service.rs
+++ b/crates/bazel-mcp-runner/src/service.rs
@@ -17,7 +17,7 @@ use bazel_mcp_policy::{
 };
 use bazel_mcp_reducer::{
     Budget, StreamReductionOutput, finalize_diagnostics, normalize_terminal_text,
-    parse_lcov_reader, parse_test_xml,
+    parse_go_diagnostic, parse_lcov_reader, parse_test_xml,
 };
 use bazel_mcp_store::{InvocationCompletion, InvocationPaths, Store, StoreError};
 use bazel_mcp_types::{
@@ -1423,6 +1423,18 @@ impl InvocationService {
             self.enrich_tests(paths, &queued.request.workspace, &mut summary, &artifacts)
                 .await;
             finalize_diagnostics(&mut summary, Budget::result_default());
+            if !summary.success && summary.inspect_hint.is_none() {
+                let view = if summary
+                    .tests
+                    .iter()
+                    .any(|test| test.status != TestStatus::Passed && test.test_log_available)
+                {
+                    "test_log"
+                } else {
+                    "log"
+                };
+                summary.inspect_hint = Some(view.to_owned());
+            }
             if queued.request.command == BazelCommand::Coverage {
                 summary.coverage = self
                     .load_coverage(&queued.request.workspace, &artifacts)
@@ -1715,7 +1727,7 @@ impl InvocationService {
             let mut saw_artifact = false;
             let mut copied_for_test = false;
             let mut saw_remote = false;
-            let mut actionable_excerpt = None::<String>;
+            let mut actionable_excerpt = None::<Diagnostic>;
             for log in matching_logs {
                 saw_artifact = true;
                 if !log.locally_available {
@@ -1760,8 +1772,21 @@ impl InvocationService {
                             &visible_line.replace(workspace_text.as_ref(), "<workspace>"),
                             4 * 1024,
                         );
-                        if is_actionable_evidence(&text) {
-                            actionable_excerpt = Some(bounded_text(&text, 1_000));
+                        if let Some(mut diagnostic) = parse_go_diagnostic(&text) {
+                            diagnostic.category = DiagnosticCategory::Test;
+                            diagnostic.target = Some(test.label.clone());
+                            diagnostic.message = bounded_text(&diagnostic.message, 1_000);
+                            actionable_excerpt = Some(diagnostic);
+                        } else if is_actionable_evidence(&text) {
+                            actionable_excerpt = Some(Diagnostic {
+                                severity: Severity::Error,
+                                category: DiagnosticCategory::Test,
+                                message: bounded_text(&text, 1_000),
+                                location: None,
+                                target: Some(test.label.clone()),
+                                action: None,
+                                repetition_count: 1,
+                            });
                         }
                         let record = EvidenceRecord {
                             label: Some(test.label.clone()),
@@ -1789,16 +1814,8 @@ impl InvocationService {
             if copied_for_test {
                 test.test_log_available = true;
                 test.test_log_unavailable_reason = None;
-                if let Some(message) = actionable_excerpt {
-                    diagnostics.push(Diagnostic {
-                        severity: Severity::Error,
-                        category: DiagnosticCategory::Compilation,
-                        message,
-                        location: None,
-                        target: Some(test.label.clone()),
-                        action: None,
-                        repetition_count: 1,
-                    });
+                if let Some(diagnostic) = actionable_excerpt {
+                    diagnostics.push(diagnostic);
                 }
             } else {
                 test.test_log_available = false;
@@ -1832,6 +1849,13 @@ impl InvocationService {
             false
         };
         if committed {
+            for diagnostic in &diagnostics {
+                summary.diagnostics.retain(|existing| {
+                    !(existing.category == DiagnosticCategory::Compilation
+                        && existing.message == diagnostic.message
+                        && existing.location == diagnostic.location)
+                });
+            }
             summary.diagnostics.extend(diagnostics);
         } else {
             let _ = tokio::fs::remove_file(&raw_temporary).await;
@@ -2177,6 +2201,8 @@ fn is_actionable_evidence(line: &str) -> bool {
         || lower.contains("no such target")
         || lower.contains("no such package")
         || lower.contains("undefined reference")
+        || lower.contains("missing strict dependencies")
+        || (lower.contains(".go: import of \"") && lower.ends_with('"'))
         || lower.contains("root_cause")
 }
 

--- a/crates/bazel-mcp-runner/tests/process.rs
+++ b/crates/bazel-mcp-runner/tests/process.rs
@@ -389,12 +389,9 @@ async fn failed_test_logs_are_snapshotted_and_retrieved_without_a_public_uri() {
     tokio::fs::create_dir_all(&test_directory).await.unwrap();
     let test_log = test_directory.join("test.log");
     let test_xml = test_directory.join("test.xml");
-    tokio::fs::write(
-        &test_log,
-        "setup\nassertion error: SNAPSHOT_TEST_ROOT_CAUSE\n",
-    )
-    .await
-    .unwrap();
+    tokio::fs::write(&test_log, "setup\npkg/failing_test.go:42: got 1, want 2\n")
+        .await
+        .unwrap();
     tokio::fs::write(
         &test_xml,
         r#"<testsuites><testsuite><testcase name="failing_case" time="0.01"><failure message="expected true"/></testcase></testsuite></testsuites>"#,
@@ -414,7 +411,7 @@ async fn failed_test_logs_are_snapshotted_and_retrieved_without_a_public_uri() {
     let flag_marker = root.path().join("saw-test-output-errors");
     let failed_once = root.path().join("failed-once");
     let script = format!(
-        "#!/bin/sh\nif [ \"${{1:-}}\" = --version ]; then echo 'bazel 9.1.0'; exit 0; fi\nfor arg in \"$@\"; do\n  case \"$arg\" in\n    --build_event_binary_file=*) bep_path=${{arg#*=}} ;;\n    --test_output=errors) touch '{}' ;;\n  esac\ndone\nif [ -f '{}' ]; then : > \"$bep_path\"; exit 0; fi\ncp '{}' \"$bep_path\"\ntouch '{}'\necho 'SNAPSHOT_TEST_ROOT_CAUSE'\nexit 1\n",
+        "#!/bin/sh\nif [ \"${{1:-}}\" = --version ]; then echo 'bazel 9.1.0'; exit 0; fi\nfor arg in \"$@\"; do\n  case \"$arg\" in\n    --build_event_binary_file=*) bep_path=${{arg#*=}} ;;\n    --test_output=errors) touch '{}' ;;\n  esac\ndone\nif [ -f '{}' ]; then : > \"$bep_path\"; exit 0; fi\ncp '{}' \"$bep_path\"\ntouch '{}'\necho 'test execution failed'\nexit 1\n",
         flag_marker.display(),
         failed_once.display(),
         bep.display(),
@@ -433,7 +430,27 @@ async fn failed_test_logs_are_snapshotted_and_retrieved_without_a_public_uri() {
     assert_eq!(failed.state, InvocationState::Failed);
     assert!(flag_marker.exists());
     let summary = failed.summary.as_ref().unwrap();
-    assert!(summary.headline.contains("SNAPSHOT_TEST_ROOT_CAUSE"));
+    assert!(summary.headline.contains("got 1, want 2"));
+    assert_eq!(summary.inspect_hint.as_deref(), Some("test_log"));
+    let diagnostic = summary
+        .diagnostics
+        .iter()
+        .find(|diagnostic| diagnostic.message.contains("got 1, want 2"))
+        .unwrap();
+    assert_eq!(
+        summary
+            .diagnostics
+            .iter()
+            .filter(|diagnostic| diagnostic.message.contains("got 1, want 2"))
+            .count(),
+        1
+    );
+    assert_eq!(diagnostic.category, DiagnosticCategory::Test);
+    assert_eq!(
+        diagnostic.location.as_ref().unwrap().path,
+        "pkg/failing_test.go"
+    );
+    assert_eq!(diagnostic.location.as_ref().unwrap().line, Some(42));
     assert!(summary.tests[0].test_log_available);
     assert_eq!(summary.tests[0].cases[0].name, "failing_case");
     assert!(!serde_json::to_string(summary).unwrap().contains("log_uri"));
@@ -457,12 +474,12 @@ async fn failed_test_logs_are_snapshotted_and_retrieved_without_a_public_uri() {
     assert!(
         items
             .iter()
-            .any(|item| item.as_str().unwrap().contains("SNAPSHOT_TEST_ROOT_CAUSE"))
+            .any(|item| item.as_str().unwrap().contains("got 1, want 2"))
     );
 
     let failed_paths = service.store().paths_for(&failed);
     let retained_before = tokio::fs::read(&failed_paths.test_logs_raw).await.unwrap();
-    assert!(String::from_utf8_lossy(&retained_before).contains("SNAPSHOT_TEST_ROOT_CAUSE"));
+    assert!(String::from_utf8_lossy(&retained_before).contains("got 1, want 2"));
     tokio::fs::remove_file(&flag_marker).await.unwrap();
     let passing = service
         .run(InvocationRequest::new(

--- a/crates/bazel-mcp-server/src/handler.rs
+++ b/crates/bazel-mcp-server/src/handler.rs
@@ -102,6 +102,8 @@ struct RunResult<'a> {
     query_result_count: Option<u64>,
     query_sample: Option<&'a [QueryRow]>,
     truncated: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    inspect_hint: Option<&'a str>,
     available_views: &'static [&'static str],
     more_available: bool,
 }
@@ -378,6 +380,7 @@ impl BazelMcpServer {
                 truncated: summary.truncated
                     || diagnostic_count < summary.diagnostics.len()
                     || query_sample_count < summary.query_sample.len(),
+                inspect_hint: summary.inspect_hint.as_deref(),
                 available_views: &[
                     "summary",
                     "metrics",


### PR DESCRIPTION
## Summary

- parse native Go compiler diagnostics into structured source locations
- collapse rules_go strict-dependency failures into actionable deps guidance
- promote and deduplicate Go test assertions, with failure-specific inspect hints

## Root cause

Go compiler diagnostics use `file.go:line[:column]: message` and often omit `error:`, so the generic text filter dropped them and ranked GoCompilePkg or Bazel wrapper errors first.

## Impact

`bazel.run` now returns the source-level Go cause immediately for compile failures, missing deps, failed tests, and Gazelle self-bootstrap failures while preserving supporting evidence for inspection.

## Validation

- Bazel MCP `test //...` (30 targets; 13 tests)
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo shear`
- live Bazelisk compiler, strict-deps, and test failure replays
- live Gazelle self-bootstrap failure replay
