### PR TITLE
fix(runner): surface Rust test failure evidence

### DIFF
--- a/crates/bazel-mcp-reducer/src/build.rs
+++ b/crates/bazel-mcp-reducer/src/build.rs
@@ -650,16 +650,20 @@ fn diagnostic_priority(diagnostic: &Diagnostic) -> (Severity, u8, u8) {
         DiagnosticCategory::Action => 5,
     };
     let lower = diagnostic.message.to_ascii_lowercase();
-    let evidence_quality = if diagnostic.location.is_some() {
+    let rust_failure =
+        lower.contains("panicked at") || (lower.contains("assertion") && lower.contains(" failed"));
+    let evidence_quality = if diagnostic.location.is_some()
+        || (lower.contains("root_cause") && !lower.contains("error executing"))
+    {
         0
+    } else if diagnostic.category == DiagnosticCategory::Test && rust_failure {
+        1
     } else if lower.starts_with("test failed:")
         || lower.starts_with("test timed out:")
         || lower.starts_with("test was incomplete:")
         || lower.starts_with("test result was unavailable:")
     {
         3
-    } else if lower.contains("root_cause") && !lower.contains("error executing") {
-        0
     } else if lower.contains("error executing") {
         2
     } else {
@@ -1075,7 +1079,13 @@ fn compact_go_path(path: &str) -> String {
 }
 
 fn is_actionable(line: &str) -> bool {
+    let line = line.trim();
     let lower = line.to_ascii_lowercase();
+    if matches!(lower.as_str(), "failure:" | "failures:")
+        || (line.starts_with("test ") && lower.ends_with(" ... ok"))
+    {
+        return false;
+    }
     lower.contains("error:")
         || lower.starts_with("error ")
         || lower.contains("failed:")
@@ -1085,6 +1095,10 @@ fn is_actionable(line: &str) -> bool {
         || lower.contains("undefined reference")
         || lower.contains("fatal:")
         || lower.contains("root_cause")
+        || lower.contains("panicked at")
+        || (lower.contains("assertion") && lower.contains(" failed"))
+        || lower.starts_with("test result: failed")
+        || (line.starts_with("test ") && line.ends_with(" ... FAILED"))
 }
 
 fn category_from_text(line: &str) -> DiagnosticCategory {
@@ -1095,7 +1109,8 @@ fn category_from_text(line: &str) -> DiagnosticCategory {
         DiagnosticCategory::Visibility
     } else if lower.contains("analysis") {
         DiagnosticCategory::Analysis
-    } else if lower.contains("test") {
+    } else if lower.contains("test") || lower.contains("panicked at") || lower.contains("assertion")
+    {
         DiagnosticCategory::Test
     } else if lower.contains("error:")
         || lower.contains("error[")
@@ -1473,6 +1488,74 @@ AssertionError: mismatch
                 .collect::<Vec<_>>(),
             vec!["pkg/first_test.py", "pkg/second_test.py"]
         );
+    }
+
+    #[test]
+    fn keeps_failed_rust_evidence_and_rejects_successful_test_names() {
+        let stderr = b"test build::tests::successful_root_cause_test ... ok\n\
+test test::tests::fails ... FAILED\n\
+failures:\n\
+thread 'test::tests::fails' panicked at src/test.rs:7:9:\n\
+assertion `left == right` failed\n";
+        let summary = reduce_invocation(ReductionInput {
+            events: &[],
+            stdout: b"",
+            stderr,
+            exit_code: Some(1),
+            elapsed_ms: 1,
+            budget: Budget::result_default(),
+        });
+
+        assert!(
+            summary
+                .diagnostics
+                .iter()
+                .any(|diagnostic| diagnostic.message.contains("panicked at"))
+        );
+        assert!(
+            summary
+                .diagnostics
+                .iter()
+                .any(|diagnostic| diagnostic.message.contains("assertion"))
+        );
+        assert!(summary.diagnostics.iter().all(|diagnostic| {
+            !diagnostic.message.contains("successful_root_cause_test")
+                && diagnostic.message != "failures:"
+        }));
+    }
+
+    #[test]
+    fn ranks_combined_rust_failure_above_single_log_lines() {
+        let diagnostic = |message: &str, location| Diagnostic {
+            severity: Severity::Error,
+            category: DiagnosticCategory::Test,
+            message: message.to_owned(),
+            location,
+            target: Some("//pkg:test".to_owned()),
+            action: None,
+            repetition_count: 1,
+        };
+        let mut summary = InvocationSummary {
+            success: false,
+            diagnostics: vec![
+                diagnostic("thread 'tests::fails' panicked at src/test.rs:7:9:", None),
+                diagnostic("assertion `left == right` failed", None),
+                diagnostic(
+                    "Rust test tests::fails failed at src/test.rs:7:9: assertion `left == right` failed; left: 1; right: 2",
+                    Some(bazel_mcp_types::DiagnosticLocation {
+                        path: "src/test.rs".to_owned(),
+                        line: Some(7),
+                        column: Some(9),
+                    }),
+                ),
+            ],
+            ..InvocationSummary::default()
+        };
+
+        finalize_diagnostics(&mut summary, Budget::result_default());
+
+        assert!(summary.diagnostics[0].message.starts_with("Rust test"));
+        assert!(summary.headline.contains("left: 1; right: 2"));
     }
 
     #[test]

--- a/crates/bazel-mcp-reducer/src/lib.rs
+++ b/crates/bazel-mcp-reducer/src/lib.rs
@@ -24,5 +24,5 @@ pub use query::reduce_query;
 pub use starlark::{
     REDUCER_API_VERSION, StarlarkLimits, StarlarkReducerConfig, load_starlark_reducers,
 };
-pub use test::{TestXmlError, parse_test_xml};
+pub use test::{TestFailureAccumulator, TestFailureEvidence, TestXmlError, parse_test_xml};
 pub use text::{deduplicate_lines, normalize_terminal_text};

--- a/crates/bazel-mcp-reducer/src/test.rs
+++ b/crates/bazel-mcp-reducer/src/test.rs
@@ -1,4 +1,4 @@
-use bazel_mcp_types::{TestCase, TestStatus};
+use bazel_mcp_types::{DiagnosticLocation, TestCase, TestStatus};
 use quick_xml::de::from_str;
 use serde::Deserialize;
 use thiserror::Error;
@@ -7,6 +7,162 @@ use thiserror::Error;
 pub enum TestXmlError {
     #[error(transparent)]
     Xml(#[from] quick_xml::DeError),
+}
+
+const MAX_LOG_FAILURES: usize = 20;
+const MAX_TEST_NAME_BYTES: usize = 512;
+const MAX_FAILURE_MESSAGE_BYTES: usize = 1_000;
+const MAX_FAILURE_DETAIL_BYTES: usize = 256;
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct TestFailureEvidence {
+    pub name: String,
+    pub message: String,
+    pub location: Option<DiagnosticLocation>,
+}
+
+/// Streaming, bounded extraction of concrete failed-test evidence from test logs.
+///
+/// The first supported structured format is Rust's libtest output. Keeping this
+/// state machine in the reducer makes selection deterministic without retaining
+/// an entire potentially large test log in memory.
+#[derive(Default)]
+pub struct TestFailureAccumulator {
+    failed_names: Vec<String>,
+    failures: Vec<TestFailureEvidence>,
+    current: Option<RustFailureBlock>,
+}
+
+#[derive(Default)]
+struct RustFailureBlock {
+    name: String,
+    location: Option<DiagnosticLocation>,
+    assertion: Option<String>,
+    panic_message: Option<String>,
+    details: Vec<String>,
+    saw_panic: bool,
+}
+
+impl TestFailureAccumulator {
+    pub fn observe_line(&mut self, line: &str) {
+        let line = line.trim();
+        if line.is_empty() {
+            return;
+        }
+
+        if let Some(name) = rust_failed_status_name(line) {
+            push_unique_bounded(
+                &mut self.failed_names,
+                name,
+                MAX_LOG_FAILURES,
+                MAX_TEST_NAME_BYTES,
+            );
+        }
+
+        if let Some(name) = rust_failure_block_name(line) {
+            self.finish_current();
+            self.current = Some(RustFailureBlock {
+                name: bounded_text(name, MAX_TEST_NAME_BYTES),
+                ..RustFailureBlock::default()
+            });
+            return;
+        }
+
+        if let Some((name, location)) = rust_panic(line) {
+            let replace = self
+                .current
+                .as_ref()
+                .is_some_and(|current| !current.name.is_empty() && current.name != name);
+            if replace {
+                self.finish_current();
+            }
+            let current = self.current.get_or_insert_with(RustFailureBlock::default);
+            current.name = bounded_text(name, MAX_TEST_NAME_BYTES);
+            current.location = location;
+            current.saw_panic = true;
+            return;
+        }
+
+        if is_failure_heading(line) {
+            self.finish_current();
+            return;
+        }
+
+        let Some(current) = self.current.as_mut() else {
+            return;
+        };
+        let lower = line.to_ascii_lowercase();
+        if lower.contains("assertion") && lower.contains(" failed") {
+            current.assertion = Some(bounded_text(line, MAX_FAILURE_DETAIL_BYTES));
+        } else if is_assertion_detail(&lower) {
+            if current.details.len() < 4 {
+                current
+                    .details
+                    .push(bounded_text(line, MAX_FAILURE_DETAIL_BYTES));
+            }
+        } else if current.saw_panic
+            && current.panic_message.is_none()
+            && !lower.starts_with("note:")
+            && !lower.starts_with("stack backtrace:")
+            && !lower.starts_with("test result:")
+        {
+            current.panic_message = Some(bounded_text(line, MAX_FAILURE_DETAIL_BYTES));
+        }
+    }
+
+    #[must_use]
+    pub fn finish(mut self) -> Vec<TestFailureEvidence> {
+        self.finish_current();
+        for name in self.failed_names {
+            if self.failures.len() >= MAX_LOG_FAILURES {
+                break;
+            }
+            if self.failures.iter().any(|failure| failure.name == name) {
+                continue;
+            }
+            self.failures.push(TestFailureEvidence {
+                message: format!("Rust test {name} failed"),
+                name,
+                location: None,
+            });
+        }
+        self.failures
+    }
+
+    fn finish_current(&mut self) {
+        let Some(current) = self.current.take() else {
+            return;
+        };
+        if current.name.is_empty() || self.failures.len() >= MAX_LOG_FAILURES {
+            return;
+        }
+        let mut message = format!("Rust test {} failed", current.name);
+        if let Some(location) = &current.location {
+            message.push_str(" at ");
+            message.push_str(&location.path);
+            if let Some(line) = location.line {
+                message.push(':');
+                message.push_str(&line.to_string());
+            }
+            if let Some(column) = location.column {
+                message.push(':');
+                message.push_str(&column.to_string());
+            }
+        }
+        if let Some(reason) = current.assertion.or(current.panic_message) {
+            message.push_str(": ");
+            message.push_str(&reason);
+        }
+        for detail in current.details {
+            message.push_str("; ");
+            message.push_str(&detail);
+        }
+        self.failures.push(TestFailureEvidence {
+            name: current.name,
+            message: bounded_text(&message, MAX_FAILURE_MESSAGE_BYTES),
+            location: current.location,
+        });
+    }
 }
 
 #[derive(Debug, Deserialize)]
@@ -78,6 +234,88 @@ fn duration_ms(seconds: f64) -> Option<u64> {
     }
 }
 
+fn rust_failed_status_name(line: &str) -> Option<&str> {
+    line.strip_prefix("test ")?
+        .strip_suffix(" ... FAILED")
+        .filter(|name| !name.is_empty())
+}
+
+fn rust_failure_block_name(line: &str) -> Option<&str> {
+    let body = line.strip_prefix("---- ")?.strip_suffix(" ----")?;
+    body.strip_suffix(" stdout")
+        .or_else(|| body.strip_suffix(" stderr"))
+        .filter(|name| !name.is_empty())
+}
+
+fn rust_panic(line: &str) -> Option<(&str, Option<DiagnosticLocation>)> {
+    let rest = line.strip_prefix("thread '")?;
+    let marker = " panicked at ";
+    let marker_index = rest.find(marker)?;
+    let thread = &rest[..marker_index];
+    let quote = thread.rfind('\'')?;
+    let name = &thread[..quote];
+    if name.is_empty() {
+        return None;
+    }
+    let location = parse_location(&rest[marker_index + marker.len()..]);
+    Some((name, location))
+}
+
+fn parse_location(value: &str) -> Option<DiagnosticLocation> {
+    let value = value.trim().trim_end_matches(':');
+    let mut parts = value.rsplitn(3, ':');
+    let column = parts.next()?.parse::<u32>().ok()?;
+    let line = parts.next()?.parse::<u32>().ok()?;
+    let path = parts.next()?.trim();
+    if path.is_empty() {
+        return None;
+    }
+    Some(DiagnosticLocation {
+        path: bounded_text(path, MAX_FAILURE_DETAIL_BYTES),
+        line: Some(line),
+        column: Some(column),
+    })
+}
+
+fn is_assertion_detail(lower: &str) -> bool {
+    ["left:", "right:", "expected:", "actual:"]
+        .iter()
+        .any(|prefix| lower.starts_with(prefix))
+}
+
+fn is_failure_heading(line: &str) -> bool {
+    matches!(
+        line.trim().to_ascii_lowercase().as_str(),
+        "failure:" | "failures:"
+    )
+}
+
+fn push_unique_bounded(
+    values: &mut Vec<String>,
+    value: &str,
+    maximum_items: usize,
+    maximum_bytes: usize,
+) {
+    if values.len() >= maximum_items {
+        return;
+    }
+    let value = bounded_text(value, maximum_bytes);
+    if !values.contains(&value) {
+        values.push(value);
+    }
+}
+
+fn bounded_text(value: &str, maximum_bytes: usize) -> String {
+    if value.len() <= maximum_bytes {
+        return value.to_owned();
+    }
+    let mut boundary = maximum_bytes;
+    while !value.is_char_boundary(boundary) {
+        boundary -= 1;
+    }
+    format!("{}…", &value[..boundary])
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -111,5 +349,62 @@ mod tests {
         assert_eq!(cases.len(), 2);
         assert_eq!(cases[0].status, TestStatus::Failed);
         assert_eq!(cases[1].status, TestStatus::Passed);
+    }
+
+    #[test]
+    fn extracts_rust_test_name_assertion_values_and_location() {
+        let mut accumulator = TestFailureAccumulator::default();
+        for line in [
+            "running 3 tests",
+            "test build::tests::successful_root_cause_test ... ok",
+            "test test::tests::parses_direct_testsuite_root ... FAILED",
+            "failures:",
+            "---- test::tests::parses_direct_testsuite_root stdout ----",
+            "thread 'test::tests::parses_direct_testsuite_root' (3670855) panicked at crates/bazel-mcp-reducer/src/test.rs:101:9:",
+            "assertion `left == right` failed",
+            "left: \"one\"",
+            "right: \"expected\"",
+            "failures:",
+            "test::tests::parses_direct_testsuite_root",
+            "test result: FAILED. 2 passed; 1 failed",
+        ] {
+            accumulator.observe_line(line);
+        }
+
+        let failures = accumulator.finish();
+        assert_eq!(failures.len(), 1);
+        assert_eq!(
+            failures[0].name,
+            "test::tests::parses_direct_testsuite_root"
+        );
+        assert!(
+            failures[0]
+                .message
+                .contains("assertion `left == right` failed")
+        );
+        assert!(failures[0].message.contains("left: \"one\""));
+        assert!(failures[0].message.contains("right: \"expected\""));
+        assert_eq!(
+            failures[0].location,
+            Some(DiagnosticLocation {
+                path: "crates/bazel-mcp-reducer/src/test.rs".into(),
+                line: Some(101),
+                column: Some(9),
+            })
+        );
+        assert!(!failures[0].message.contains("successful_root_cause_test"));
+    }
+
+    #[test]
+    fn falls_back_to_failed_rust_status_without_a_panic_block() {
+        let mut accumulator = TestFailureAccumulator::default();
+        accumulator.observe_line("test tests::failed_without_output ... FAILED");
+        let failures = accumulator.finish();
+        assert_eq!(failures.len(), 1);
+        assert_eq!(failures[0].name, "tests::failed_without_output");
+        assert_eq!(
+            failures[0].message,
+            "Rust test tests::failed_without_output failed"
+        );
     }
 }

--- a/crates/bazel-mcp-runner/src/service.rs
+++ b/crates/bazel-mcp-runner/src/service.rs
@@ -17,15 +17,17 @@ use bazel_mcp_policy::{
 };
 use bazel_mcp_reducer::{
     Budget, PythonDiagnosticParser, REDUCER_API_VERSION, ReducerContext, ReducerPipeline,
-    StarlarkReducerConfig, StreamReductionOutput, finalize_diagnostics, load_starlark_reducers,
-    normalize_terminal_text, parse_go_diagnostic, parse_lcov_reader, parse_test_xml,
+    StarlarkReducerConfig, StreamReductionOutput, TestFailureAccumulator, TestFailureEvidence,
+    finalize_diagnostics, load_starlark_reducers, normalize_terminal_text, parse_go_diagnostic,
+    parse_lcov_reader, parse_test_xml,
 };
 use bazel_mcp_store::{InvocationCompletion, InvocationPaths, Store, StoreError};
 use bazel_mcp_types::{
     ArtifactKind, BazelCommand, CommandClass, DeferredFailure, DeferredFailureKind,
     DeferredResultRecord, DeferredResultView, DeferredRetrieval, DeferredTerminalState, Diagnostic,
     DiagnosticCategory, InvocationId, InvocationMetrics, InvocationRecord, InvocationRequest,
-    InvocationState, Page, PageRequest, ResultDisposition, Severity, Termination, TestStatus,
+    InvocationState, Page, PageRequest, ResultDisposition, Severity, Termination, TestCase,
+    TestStatus,
 };
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
@@ -1888,7 +1890,8 @@ impl InvocationService {
             let mut saw_artifact = false;
             let mut copied_for_test = false;
             let mut saw_remote = false;
-            let mut actionable_excerpt = None::<Diagnostic>;
+            let mut extracted_failures = Vec::<TestFailureEvidence>::new();
+            let mut fallback_excerpt = None::<(u8, Diagnostic)>;
             for log in matching_logs {
                 saw_artifact = true;
                 if !log.locally_available {
@@ -1907,6 +1910,7 @@ impl InvocationService {
                     continue;
                 }
                 let mut reader = BufReader::new(file);
+                let mut failure_accumulator = TestFailureAccumulator::default();
                 let mut line = Vec::new();
                 let mut complete = true;
                 loop {
@@ -1934,26 +1938,39 @@ impl InvocationService {
                             &visible_line.replace(workspace_text.as_ref(), "<workspace>"),
                             4 * 1024,
                         );
-                        if let Some(mut diagnostic) = parse_go_diagnostic(&text) {
+                        failure_accumulator.observe_line(&text);
+                        let candidate = if let Some(mut diagnostic) = parse_go_diagnostic(&text) {
                             diagnostic.category = DiagnosticCategory::Test;
                             diagnostic.target = Some(test.label.clone());
                             diagnostic.message = bounded_text(&diagnostic.message, 1_000);
-                            actionable_excerpt = Some(diagnostic);
+                            Some((0, diagnostic))
                         } else if let Some(mut diagnostic) = python_parser.observe_line(&text) {
                             diagnostic.category = DiagnosticCategory::Test;
                             diagnostic.target = Some(test.label.clone());
                             diagnostic.message = bounded_text(&diagnostic.message, 1_000);
-                            actionable_excerpt = Some(diagnostic);
-                        } else if actionable_excerpt.is_none() && is_actionable_evidence(&text) {
-                            actionable_excerpt = Some(Diagnostic {
-                                severity: Severity::Error,
-                                category: DiagnosticCategory::Test,
-                                message: bounded_text(&text, 1_000),
-                                location: None,
-                                target: Some(test.label.clone()),
-                                action: None,
-                                repetition_count: 1,
-                            });
+                            Some((0, diagnostic))
+                        } else {
+                            failure_evidence_priority(&text).map(|priority| {
+                                (
+                                    priority,
+                                    Diagnostic {
+                                        severity: Severity::Error,
+                                        category: DiagnosticCategory::Test,
+                                        message: bounded_text(&text, 1_000),
+                                        location: None,
+                                        target: Some(test.label.clone()),
+                                        action: None,
+                                        repetition_count: 1,
+                                    },
+                                )
+                            })
+                        };
+                        if let Some((priority, diagnostic)) = candidate
+                            && fallback_excerpt
+                                .as_ref()
+                                .is_none_or(|(current, _)| priority < *current)
+                        {
+                            fallback_excerpt = Some((priority, diagnostic));
                         }
                         let record = EvidenceRecord {
                             label: Some(test.label.clone()),
@@ -1974,6 +1991,16 @@ impl InvocationService {
                     }
                 }
                 if complete {
+                    for failure in failure_accumulator.finish() {
+                        if extracted_failures.len() >= 20 {
+                            break;
+                        }
+                        if !extracted_failures.iter().any(|current| {
+                            current.name == failure.name && current.message == failure.message
+                        }) {
+                            extracted_failures.push(failure);
+                        }
+                    }
                     copied_for_test = true;
                     copied_any = true;
                 }
@@ -1981,8 +2008,49 @@ impl InvocationService {
             if copied_for_test {
                 test.test_log_available = true;
                 test.test_log_unavailable_reason = None;
-                if let Some(diagnostic) = actionable_excerpt {
-                    diagnostics.push(diagnostic);
+                if extracted_failures.is_empty() {
+                    if let Some((_, diagnostic)) = fallback_excerpt {
+                        diagnostics.push(diagnostic);
+                    }
+                } else {
+                    let previous_cases = std::mem::take(&mut test.cases);
+                    let mut cases = Vec::<TestCase>::new();
+                    for failure in &extracted_failures {
+                        if cases.len() >= 20 {
+                            break;
+                        }
+                        if cases.iter().any(|case| case.name == failure.name) {
+                            continue;
+                        }
+                        cases.push(TestCase {
+                            name: failure.name.clone(),
+                            status: TestStatus::Failed,
+                            duration_ms: None,
+                            message: Some(failure.message.clone()),
+                        });
+                    }
+                    for case in previous_cases {
+                        if cases.len() >= 20 {
+                            break;
+                        }
+                        if !cases.iter().any(|current| {
+                            current.name == case.name && current.message == case.message
+                        }) {
+                            cases.push(case);
+                        }
+                    }
+                    test.cases = cases;
+                    for failure in extracted_failures.into_iter().take(20) {
+                        diagnostics.push(Diagnostic {
+                            severity: Severity::Error,
+                            category: DiagnosticCategory::Test,
+                            message: failure.message,
+                            location: failure.location,
+                            target: Some(test.label.clone()),
+                            action: None,
+                            repetition_count: 1,
+                        });
+                    }
                 }
             } else {
                 test.test_log_available = false;
@@ -2360,18 +2428,44 @@ fn failure_evidence_records(
 }
 
 fn is_actionable_evidence(line: &str) -> bool {
+    failure_evidence_priority(line).is_some()
+}
+
+fn failure_evidence_priority(line: &str) -> Option<u8> {
+    let line = line.trim();
     let lower = line.to_ascii_lowercase();
-    lower.contains("error:")
+    let base = lower
+        .split_once(" [repeated ")
+        .map_or(lower.as_str(), |(base, _)| base);
+    if matches!(base, "failure:" | "failures:")
+        || (line.starts_with("test ") && base.ends_with(" ... ok"))
+    {
+        return None;
+    }
+    if lower.contains("root_cause")
+        || lower.contains("panicked at")
+        || (lower.contains("assertion") && lower.contains(" failed"))
+    {
+        Some(0)
+    } else if lower.contains("error:")
         || lower.starts_with("error ")
-        || lower.contains("failed:")
-        || lower.contains("failure")
         || lower.contains("fatal:")
         || lower.contains("no such target")
         || lower.contains("no such package")
         || lower.contains("undefined reference")
         || lower.contains("missing strict dependencies")
         || (lower.contains(".go: import of \"") && lower.ends_with('"'))
-        || lower.contains("root_cause")
+    {
+        Some(1)
+    } else if lower.contains("failed:")
+        || lower.contains("failure")
+        || lower.starts_with("test result: failed")
+        || (line.starts_with("test ") && line.ends_with(" ... FAILED"))
+    {
+        Some(2)
+    } else {
+        None
+    }
 }
 
 async fn write_private_atomic(path: &Path, bytes: &[u8]) -> Result<(), io::Error> {

--- a/crates/bazel-mcp-runner/tests/process.rs
+++ b/crates/bazel-mcp-runner/tests/process.rs
@@ -712,6 +712,110 @@ FAILED (failures=1)
 }
 
 #[tokio::test]
+async fn failed_rust_test_log_promotes_case_and_assertion_to_initial_summary() {
+    let root = tempfile::tempdir().unwrap();
+    let workspace = root.path().join("workspace");
+    let output_root = root.path().join("output-user-root");
+    let test_directory = output_root.join("execroot/ws/bazel-out/testlogs/pkg/failing");
+    tokio::fs::create_dir_all(&workspace).await.unwrap();
+    tokio::fs::create_dir_all(&test_directory).await.unwrap();
+    let test_log = test_directory.join("test.log");
+    let test_xml = test_directory.join("test.xml");
+    tokio::fs::write(
+        &test_log,
+        "running 3 tests\n\
+test build::tests::successful_root_cause_test ... ok\n\
+test test::tests::parses_direct_testsuite_root ... FAILED\n\
+test test::tests::another_success ... ok\n\
+\n\
+failures:\n\
+\n\
+---- test::tests::parses_direct_testsuite_root stdout ----\n\
+thread 'test::tests::parses_direct_testsuite_root' (3670855) panicked at crates/bazel-mcp-reducer/src/test.rs:101:9:\n\
+assertion `left == right` failed\n\
+left: \"one\"\n\
+right: \"expected\"\n\
+note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace\n\
+\n\
+failures:\n\
+    test::tests::parses_direct_testsuite_root\n\
+\n\
+test result: FAILED. 2 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out\n",
+    )
+    .await
+    .unwrap();
+    tokio::fs::write(
+        &test_xml,
+        r#"<testsuites><testsuite><testcase name="crates/bazel-mcp-reducer/unit_test" time="0.01"><failure message="exited with error code 101"/></testcase></testsuite></testsuites>"#,
+    )
+    .await
+    .unwrap();
+    let bep = root.path().join("failed-rust-test.bep");
+    tokio::fs::write(
+        &bep,
+        failed_test_bep(
+            &format!("file://{}", test_log.display()),
+            &format!("file://{}", test_xml.display()),
+        ),
+    )
+    .await
+    .unwrap();
+    let flag_marker = root.path().join("saw-test-output-errors");
+    let script = format!(
+        "#!/bin/sh\nif [ \"${{1:-}}\" = --version ]; then echo 'bazel 9.1.0'; exit 0; fi\nfor arg in \"$@\"; do\n  case \"$arg\" in\n    --build_event_binary_file=*) bep_path=${{arg#*=}} ;;\n    --test_output=errors) touch '{}' ;;\n  esac\ndone\ncp '{}' \"$bep_path\"\nexit 1\n",
+        flag_marker.display(),
+        bep.display(),
+    );
+    let service = configured_service(&root, &workspace, &script, |_| {}).await;
+
+    let failed = service
+        .run(InvocationRequest::new(
+            workspace,
+            BazelCommand::Test,
+            vec!["//pkg:failing".into()],
+        ))
+        .await
+        .unwrap();
+
+    assert_eq!(failed.state, InvocationState::Failed);
+    assert!(flag_marker.exists());
+    let summary = failed.summary.as_ref().unwrap();
+    assert!(
+        summary
+            .headline
+            .contains("test::tests::parses_direct_testsuite_root")
+    );
+    assert!(
+        summary
+            .headline
+            .contains("assertion `left == right` failed")
+    );
+    assert_eq!(summary.diagnostics[0].category, DiagnosticCategory::Test);
+    assert_eq!(
+        summary.diagnostics[0].location.as_ref().unwrap().path,
+        "crates/bazel-mcp-reducer/src/test.rs"
+    );
+    assert!(
+        summary
+            .diagnostics
+            .iter()
+            .all(|diagnostic| !diagnostic.message.ends_with(" ... ok"))
+    );
+    assert!(summary.tests[0].test_log_available);
+    assert_eq!(
+        summary.tests[0].cases[0].name,
+        "test::tests::parses_direct_testsuite_root"
+    );
+    assert!(
+        summary.tests[0].cases[0]
+            .message
+            .as_ref()
+            .unwrap()
+            .contains("right: \"expected\"")
+    );
+}
+
+#[tokio::test]
 async fn cancellation_stops_a_running_process_group() {
     let root = tempfile::tempdir().unwrap();
     let workspace = root.path().join("workspace");

--- a/crates/bazel-mcp-runner/tests/process.rs
+++ b/crates/bazel-mcp-runner/tests/process.rs
@@ -1107,12 +1107,65 @@ async fn scheduler_uses_effective_output_base_and_never_evaluates_arguments() {
     let root = tempfile::tempdir().unwrap();
     let first = root.path().join("first-workspace");
     let second = root.path().join("second-workspace");
+    let independent_first = root.path().join("independent-first-started");
+    let independent_second = root.path().join("independent-second-started");
+    let shared_first = root.path().join("shared-first-started");
+    let shared_second = root.path().join("shared-second-started");
+    let shared_release = root.path().join("shared-release");
     tokio::fs::create_dir(&first).await.unwrap();
     tokio::fs::create_dir(&second).await.unwrap();
     tokio::fs::write(second.join("MODULE.bazel"), "module(name='second')\n")
         .await
         .unwrap();
-    let service = service(&root, &first, "#!/bin/sh\nsleep 0.3\nexit 0\n").await;
+    let script = format!(
+        "#!/bin/sh\n\
+if [ \"${{1:-}}\" = --version ]; then echo 'bazel 9.1.0'; exit 0; fi\n\
+wait_for() {{\n\
+  i=0\n\
+  while [ \"$i\" -lt 500 ]; do\n\
+    [ -f \"$1\" ] && return 0\n\
+    i=$((i+1))\n\
+    sleep 0.01\n\
+  done\n\
+  return 1\n\
+}}\n\
+for arg in \"$@\"; do\n\
+  case \"$arg\" in\n\
+    //:warm-version-cache) exit 0 ;;\n\
+    //:independent-first)\n\
+      touch '{}'\n\
+      wait_for '{}'\n\
+      exit $?\n\
+      ;;\n\
+    //:independent-second)\n\
+      touch '{}'\n\
+      wait_for '{}'\n\
+      exit $?\n\
+      ;;\n\
+    //:shared-first)\n\
+      touch '{}'\n\
+      wait_for '{}'\n\
+      exit $?\n\
+      ;;\n\
+    //:shared-second)\n\
+      touch '{}'\n\
+      wait_for '{}'\n\
+      exit $?\n\
+      ;;\n\
+  esac\n\
+done\n\
+sleep 0.3\n\
+exit 0\n",
+        independent_first.display(),
+        independent_second.display(),
+        independent_second.display(),
+        independent_first.display(),
+        shared_first.display(),
+        shared_release.display(),
+        shared_second.display(),
+        shared_release.display(),
+    );
+    let service = service(&root, &first, &script).await;
 
     service
         .run(InvocationRequest::new(
@@ -1125,42 +1178,82 @@ async fn scheduler_uses_effective_output_base_and_never_evaluates_arguments() {
 
     let shell_marker = root.path().join("shell-evaluated");
     let literal_argument = format!("$(touch {})", shell_marker.display());
-    let independent_started = Instant::now();
     let (first_result, second_result) = tokio::join!(
         service.run(InvocationRequest::new(
             first.clone(),
             BazelCommand::Build,
-            vec![literal_argument],
+            vec![literal_argument, "//:independent-first".into()],
         )),
         service.run(InvocationRequest::new(
             second.clone(),
             BazelCommand::Build,
-            vec!["//...".into()],
+            vec!["//:independent-second".into()],
         )),
     );
-    let independent_elapsed = independent_started.elapsed();
     assert_eq!(first_result.unwrap().state, InvocationState::Succeeded);
     assert_eq!(second_result.unwrap().state, InvocationState::Succeeded);
+    assert!(independent_first.exists());
+    assert!(independent_second.exists());
     assert!(!shell_marker.exists());
 
     let shared_output_base = root.path().join("shared-output-base");
     let startup_argument = format!("--output_base={}", shared_output_base.display());
-    let mut first_request =
-        InvocationRequest::new(first.clone(), BazelCommand::Build, vec!["//...".into()]);
+    let mut first_request = InvocationRequest::new(
+        first.clone(),
+        BazelCommand::Build,
+        vec!["//:shared-first".into()],
+    );
     first_request.startup_arguments = vec![startup_argument.clone()];
-    let mut second_request =
-        InvocationRequest::new(second.clone(), BazelCommand::Build, vec!["//...".into()]);
+    let mut second_request = InvocationRequest::new(
+        second.clone(),
+        BazelCommand::Build,
+        vec!["//:shared-second".into()],
+    );
     second_request.startup_arguments = vec![startup_argument];
-    let serialized_started = Instant::now();
-    let (first_result, second_result) =
-        tokio::join!(service.run(first_request), service.run(second_request),);
-    let serialized_elapsed = serialized_started.elapsed();
+    let first_id = first_request.id;
+    let second_id = second_request.id;
+    let first_run = tokio::spawn({
+        let service = service.clone();
+        async move { service.run(first_request).await.unwrap() }
+    });
+    let second_run = tokio::spawn({
+        let service = service.clone();
+        async move { service.run(second_request).await.unwrap() }
+    });
+    wait_for_invocation(&service, first_id).await;
+    wait_for_invocation(&service, second_id).await;
+
+    let one_started = tokio::time::timeout(Duration::from_secs(2), async {
+        while !shared_first.exists() && !shared_second.exists() {
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+    })
+    .await
+    .is_ok();
+    let overlap_before_release = match (shared_first.exists(), shared_second.exists()) {
+        (true, false) => {
+            tokio::time::timeout(Duration::from_secs(1), wait_for_path(&shared_second))
+                .await
+                .is_ok()
+        }
+        (false, true) => tokio::time::timeout(Duration::from_secs(1), wait_for_path(&shared_first))
+            .await
+            .is_ok(),
+        (true, true) => true,
+        (false, false) => false,
+    };
+    tokio::fs::write(&shared_release, b"release").await.unwrap();
+    let (first_result, second_result) = tokio::join!(first_run, second_run);
+
+    assert!(one_started, "neither shared output-base request started");
+    assert!(
+        !overlap_before_release,
+        "shared output-base requests overlapped before the active request was released"
+    );
     assert_eq!(first_result.unwrap().state, InvocationState::Succeeded);
     assert_eq!(second_result.unwrap().state, InvocationState::Succeeded);
-    assert!(
-        serialized_elapsed > independent_elapsed + Duration::from_millis(200),
-        "shared output base did not serialize: independent={independent_elapsed:?}, shared={serialized_elapsed:?}"
-    );
+    assert!(shared_first.exists());
+    assert!(shared_second.exists());
 
     let mut same_workspace = Vec::new();
     for _ in 0..4 {

--- a/crates/bazel-mcp-server/src/handler.rs
+++ b/crates/bazel-mcp-server/src/handler.rs
@@ -1449,6 +1449,68 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn failed_run_response_keeps_primary_rust_test_evidence_under_budget() {
+        let root = tempdir().unwrap();
+        let store = Store::open(root.path()).await.unwrap();
+        let mut record = InvocationRecord::queued(InvocationRequest::new(
+            PathBuf::from("/workspace/rust-failure"),
+            BazelCommand::Test,
+            vec!["//pkg:unit_test".to_owned()],
+        ));
+        record.state = InvocationState::Failed;
+        record.termination = Some(Termination::Exit { code: 3 });
+        let primary = "Rust test tests::parses_value failed at src/test.rs:17:9: assertion `left == right` failed; left: 1; right: 2";
+        let mut diagnostics = vec![Diagnostic {
+            severity: bazel_mcp_types::Severity::Error,
+            category: bazel_mcp_types::DiagnosticCategory::Test,
+            message: primary.to_owned(),
+            location: Some(bazel_mcp_types::DiagnosticLocation {
+                path: "src/test.rs".to_owned(),
+                line: Some(17),
+                column: Some(9),
+            }),
+            target: Some("//pkg:unit_test".to_owned()),
+            action: None,
+            repetition_count: 1,
+        }];
+        diagnostics.extend((0..30).map(|index| Diagnostic {
+            severity: bazel_mcp_types::Severity::Error,
+            category: bazel_mcp_types::DiagnosticCategory::Action,
+            message: format!("noise-{index}-{}", "x".repeat(900)),
+            location: None,
+            target: None,
+            action: None,
+            repetition_count: 1,
+        }));
+        record.summary = Some(bazel_mcp_types::InvocationSummary {
+            success: false,
+            headline: format!("Bazel failed: {primary}"),
+            diagnostics,
+            test_counts: bazel_mcp_types::TestCounts {
+                failed: 1,
+                ..bazel_mcp_types::TestCounts::default()
+            },
+            ..bazel_mcp_types::InvocationSummary::default()
+        });
+        store.create_invocation(&record).await.unwrap();
+        let runner = InvocationService::new(store, RunnerConfig::default()).unwrap();
+        let server = BazelMcpServer::new(runner, ResultEncoding::Text);
+
+        let result = server.build_run_result(&record, false).await.unwrap();
+        let Some(ContentBlock::Text(content)) = result.content.first() else {
+            panic!("run result did not contain one text block");
+        };
+        let value: serde_json::Value = serde_json::from_str(&content.text).unwrap();
+        assert_eq!(value["headline"], format!("Bazel failed: {primary}"));
+        assert_eq!(value["diagnostics"][0]["message"], primary);
+        assert_eq!(value["diagnostics"][0]["category"], "test");
+        assert_eq!(value["diagnostics"][0]["location"]["line"], 17);
+        assert_eq!(value["tests"]["failed"], 1);
+        assert_eq!(value["truncated"], true);
+        assert!(content.text.len() <= 8 * 1024);
+    }
+
+    #[tokio::test]
     async fn negotiated_capabilities_and_tool_metadata_do_not_mix_dialects() {
         let root = tempdir().unwrap();
         let runner = InvocationService::new(


### PR DESCRIPTION
## Summary

- extract bounded, structured Rust libtest failures while snapshotting retained test logs
- promote the failing test name, assertion details, values, and source location into the initial `bazel.run` summary and test cases
- filter successful Rust test lines and generic `failures:` headings from primary diagnostics
- preserve the recently added Go diagnostic parsing and add regression coverage for reducer ranking, runner enrichment, and the 8 KiB server response budget

## Why

A failed Rust test could initially surface only a generic BEP/XML result such as `failures:`, while the concrete test name and assertion remained in the retained `test.log`. Agents then needed a second `bazel.inspect` call and had to scan unrelated successful-test output.

The root cause was that test-log enrichment selected isolated actionable lines but did not assemble the Rust libtest multi-line failure block into one ranked diagnostic.

## Impact

The first failed `bazel.run` response now leads with the failing Rust test and assertion, while keeping extraction streaming, deterministic, redacted, and bounded to 20 failures. This avoids an unnecessary follow-up inspection in the reproduced case and keeps successful test output out of the initial evidence.

## Checks

- `make test`
- `bazel.run test //crates/bazel-mcp-reducer:unit_test //crates/bazel-mcp-runner:process_test //crates/bazel-mcp-server:unit_test`
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo shear`
- `git diff --check`

`make check` completed formatting and Clippy, then could not enter its Nix wrapper because Nix is not installed; its remaining `cargo shear` step passed directly.