### PR TITLE
fix(reducer): preserve Python traceback diagnostics

### DIFF
--- a/LEARNINGS.md
+++ b/LEARNINGS.md
@@ -60,3 +60,12 @@ unrelated to MCP efficiency. Do not include secrets or raw sensitive output.
 - `bazel.run mod deps` refreshed the rules_rs crate extension lock with a compact
   success summary and no raw dependency output; use that informational command
   plus a local lockfile diff for token-efficient Cargo dependency changes.
+- Python precompilation surfaced `Unhandled error:` ahead of a retained
+  `SyntaxError` and omitted the source line; pair standard traceback frames with
+  terminal exception classes so agents can edit the failing file without a log
+  inspection. Thread: `019f6b89-e945-78a0-9264-a6ad416905a1`.
+- Python import and assertion failures retained the terminal exception but
+  discarded the preceding runfiles source frame, while a trailing `FAILED`
+  summary could replace richer test evidence; prefer located traceback causes
+  and keep `test_log` as optional context. Thread:
+  `019f6b89-e945-78a0-9264-a6ad416905a1`.

--- a/crates/bazel-mcp-reducer/src/build.rs
+++ b/crates/bazel-mcp-reducer/src/build.rs
@@ -816,6 +816,12 @@ fn bounded_text(value: &str, maximum_bytes: usize) -> String {
 
 fn add_text_diagnostics(input: &[u8], diagnostics: &mut Vec<Diagnostic>) {
     let normalized = normalize_terminal_text(input);
+    let mut python_parser = PythonDiagnosticParser::default();
+    for line in normalized.lines() {
+        if let Some(diagnostic) = python_parser.observe_line(line) {
+            diagnostics.push(diagnostic);
+        }
+    }
     let candidates = deduplicate_lines(&normalized);
     let has_strict_dependency_block = candidates.iter().any(|(line, _)| {
         line.to_ascii_lowercase()
@@ -837,6 +843,9 @@ fn add_text_diagnostics(input: &[u8], diagnostics: &mut Vec<Diagnostic>) {
         if let Some(mut diagnostic) = parse_go_diagnostic(&line) {
             diagnostic.repetition_count = count;
             diagnostics.push(diagnostic);
+            continue;
+        }
+        if parse_python_location(&line).is_some() || python_exception_message(&line).is_some() {
             continue;
         }
         if has_strict_dependency_block
@@ -873,6 +882,111 @@ fn add_text_diagnostics(input: &[u8], diagnostics: &mut Vec<Diagnostic>) {
             repetition_count: count,
         });
     }
+}
+
+/// Stateful extractor for standard Python traceback and syntax-error output.
+///
+/// Python reports source locations on a `File "...", line N` frame before the
+/// terminal exception. Keeping only the latest frame is bounded and matches
+/// traceback semantics, where the innermost frame is printed last.
+#[derive(Debug, Default)]
+pub struct PythonDiagnosticParser {
+    location: Option<DiagnosticLocation>,
+}
+
+impl PythonDiagnosticParser {
+    /// Observes one normalized output line and returns a diagnostic when the
+    /// line terminates a Python exception block.
+    pub fn observe_line(&mut self, line: &str) -> Option<Diagnostic> {
+        if line.trim() == "Traceback (most recent call last):" {
+            self.location = None;
+            return None;
+        }
+        if let Some(location) = parse_python_location(line) {
+            self.location = Some(location);
+            return None;
+        }
+        let message = python_exception_message(line)?;
+        let exception_type = message.split_once(':').map_or(message, |(name, _)| name);
+        Some(Diagnostic {
+            severity: if exception_type.ends_with("Warning") {
+                Severity::Warning
+            } else {
+                Severity::Error
+            },
+            category: DiagnosticCategory::Compilation,
+            message: message.to_owned(),
+            location: self.location.take(),
+            target: None,
+            action: None,
+            repetition_count: 1,
+        })
+    }
+}
+
+fn parse_python_location(line: &str) -> Option<DiagnosticLocation> {
+    let marker = "File \"";
+    let start = line.find(marker)? + marker.len();
+    let remainder = &line[start..];
+    let (path, remainder) = remainder.split_once("\", line ")?;
+    if path.starts_with('<') || path.ends_with("_stage2_bootstrap.py") {
+        return None;
+    }
+    let digits = remainder
+        .bytes()
+        .take_while(|byte| byte.is_ascii_digit())
+        .count();
+    if digits == 0 {
+        return None;
+    }
+    let line_number = remainder[..digits].parse::<u32>().ok()?;
+    Some(DiagnosticLocation {
+        path: compact_python_path(path),
+        line: Some(line_number),
+        column: None,
+    })
+}
+
+fn python_exception_message(line: &str) -> Option<&str> {
+    let mut line = line.trim();
+    if let Some(remainder) = line.strip_prefix('E')
+        && remainder.chars().next().is_some_and(char::is_whitespace)
+    {
+        line = remainder.trim_start();
+    }
+    if line.contains("File \"") {
+        return None;
+    }
+    let exception_type = line.split_once(':').map_or(line, |(name, _)| name);
+    if exception_type.is_empty()
+        || exception_type
+            .bytes()
+            .any(|byte| !(byte.is_ascii_alphanumeric() || matches!(byte, b'_' | b'.')))
+    {
+        return None;
+    }
+    let class_name = exception_type.rsplit('.').next()?;
+    let recognized = class_name.ends_with("Error")
+        || class_name.ends_with("Exception")
+        || class_name.ends_with("Failure")
+        || class_name.ends_with("Warning")
+        || matches!(class_name, "Failed" | "KeyboardInterrupt" | "SystemExit");
+    recognized.then_some(line)
+}
+
+fn compact_python_path(path: &str) -> String {
+    let path = path.trim_matches('"').replace('\\', "/");
+    for marker in [".runfiles/_main/", ".runfiles/__main__/"] {
+        if let Some((_, relative)) = path.rsplit_once(marker) {
+            return relative.to_owned();
+        }
+    }
+    if let Some((_, after_execroot)) = path.rsplit_once("/execroot/")
+        && let Some((_, relative)) = after_execroot.split_once('/')
+    {
+        return relative.to_owned();
+    }
+    path.strip_prefix("./").unwrap_or(&path).to_owned()
 }
 
 /// Parses the standard Go compiler location form without depending on a
@@ -1249,6 +1363,115 @@ ERROR: Build did NOT complete successfully
                 .map(|location| location.path.as_str())
                 .collect::<Vec<_>>(),
             vec!["first.go", "second.go"]
+        );
+    }
+
+    #[test]
+    fn ranks_python_syntax_errors_ahead_of_pycompile_wrappers() {
+        let stderr = br#"Unhandled error:
+Traceback (most recent call last):
+  File "/opt/python/lib/python3.11/py_compile.py", line 144, in compile
+  File "mcp_reducer_fixture/syntax_failure_test.py", line 6
+    configuration = {
+                    ^
+SyntaxError: '{' was never closed
+py_compile.PyCompileError:   File "mcp_reducer_fixture/syntax_failure_test.py", line 6
+SyntaxError: '{' was never closed
+ERROR: Build did NOT complete successfully
+"#;
+        let summary = reduce_invocation(ReductionInput {
+            events: &[],
+            stdout: b"",
+            stderr,
+            exit_code: Some(1),
+            elapsed_ms: 1,
+            budget: Budget::result_default(),
+        });
+
+        let diagnostic = &summary.diagnostics[0];
+        assert_eq!(diagnostic.message, "SyntaxError: '{' was never closed");
+        assert_eq!(diagnostic.category, DiagnosticCategory::Compilation);
+        assert_eq!(diagnostic.repetition_count, 2);
+        assert_eq!(
+            diagnostic.location,
+            Some(DiagnosticLocation {
+                path: "mcp_reducer_fixture/syntax_failure_test.py".into(),
+                line: Some(6),
+                column: None,
+            })
+        );
+        assert!(summary.headline.contains("SyntaxError"));
+    }
+
+    #[test]
+    fn extracts_python_test_traceback_locations_from_bazel_runfiles() {
+        let stderr = br#"Traceback (most recent call last):
+  File "/tmp/output/test.runfiles/_main/pkg/_pricing_test_stage2_bootstrap.py", line 588, in <module>
+  File "/tmp/output/test.runfiles/_main/pkg/pricing_test.py", line 7, in test_total
+    self.assertEqual(actual_total, 41)
+AssertionError: 42 != 41
+"#;
+        let summary = reduce_invocation(ReductionInput {
+            events: &[],
+            stdout: b"",
+            stderr,
+            exit_code: Some(1),
+            elapsed_ms: 1,
+            budget: Budget::result_default(),
+        });
+
+        assert_eq!(summary.diagnostics.len(), 1);
+        assert_eq!(summary.diagnostics[0].message, "AssertionError: 42 != 41");
+        assert_eq!(
+            summary.diagnostics[0].location,
+            Some(DiagnosticLocation {
+                path: "pkg/pricing_test.py".into(),
+                line: Some(7),
+                column: None,
+            })
+        );
+    }
+
+    #[test]
+    fn recognizes_pytest_exception_prefixes() {
+        let mut parser = PythonDiagnosticParser::default();
+        assert!(
+            parser
+                .observe_line("  File \"pkg/test_checkout.py\", line 19, in test_total")
+                .is_none()
+        );
+        let diagnostic = parser
+            .observe_line("E       ValueError: invalid discount")
+            .unwrap();
+
+        assert_eq!(diagnostic.message, "ValueError: invalid discount");
+        assert_eq!(diagnostic.location.unwrap().line, Some(19));
+    }
+
+    #[test]
+    fn keeps_identical_python_messages_at_distinct_locations() {
+        let summary = reduce_invocation(ReductionInput {
+            events: &[],
+            stdout: b"",
+            stderr: br#"  File "pkg/first_test.py", line 3, in test_value
+AssertionError: mismatch
+  File "pkg/second_test.py", line 8, in test_value
+AssertionError: mismatch
+"#,
+            exit_code: Some(1),
+            elapsed_ms: 1,
+            budget: Budget::result_default(),
+        });
+
+        assert_eq!(summary.diagnostics.len(), 2);
+        assert_eq!(
+            summary
+                .diagnostics
+                .iter()
+                .filter_map(|diagnostic| diagnostic.location.as_ref())
+                .map(|location| location.path.as_str())
+                .collect::<Vec<_>>(),
+            vec!["pkg/first_test.py", "pkg/second_test.py"]
         );
     }
 

--- a/crates/bazel-mcp-reducer/src/lib.rs
+++ b/crates/bazel-mcp-reducer/src/lib.rs
@@ -11,8 +11,9 @@ mod text;
 
 pub use budget::{Budget, Budgeted};
 pub use build::{
-    BepAccumulator, ReductionInput, StreamReductionOutput, extract_canonical_arguments,
-    finalize_diagnostics, parse_go_diagnostic, reduce_artifacts, reduce_invocation,
+    BepAccumulator, PythonDiagnosticParser, ReductionInput, StreamReductionOutput,
+    extract_canonical_arguments, finalize_diagnostics, parse_go_diagnostic, reduce_artifacts,
+    reduce_invocation,
 };
 pub use coverage::{CoverageError, parse_lcov, parse_lcov_reader};
 pub use extension::{

--- a/crates/bazel-mcp-runner/src/service.rs
+++ b/crates/bazel-mcp-runner/src/service.rs
@@ -16,9 +16,9 @@ use bazel_mcp_policy::{
     validate_workspace,
 };
 use bazel_mcp_reducer::{
-    Budget, REDUCER_API_VERSION, ReducerContext, ReducerPipeline, StarlarkReducerConfig,
-    StreamReductionOutput, finalize_diagnostics, load_starlark_reducers, normalize_terminal_text,
-    parse_go_diagnostic, parse_lcov_reader, parse_test_xml,
+    Budget, PythonDiagnosticParser, REDUCER_API_VERSION, ReducerContext, ReducerPipeline,
+    StarlarkReducerConfig, StreamReductionOutput, finalize_diagnostics, load_starlark_reducers,
+    normalize_terminal_text, parse_go_diagnostic, parse_lcov_reader, parse_test_xml,
 };
 use bazel_mcp_store::{InvocationCompletion, InvocationPaths, Store, StoreError};
 use bazel_mcp_types::{
@@ -1901,6 +1901,7 @@ impl InvocationService {
                 let Ok(file) = tokio::fs::File::open(&path).await else {
                     continue;
                 };
+                let mut python_parser = PythonDiagnosticParser::default();
                 let marker = format!("\n===== {} :: {} =====\n", test.label, log.name);
                 if raw.write_all(marker.as_bytes()).await.is_err() {
                     continue;
@@ -1938,7 +1939,12 @@ impl InvocationService {
                             diagnostic.target = Some(test.label.clone());
                             diagnostic.message = bounded_text(&diagnostic.message, 1_000);
                             actionable_excerpt = Some(diagnostic);
-                        } else if is_actionable_evidence(&text) {
+                        } else if let Some(mut diagnostic) = python_parser.observe_line(&text) {
+                            diagnostic.category = DiagnosticCategory::Test;
+                            diagnostic.target = Some(test.label.clone());
+                            diagnostic.message = bounded_text(&diagnostic.message, 1_000);
+                            actionable_excerpt = Some(diagnostic);
+                        } else if actionable_excerpt.is_none() && is_actionable_evidence(&text) {
                             actionable_excerpt = Some(Diagnostic {
                                 severity: Severity::Error,
                                 category: DiagnosticCategory::Test,
@@ -2014,7 +2020,8 @@ impl InvocationService {
                 summary.diagnostics.retain(|existing| {
                     !(existing.category == DiagnosticCategory::Compilation
                         && existing.message == diagnostic.message
-                        && existing.location == diagnostic.location)
+                        && (existing.location == diagnostic.location
+                            || existing.location.is_none()))
                 });
             }
             summary.diagnostics.extend(diagnostics);

--- a/crates/bazel-mcp-runner/tests/process.rs
+++ b/crates/bazel-mcp-runner/tests/process.rs
@@ -636,6 +636,82 @@ async fn failed_test_logs_are_snapshotted_and_retrieved_without_a_public_uri() {
 }
 
 #[tokio::test]
+async fn failed_python_test_logs_promote_the_located_traceback_cause() {
+    let root = tempfile::tempdir().unwrap();
+    let workspace = root.path().join("workspace");
+    let output_root = root.path().join("output-user-root");
+    let test_directory = output_root.join("execroot/ws/bazel-out/testlogs/pkg/failing");
+    tokio::fs::create_dir_all(&workspace).await.unwrap();
+    tokio::fs::create_dir_all(&test_directory).await.unwrap();
+    let test_log = test_directory.join("test.log");
+    let test_xml = test_directory.join("test.xml");
+    tokio::fs::write(
+        &test_log,
+        r#"Traceback (most recent call last):
+  File "/tmp/output/failing.runfiles/_main/pkg/failing_test.py", line 7, in test_total
+    self.assertEqual(actual_total, 41)
+AssertionError: 42 != 41 : invoice total should include the fee
+FAILED (failures=1)
+"#,
+    )
+    .await
+    .unwrap();
+    tokio::fs::write(
+        &test_xml,
+        r#"<testsuites><testsuite><testcase name="test_total"><failure message="invoice total mismatch"/></testcase></testsuite></testsuites>"#,
+    )
+    .await
+    .unwrap();
+    let bep = root.path().join("failed-python-test.bep");
+    tokio::fs::write(
+        &bep,
+        failed_test_bep(
+            &format!("file://{}", test_log.display()),
+            &format!("file://{}", test_xml.display()),
+        ),
+    )
+    .await
+    .unwrap();
+    let script = format!(
+        "#!/bin/sh\nif [ \"${{1:-}}\" = --version ]; then echo 'bazel 9.1.0'; exit 0; fi\nfor arg in \"$@\"; do\n  case \"$arg\" in\n    --build_event_binary_file=*) bep_path=${{arg#*=}} ;;\n  esac\ndone\ncp '{}' \"$bep_path\"\necho 'AssertionError: 42 != 41 : invoice total should include the fee' >&2\nexit 1\n",
+        bep.display(),
+    );
+    let service = configured_service(&root, &workspace, &script, |_| {}).await;
+
+    let failed = service
+        .run(InvocationRequest::new(
+            workspace,
+            BazelCommand::Test,
+            vec!["//pkg:failing".into()],
+        ))
+        .await
+        .unwrap();
+    let summary = failed.summary.as_ref().unwrap();
+    assert_eq!(summary.inspect_hint.as_deref(), Some("test_log"));
+    assert!(
+        summary
+            .headline
+            .contains("invoice total should include the fee")
+    );
+    let matching = summary
+        .diagnostics
+        .iter()
+        .filter(|diagnostic| {
+            diagnostic
+                .message
+                .contains("invoice total should include the fee")
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(matching.len(), 1);
+    assert_eq!(matching[0].category, DiagnosticCategory::Test);
+    assert_eq!(
+        matching[0].location.as_ref().unwrap().path,
+        "pkg/failing_test.py"
+    );
+    assert_eq!(matching[0].location.as_ref().unwrap().line, Some(7));
+}
+
+#[tokio::test]
 async fn cancellation_stops_a_running_process_group() {
     let root = tempfile::tempdir().unwrap();
     let workspace = root.path().join("workspace");


### PR DESCRIPTION
## Summary

- pair standard Python traceback frames with terminal exception classes
- compact Bazel runfiles and execroot paths into actionable source locations
- promote located Python test failures without allowing trailing summaries to overwrite them
- deduplicate weaker compilation copies after test-log enrichment

## Root cause

Python prints source locations on a preceding `File "...", line N` frame rather than on the terminal exception line. The line-oriented reducer retained exceptions such as `SyntaxError`, `ModuleNotFoundError`, and `AssertionError`, but discarded their source frames. For precompilation failures, the generic `Unhandled error:` wrapper could therefore rank first; for failed tests, a later `FAILED (...)` summary could replace richer evidence.

## Impact

`bazel.run` now returns the exact Python exception and source line for syntax, import, and assertion failures. Failed tests remain categorized as test diagnostics and retain `inspect_hint=test_log` for optional supporting context.

## Live validation

Replayed failures in `bazel-contrib/rules_python` at commit `68d08786c9299b768f72a436e07cee332bd99f7c`:

- syntax failure: `SyntaxError` at `syntax_failure_test.py:6`
- missing import: `ModuleNotFoundError` at `missing_import_test.py:3`
- assertion failure: one `AssertionError` at `assertion_failure_test.py:7`

## Checks

- Bazel MCP `test //...` (30 targets; 13 tests)
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo shear`
- `git diff --check`
