### PR TITLE
fix(reducer): surface Java root causes

### DIFF
--- a/LEARNINGS.md
+++ b/LEARNINGS.md
@@ -77,3 +77,11 @@ unrelated to MCP efficiency. Do not include secrets or raw sensitive output.
   terminal `Error in fail`, forcing log inspection or returning a large BEP
   wrapper; pair them into a concise loading or analysis diagnostic. Thread:
   `019f6b89-e945-78a0-9264-a6ad416905a1`.
+- Javac diagnostics retained the source path inside the message but discarded
+  its structured location and the following `symbol:` detail; pair the bounded
+  compiler block before ranking. Thread:
+  `019f6b89-e945-78a0-9264-a6ad416905a1`.
+- Java test exceptions were recognized as Python-style compilation failures,
+  while their application stack frames remained only in `test_log`; prefer the
+  first non-framework JVM frame as located test evidence. Thread:
+  `019f6b89-e945-78a0-9264-a6ad416905a1`.

--- a/crates/bazel-mcp-reducer/src/build.rs
+++ b/crates/bazel-mcp-reducer/src/build.rs
@@ -820,6 +820,19 @@ fn bounded_text(value: &str, maximum_bytes: usize) -> String {
 
 fn add_text_diagnostics(input: &[u8], diagnostics: &mut Vec<Diagnostic>) {
     let normalized = normalize_terminal_text(input);
+    diagnostics.extend(parse_java_compiler_diagnostics(&normalized));
+    let mut java_parser = JavaTestDiagnosticParser::default();
+    let mut java_test_messages = BTreeSet::new();
+    for line in normalized.lines() {
+        if let Some(diagnostic) = java_parser.observe_line(line) {
+            java_test_messages.insert(diagnostic.message.clone());
+            diagnostics.push(diagnostic);
+        }
+    }
+    if let Some(diagnostic) = java_parser.finish() {
+        java_test_messages.insert(diagnostic.message.clone());
+        diagnostics.push(diagnostic);
+    }
     let mut starlark_parser = StarlarkDiagnosticParser::default();
     for line in normalized.lines() {
         if let Some(diagnostic) = starlark_parser.observe_line(line) {
@@ -828,6 +841,10 @@ fn add_text_diagnostics(input: &[u8], diagnostics: &mut Vec<Diagnostic>) {
     }
     let mut python_parser = PythonDiagnosticParser::default();
     for line in normalized.lines() {
+        if java_exception_message(line).is_some_and(|message| java_test_messages.contains(message))
+        {
+            continue;
+        }
         if let Some(diagnostic) = python_parser.observe_line(line) {
             diagnostics.push(diagnostic);
         }
@@ -853,6 +870,12 @@ fn add_text_diagnostics(input: &[u8], diagnostics: &mut Vec<Diagnostic>) {
         if let Some(mut diagnostic) = parse_go_diagnostic(&line) {
             diagnostic.repetition_count = count;
             diagnostics.push(diagnostic);
+            continue;
+        }
+        if parse_java_compiler_diagnostic(&line).is_some()
+            || java_exception_message(&line)
+                .is_some_and(|message| java_test_messages.contains(message))
+        {
             continue;
         }
         if parse_starlark_inline_diagnostic(&line)
@@ -899,6 +922,223 @@ fn add_text_diagnostics(input: &[u8], diagnostics: &mut Vec<Diagnostic>) {
             repetition_count: count,
         });
     }
+}
+
+fn parse_java_compiler_diagnostics(input: &str) -> Vec<Diagnostic> {
+    const MAX_CONTEXT_LINES: usize = 8;
+    let lines = input.lines().collect::<Vec<_>>();
+    let mut diagnostics = Vec::new();
+    for (index, line) in lines.iter().enumerate() {
+        let Some(mut diagnostic) = parse_java_compiler_diagnostic(line) else {
+            continue;
+        };
+        if diagnostic
+            .message
+            .eq_ignore_ascii_case("cannot find symbol")
+        {
+            for context in lines.iter().skip(index + 1).take(MAX_CONTEXT_LINES) {
+                if parse_java_compiler_diagnostic(context).is_some()
+                    || context.trim_start().starts_with("ERROR:")
+                {
+                    break;
+                }
+                if let Some(symbol) = context.trim().strip_prefix("symbol:") {
+                    diagnostic.message = format!(
+                        "cannot find symbol: {}",
+                        symbol.split_whitespace().collect::<Vec<_>>().join(" ")
+                    );
+                    break;
+                }
+            }
+        }
+        diagnostics.push(diagnostic);
+    }
+    diagnostics
+}
+
+fn parse_java_compiler_diagnostic(line: &str) -> Option<Diagnostic> {
+    let marker = line.rfind(".java:")?;
+    let path_end = marker + ".java".len();
+    let path = line[..path_end]
+        .trim()
+        .strip_prefix("ERROR: ")
+        .unwrap_or_else(|| line[..path_end].trim());
+    let (line_number, remainder) = split_u32_prefix(&line[path_end + 1..])?;
+    let (column, message) = split_u32_prefix(remainder)
+        .map_or((None, remainder), |(column, message)| {
+            (Some(column), message)
+        });
+    let message = message.trim();
+    let (severity, message) = if let Some(message) = message.strip_prefix("error:") {
+        (Severity::Error, message.trim())
+    } else {
+        let message = message.strip_prefix("warning:")?;
+        (Severity::Warning, message.trim())
+    };
+    if message.is_empty() {
+        return None;
+    }
+    Some(Diagnostic {
+        severity,
+        category: DiagnosticCategory::Compilation,
+        message: message.to_owned(),
+        location: Some(DiagnosticLocation {
+            path: compact_java_path(path),
+            line: Some(line_number),
+            column,
+        }),
+        target: None,
+        action: None,
+        repetition_count: 1,
+    })
+}
+
+/// Stateful extractor for Java exceptions followed by JVM stack frames.
+#[derive(Debug, Default)]
+pub struct JavaTestDiagnosticParser {
+    pending: Option<Diagnostic>,
+    pending_is_explicit: bool,
+    frames_seen: usize,
+}
+
+impl JavaTestDiagnosticParser {
+    const MAX_STACK_FRAMES: usize = 64;
+
+    /// Observes one normalized test-log line and emits an exception once an
+    /// application frame, another exception, or the end of its stack is seen.
+    pub fn observe_line(&mut self, line: &str) -> Option<Diagnostic> {
+        if let Some((message, explicitly_java)) = parse_java_exception_line(line) {
+            let previous = self.take_confirmed();
+            self.pending = Some(Diagnostic {
+                severity: Severity::Error,
+                category: DiagnosticCategory::Test,
+                message: message.to_owned(),
+                location: None,
+                target: None,
+                action: None,
+                repetition_count: 1,
+            });
+            self.pending_is_explicit = explicitly_java;
+            self.frames_seen = 0;
+            return previous;
+        }
+        self.pending.as_ref()?;
+        if let Some((location, framework_frame)) = parse_java_stack_frame(line) {
+            self.frames_seen = self.frames_seen.saturating_add(1);
+            if !framework_frame {
+                let mut diagnostic = self.pending.take()?;
+                diagnostic.location = Some(location);
+                self.pending_is_explicit = false;
+                self.frames_seen = 0;
+                return Some(diagnostic);
+            }
+            if self.frames_seen >= Self::MAX_STACK_FRAMES {
+                return self.take_confirmed();
+            }
+            return None;
+        }
+        if line.trim().is_empty() {
+            return None;
+        }
+        self.take_confirmed()
+    }
+
+    /// Emits an exception that reached end-of-file without an application frame.
+    pub fn finish(&mut self) -> Option<Diagnostic> {
+        self.take_confirmed()
+    }
+
+    fn take_confirmed(&mut self) -> Option<Diagnostic> {
+        let confirmed = self.pending_is_explicit || self.frames_seen > 0;
+        self.pending_is_explicit = false;
+        self.frames_seen = 0;
+        if confirmed {
+            self.pending.take()
+        } else {
+            self.pending = None;
+            None
+        }
+    }
+}
+
+fn java_exception_message(line: &str) -> Option<&str> {
+    parse_java_exception_line(line).map(|(message, _)| message)
+}
+
+fn parse_java_exception_line(line: &str) -> Option<(&str, bool)> {
+    let mut line = line.trim();
+    let mut explicitly_java = false;
+    if let Some(remainder) = line.strip_prefix("Exception in thread \"") {
+        let (_, remainder) = remainder.split_once("\" ")?;
+        line = remainder;
+        explicitly_java = true;
+    } else if let Some(remainder) = line.strip_prefix("Caused by: ") {
+        line = remainder;
+        explicitly_java = true;
+    }
+    let exception_type = line.split_once(':').map_or(line, |(name, _)| name);
+    if exception_type.is_empty()
+        || exception_type
+            .bytes()
+            .any(|byte| !(byte.is_ascii_alphanumeric() || matches!(byte, b'_' | b'.' | b'$')))
+    {
+        return None;
+    }
+    let class_name = exception_type.rsplit('.').next()?;
+    let recognized = class_name.ends_with("Error")
+        || class_name.ends_with("Exception")
+        || class_name.ends_with("Failure");
+    (recognized && (explicitly_java || exception_type.contains('.')))
+        .then_some((line, explicitly_java))
+}
+
+fn parse_java_stack_frame(line: &str) -> Option<(DiagnosticLocation, bool)> {
+    let frame = line.trim().strip_prefix("at ")?;
+    let (callable, source) = frame.split_once('(')?;
+    let source = source.strip_suffix(')')?;
+    let (file, line_number) = source.rsplit_once(':')?;
+    if !file.ends_with(".java") {
+        return None;
+    }
+    let line_number = line_number.parse::<u32>().ok()?;
+    let callable = callable.rsplit_once('/').map_or(callable, |(_, name)| name);
+    let class_name = callable.rsplit_once('.')?.0;
+    let package = class_name.rsplit_once('.').map(|(package, _)| package);
+    let path = package.map_or_else(
+        || file.to_owned(),
+        |package| format!("{}/{}", package.replace('.', "/"), file),
+    );
+    let framework_frame = [
+        "java.",
+        "javax.",
+        "jdk.",
+        "sun.",
+        "junit.",
+        "org.junit.",
+        "org.hamcrest.",
+        "org.opentest4j.",
+        "com.google.testing.junit.",
+    ]
+    .iter()
+    .any(|prefix| callable.starts_with(prefix));
+    Some((
+        DiagnosticLocation {
+            path,
+            line: Some(line_number),
+            column: None,
+        },
+        framework_frame,
+    ))
+}
+
+fn compact_java_path(path: &str) -> String {
+    let path = path.trim_matches('"').replace('\\', "/");
+    if let Some((_, after_execroot)) = path.rsplit_once("/execroot/")
+        && let Some((_, relative)) = after_execroot.split_once('/')
+    {
+        return relative.to_owned();
+    }
+    path.strip_prefix("./").unwrap_or(&path).to_owned()
 }
 
 /// Stateful extractor for Bazel's Starlark source and traceback diagnostics.
@@ -1573,6 +1813,92 @@ ERROR: Build did NOT complete successfully
                 .map(|location| location.path.as_str())
                 .collect::<Vec<_>>(),
             vec!["first.go", "second.go"]
+        );
+    }
+
+    #[test]
+    fn structures_java_compiler_errors_and_retains_symbol_details() {
+        let summary = reduce_invocation(ReductionInput {
+            events: &[],
+            stdout: b"",
+            stderr: br#"mcp/java_fixture/MissingSymbol.java:5: error: cannot find symbol
+    MissingInvoiceCalculator calculator = new MissingInvoiceCalculator();
+    ^
+  symbol:   class MissingInvoiceCalculator
+  location: class MissingSymbol
+ERROR: Building mcp/java_fixture/libmissing_symbol.jar failed: error executing Javac command
+"#,
+            exit_code: Some(1),
+            elapsed_ms: 1,
+            budget: Budget::result_default(),
+        });
+
+        let diagnostic = &summary.diagnostics[0];
+        assert_eq!(
+            diagnostic.message,
+            "cannot find symbol: class MissingInvoiceCalculator"
+        );
+        assert_eq!(diagnostic.category, DiagnosticCategory::Compilation);
+        assert_eq!(
+            diagnostic.location,
+            Some(DiagnosticLocation {
+                path: "mcp/java_fixture/MissingSymbol.java".into(),
+                line: Some(5),
+                column: None,
+            })
+        );
+    }
+
+    #[test]
+    fn structures_java_type_errors_without_context_lines() {
+        let summary = reduce_invocation(ReductionInput {
+            events: &[],
+            stdout: b"",
+            stderr: b"mcp/java_fixture/TypeMismatch.java:5: error: incompatible types: String cannot be converted to int\n",
+            exit_code: Some(1),
+            elapsed_ms: 1,
+            budget: Budget::result_default(),
+        });
+
+        assert_eq!(
+            summary.diagnostics[0].message,
+            "incompatible types: String cannot be converted to int"
+        );
+        assert_eq!(
+            summary.diagnostics[0].location.as_ref().unwrap().line,
+            Some(5)
+        );
+    }
+
+    #[test]
+    fn extracts_java_test_failures_from_the_first_application_frame() {
+        let summary = reduce_invocation(ReductionInput {
+            events: &[],
+            stdout: b"",
+            stderr: br#"java.lang.AssertionError: invoice total mismatch
+    at org.junit.Assert.fail(Assert.java:89)
+    at org.junit.Assert.assertEquals(Assert.java:120)
+    at mcp.java_fixture.RuntimeFailure.assertInvoiceTotal(RuntimeFailure.java:9)
+    at mcp.java_fixture.RuntimeFailure.main(RuntimeFailure.java:5)
+"#,
+            exit_code: Some(1),
+            elapsed_ms: 1,
+            budget: Budget::result_default(),
+        });
+
+        let diagnostic = &summary.diagnostics[0];
+        assert_eq!(
+            diagnostic.message,
+            "java.lang.AssertionError: invoice total mismatch"
+        );
+        assert_eq!(diagnostic.category, DiagnosticCategory::Test);
+        assert_eq!(
+            diagnostic.location,
+            Some(DiagnosticLocation {
+                path: "mcp/java_fixture/RuntimeFailure.java".into(),
+                line: Some(9),
+                column: None,
+            })
         );
     }
 

--- a/crates/bazel-mcp-reducer/src/lib.rs
+++ b/crates/bazel-mcp-reducer/src/lib.rs
@@ -11,9 +11,9 @@ mod text;
 
 pub use budget::{Budget, Budgeted};
 pub use build::{
-    BepAccumulator, PythonDiagnosticParser, ReductionInput, StreamReductionOutput,
-    extract_canonical_arguments, finalize_diagnostics, parse_go_diagnostic, reduce_artifacts,
-    reduce_invocation,
+    BepAccumulator, JavaTestDiagnosticParser, PythonDiagnosticParser, ReductionInput,
+    StreamReductionOutput, extract_canonical_arguments, finalize_diagnostics, parse_go_diagnostic,
+    reduce_artifacts, reduce_invocation,
 };
 pub use coverage::{CoverageError, parse_lcov, parse_lcov_reader};
 pub use extension::{

--- a/crates/bazel-mcp-runner/src/service.rs
+++ b/crates/bazel-mcp-runner/src/service.rs
@@ -16,10 +16,10 @@ use bazel_mcp_policy::{
     validate_workspace,
 };
 use bazel_mcp_reducer::{
-    Budget, PythonDiagnosticParser, REDUCER_API_VERSION, ReducerContext, ReducerPipeline,
-    StarlarkReducerConfig, StreamReductionOutput, TestFailureAccumulator, TestFailureEvidence,
-    finalize_diagnostics, load_starlark_reducers, normalize_terminal_text, parse_go_diagnostic,
-    parse_lcov_reader, parse_test_xml,
+    Budget, JavaTestDiagnosticParser, PythonDiagnosticParser, REDUCER_API_VERSION, ReducerContext,
+    ReducerPipeline, StarlarkReducerConfig, StreamReductionOutput, TestFailureAccumulator,
+    TestFailureEvidence, finalize_diagnostics, load_starlark_reducers, normalize_terminal_text,
+    parse_go_diagnostic, parse_lcov_reader, parse_test_xml,
 };
 use bazel_mcp_store::{InvocationCompletion, InvocationPaths, Store, StoreError};
 use bazel_mcp_types::{
@@ -1909,6 +1909,7 @@ impl InvocationService {
                 let Ok(file) = tokio::fs::File::open(&path).await else {
                     continue;
                 };
+                let mut java_parser = JavaTestDiagnosticParser::default();
                 let mut python_parser = PythonDiagnosticParser::default();
                 let marker = format!("\n===== {} :: {} =====\n", test.label, log.name);
                 if raw.write_all(marker.as_bytes()).await.is_err() {
@@ -1944,8 +1945,13 @@ impl InvocationService {
                             4 * 1024,
                         );
                         failure_accumulator.observe_line(&text);
+                        let java_diagnostic = java_parser.observe_line(&text);
                         let candidate = if let Some(mut diagnostic) = parse_go_diagnostic(&text) {
                             diagnostic.category = DiagnosticCategory::Test;
+                            diagnostic.target = Some(test.label.clone());
+                            diagnostic.message = bounded_text(&diagnostic.message, 1_000);
+                            Some((0, diagnostic))
+                        } else if let Some(mut diagnostic) = java_diagnostic {
                             diagnostic.target = Some(test.label.clone());
                             diagnostic.message = bounded_text(&diagnostic.message, 1_000);
                             Some((0, diagnostic))
@@ -1971,9 +1977,14 @@ impl InvocationService {
                             })
                         };
                         if let Some((priority, diagnostic)) = candidate
-                            && fallback_excerpt
-                                .as_ref()
-                                .is_none_or(|(current, _)| priority < *current)
+                            && fallback_excerpt.as_ref().is_none_or(
+                                |(current, current_diagnostic)| {
+                                    priority < *current
+                                        || (priority == *current
+                                            && diagnostic.location.is_some()
+                                            && current_diagnostic.location.is_none())
+                                },
+                            )
                         {
                             fallback_excerpt = Some((priority, diagnostic));
                         }
@@ -1993,6 +2004,18 @@ impl InvocationService {
                     }
                     if !complete {
                         break;
+                    }
+                }
+                if complete && let Some(mut diagnostic) = java_parser.finish() {
+                    diagnostic.target = Some(test.label.clone());
+                    diagnostic.message = bounded_text(&diagnostic.message, 1_000);
+                    if fallback_excerpt.as_ref().is_none_or(|(priority, current)| {
+                        *priority > 0
+                            || (*priority == 0
+                                && diagnostic.location.is_some()
+                                && current.location.is_none())
+                    }) {
+                        fallback_excerpt = Some((0, diagnostic));
                     }
                 }
                 if complete {
@@ -2091,7 +2114,8 @@ impl InvocationService {
         if committed {
             for diagnostic in &diagnostics {
                 summary.diagnostics.retain(|existing| {
-                    !(existing.category == DiagnosticCategory::Compilation
+                    !((existing.category == DiagnosticCategory::Compilation
+                        || (existing.category == diagnostic.category && existing.target.is_none()))
                         && existing.message == diagnostic.message
                         && (existing.location == diagnostic.location
                             || existing.location.is_none()))

--- a/crates/bazel-mcp-runner/tests/process.rs
+++ b/crates/bazel-mcp-runner/tests/process.rs
@@ -742,6 +742,76 @@ FAILED (failures=1)
 }
 
 #[tokio::test]
+async fn failed_java_test_logs_promote_the_located_application_frame() {
+    let root = tempfile::tempdir().unwrap();
+    let workspace = root.path().join("workspace");
+    let output_root = root.path().join("output-user-root");
+    let test_directory = output_root.join("execroot/ws/bazel-out/testlogs/pkg/failing");
+    tokio::fs::create_dir_all(&workspace).await.unwrap();
+    tokio::fs::create_dir_all(&test_directory).await.unwrap();
+    let test_log = test_directory.join("test.log");
+    let test_xml = test_directory.join("test.xml");
+    tokio::fs::write(
+        &test_log,
+        r#"java.lang.AssertionError: invoice total should include the fee
+    at org.junit.Assert.fail(Assert.java:89)
+    at mcp.java_fixture.RuntimeFailure.assertInvoiceTotal(RuntimeFailure.java:9)
+    at mcp.java_fixture.RuntimeFailure.main(RuntimeFailure.java:5)
+"#,
+    )
+    .await
+    .unwrap();
+    tokio::fs::write(
+        &test_xml,
+        r#"<testsuites><testsuite><testcase name="assertInvoiceTotal"><failure message="invoice total mismatch"/></testcase></testsuite></testsuites>"#,
+    )
+    .await
+    .unwrap();
+    let bep = root.path().join("failed-java-test.bep");
+    tokio::fs::write(
+        &bep,
+        failed_test_bep(
+            &format!("file://{}", test_log.display()),
+            &format!("file://{}", test_xml.display()),
+        ),
+    )
+    .await
+    .unwrap();
+    let script = format!(
+        "#!/bin/sh\nif [ \"${{1:-}}\" = --version ]; then echo 'bazel 9.1.0'; exit 0; fi\nfor arg in \"$@\"; do\n  case \"$arg\" in\n    --build_event_binary_file=*) bep_path=${{arg#*=}} ;;\n  esac\ndone\ncp '{}' \"$bep_path\"\nprintf '%s\\n' 'java.lang.AssertionError: invoice total should include the fee' '    at mcp.java_fixture.RuntimeFailure.assertInvoiceTotal(RuntimeFailure.java:9)' >&2\nexit 1\n",
+        bep.display(),
+    );
+    let service = configured_service(&root, &workspace, &script, |_| {}).await;
+
+    let failed = service
+        .run(InvocationRequest::new(
+            workspace,
+            BazelCommand::Test,
+            vec!["//pkg:failing".into()],
+        ))
+        .await
+        .unwrap();
+    let summary = failed.summary.as_ref().unwrap();
+    assert_eq!(summary.inspect_hint.as_deref(), Some("test_log"));
+    let matching = summary
+        .diagnostics
+        .iter()
+        .filter(|diagnostic| {
+            diagnostic
+                .message
+                .contains("invoice total should include the fee")
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(matching.len(), 1);
+    assert_eq!(matching[0].category, DiagnosticCategory::Test);
+    assert_eq!(
+        matching[0].location.as_ref().unwrap().path,
+        "mcp/java_fixture/RuntimeFailure.java"
+    );
+    assert_eq!(matching[0].location.as_ref().unwrap().line, Some(9));
+}
+
+#[tokio::test]
 async fn failed_rust_test_log_promotes_case_and_assertion_to_initial_summary() {
     let root = tempfile::tempdir().unwrap();
     let workspace = root.path().join("workspace");


### PR DESCRIPTION
## Summary

- parse javac source diagnostics into structured file and line locations
- retain bounded `symbol:` context for missing-symbol failures
- recognize Java exceptions and select the first non-framework JVM stack frame
- classify Java runtime assertions as test failures instead of compilation failures
- deduplicate identical evidence emitted through both Bazel console output and retained `test.log`

## Root cause

Java compiler diagnostics were handled as generic actionable text, leaving the source path embedded in the message and discarding javac's following symbol detail. Java exception class names also matched the Python exception heuristic, so JVM assertions were categorized as compilation failures without their application stack-frame location.

## Impact

Agents now receive concise, editable Java root causes directly from `bazel.run`: javac errors include structured source locations and missing symbols, while failed Java tests include the application frame, test category, and target without duplicate evidence.

## Validation

- live compiler and test replay against `bazelbuild/rules_java` at `ed0a552e93dbb7473c79949a86415d52dfb3245a`
- Bazel MCP `test //...`: 30 targets succeeded, 13 tests passed
- `cargo test -p bazel-mcp-reducer`: 37 unit tests and 2 golden tests passed
- `cargo test -p bazel-mcp-runner --test process failed_java_test_logs_promote_the_located_application_frame`
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo shear`
- `git diff --check`
