### PR TITLE
fix(reducer): surface protobuf diagnostics

### DIFF
--- a/LEARNINGS.md
+++ b/LEARNINGS.md
@@ -85,3 +85,11 @@ unrelated to MCP efficiency. Do not include secrets or raw sensitive output.
   while their application stack frames remained only in `test_log`; prefer the
   first non-framework JVM frame as located test evidence. Thread:
   `019f6b89-e945-78a0-9264-a6ad416905a1`.
+- Protoc source diagnostics omit generic `error:` markers, so syntax, import,
+  and schema failures were discarded in favor of Bazel action wrappers; parse
+  the `.proto:line:column` form directly. Thread:
+  `019f6b89-e945-78a0-9264-a6ad416905a1`.
+- Missing protobuf imports emit an unlocated missing-file line before the
+  editable import declaration and dependent type errors; rank the located
+  declaration first and preserve the follow-on diagnostics. Thread:
+  `019f6b89-e945-78a0-9264-a6ad416905a1`.

--- a/crates/bazel-mcp-reducer/src/build.rs
+++ b/crates/bazel-mcp-reducer/src/build.rs
@@ -867,6 +867,11 @@ fn add_text_diagnostics(input: &[u8], diagnostics: &mut Vec<Diagnostic>) {
             diagnostics.push(diagnostic);
             continue;
         }
+        if let Some(mut diagnostic) = parse_protobuf_diagnostic(&line) {
+            diagnostic.repetition_count = count;
+            diagnostics.push(diagnostic);
+            continue;
+        }
         if let Some(mut diagnostic) = parse_go_diagnostic(&line) {
             diagnostic.repetition_count = count;
             diagnostics.push(diagnostic);
@@ -922,6 +927,54 @@ fn add_text_diagnostics(input: &[u8], diagnostics: &mut Vec<Diagnostic>) {
             repetition_count: count,
         });
     }
+}
+
+fn parse_protobuf_diagnostic(line: &str) -> Option<Diagnostic> {
+    let marker = line.rfind(".proto:")?;
+    let path_end = marker + ".proto".len();
+    let path = line[..path_end]
+        .trim()
+        .strip_prefix("ERROR: ")
+        .unwrap_or_else(|| line[..path_end].trim());
+    let (line_number, remainder) = split_u32_prefix(&line[path_end + 1..])?;
+    let (column, message) = split_u32_prefix(remainder)
+        .map_or((None, remainder), |(column, message)| {
+            (Some(column), message)
+        });
+    let message = message.trim();
+    let (severity, message) = if let Some(message) = message.strip_prefix("warning:") {
+        (Severity::Warning, message.trim())
+    } else if let Some(message) = message.strip_prefix("error:") {
+        (Severity::Error, message.trim())
+    } else {
+        (Severity::Error, message)
+    };
+    if message.is_empty() {
+        return None;
+    }
+    Some(Diagnostic {
+        severity,
+        category: DiagnosticCategory::Compilation,
+        message: message.to_owned(),
+        location: Some(DiagnosticLocation {
+            path: compact_protobuf_path(path),
+            line: Some(line_number),
+            column,
+        }),
+        target: None,
+        action: None,
+        repetition_count: 1,
+    })
+}
+
+fn compact_protobuf_path(path: &str) -> String {
+    let path = path.trim_matches('"').replace('\\', "/");
+    if let Some((_, after_execroot)) = path.rsplit_once("/execroot/")
+        && let Some((_, relative)) = after_execroot.split_once('/')
+    {
+        return relative.to_owned();
+    }
+    path.strip_prefix("./").unwrap_or(&path).to_owned()
 }
 
 fn parse_java_compiler_diagnostics(input: &str) -> Vec<Diagnostic> {
@@ -1814,6 +1867,70 @@ ERROR: Build did NOT complete successfully
                 .collect::<Vec<_>>(),
             vec!["first.go", "second.go"]
         );
+    }
+
+    #[test]
+    fn structures_protobuf_syntax_errors_without_error_markers() {
+        let summary = reduce_invocation(ReductionInput {
+            events: &[],
+            stdout: b"",
+            stderr: br#"mcp/proto_fixture/syntax_failure.proto:7:1: Expected ";".
+ERROR: Build did NOT complete successfully
+"#,
+            exit_code: Some(1),
+            elapsed_ms: 1,
+            budget: Budget::result_default(),
+        });
+
+        let diagnostic = &summary.diagnostics[0];
+        assert_eq!(diagnostic.message, "Expected \";\".");
+        assert_eq!(diagnostic.category, DiagnosticCategory::Compilation);
+        assert_eq!(
+            diagnostic.location,
+            Some(DiagnosticLocation {
+                path: "mcp/proto_fixture/syntax_failure.proto".into(),
+                line: Some(7),
+                column: Some(1),
+            })
+        );
+        assert!(summary.headline.contains("Expected"));
+    }
+
+    #[test]
+    fn ranks_the_located_protobuf_import_failure_ahead_of_missing_file_noise() {
+        let summary = reduce_invocation(ReductionInput {
+            events: &[],
+            stdout: b"",
+            stderr: br#"mcp/proto_fixture/does_not_exist.proto: File not found.
+mcp/proto_fixture/missing_import.proto:5:1: Import "mcp/proto_fixture/does_not_exist.proto" was not found or had errors.
+mcp/proto_fixture/missing_import.proto:8:3: "MissingDependency" is not defined.
+"#,
+            exit_code: Some(1),
+            elapsed_ms: 1,
+            budget: Budget::result_default(),
+        });
+
+        assert_eq!(summary.diagnostics.len(), 2);
+        assert_eq!(
+            summary.diagnostics[0].message,
+            "Import \"mcp/proto_fixture/does_not_exist.proto\" was not found or had errors."
+        );
+        assert_eq!(
+            summary.diagnostics[0].location.as_ref().unwrap().line,
+            Some(5)
+        );
+    }
+
+    #[test]
+    fn parses_protobuf_warnings_and_compacts_execroot_paths() {
+        let diagnostic = parse_protobuf_diagnostic(
+            "/tmp/output/execroot/project/pkg/schema.proto:4:2: warning: Import common.proto is unused.",
+        )
+        .unwrap();
+
+        assert_eq!(diagnostic.severity, Severity::Warning);
+        assert_eq!(diagnostic.message, "Import common.proto is unused.");
+        assert_eq!(diagnostic.location.unwrap().path, "pkg/schema.proto");
     }
 
     #[test]

--- a/crates/bazel-mcp-runner/tests/process.rs
+++ b/crates/bazel-mcp-runner/tests/process.rs
@@ -428,6 +428,39 @@ async fn starlark_source_locations_are_workspace_relative() {
 }
 
 #[tokio::test]
+async fn protobuf_source_locations_are_workspace_relative() {
+    let root = tempfile::tempdir().unwrap();
+    let workspace = root.path().join("workspace");
+    tokio::fs::create_dir(&workspace).await.unwrap();
+    let service = service(
+        &root,
+        &workspace,
+        "#!/bin/sh\necho \"$PWD/proto/schema.proto:6:3: \\\"MissingMessage\\\" is not defined.\" >&2\nexit 1\n",
+    )
+    .await;
+
+    let failed = service
+        .run(InvocationRequest::new(
+            workspace,
+            BazelCommand::Build,
+            vec!["//proto:schema".into()],
+        ))
+        .await
+        .unwrap();
+    let summary = failed.summary.as_ref().unwrap();
+    assert!(summary.headline.contains("MissingMessage"));
+    let diagnostic = &summary.diagnostics[0];
+    assert_eq!(diagnostic.category, DiagnosticCategory::Compilation);
+    assert_eq!(diagnostic.message, "\"MissingMessage\" is not defined.");
+    assert_eq!(
+        diagnostic.location.as_ref().unwrap().path,
+        "proto/schema.proto"
+    );
+    assert_eq!(diagnostic.location.as_ref().unwrap().line, Some(6));
+    assert_eq!(diagnostic.location.as_ref().unwrap().column, Some(3));
+}
+
+#[tokio::test]
 async fn log_inspection_uses_bounded_opaque_cursors() {
     let root = tempfile::tempdir().unwrap();
     let workspace = root.path().join("workspace");


### PR DESCRIPTION
## Summary

- parse protoc's native `.proto:line[:column]: message` diagnostic form
- emit structured workspace-relative protobuf source locations
- preserve protoc warning severity and compact execroot paths
- prefer located missing-import declarations over unlocated missing-file noise
- retain follow-on schema diagnostics such as undefined types

## Root cause

Protoc emits precise source diagnostics without a generic `error:` marker. The generic reducer therefore discarded syntax, import, duplicate-field, and undefined-type messages, allowing Bazel's action wrapper or `Build did NOT complete successfully` to become the headline.

## Impact

Agents now receive the exact protobuf root cause and editable file, line, and column directly from `bazel.run`. Missing imports lead with the source declaration that needs editing while retaining related type failures as secondary evidence.

## Validation

- live syntax, missing-import, duplicate-field-number, and undefined-type replay against `bazelbuild/rules_proto` at `dcd61fec58ad7d9fa49a3736a2afbce29cf927c2`
- Bazel MCP `test //...`: 30 targets succeeded, 13 tests passed
- `cargo test -p bazel-mcp-reducer`: 40 unit tests and 2 golden tests passed
- `cargo test -p bazel-mcp-runner --test process protobuf_source_locations_are_workspace_relative`
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo shear`
- `git diff --check`
