### PR TITLE
fix(reducer): surface TypeScript and JavaScript diagnostics

### DIFF
--- a/LEARNINGS.md
+++ b/LEARNINGS.md
@@ -93,3 +93,11 @@ unrelated to MCP efficiency. Do not include secrets or raw sensitive output.
   editable import declaration and dependent type errors; rank the located
   declaration first and preserve the follow-on diagnostics. Thread:
   `019f6b89-e945-78a0-9264-a6ad416905a1`.
+- TypeScript compiler diagnostics use `file(line,column): error TS...` without
+  the generic marker the reducer expected, leaving Bazel's completion wrapper
+  as the headline; parse the tsc code and location directly. Thread:
+  `019f6b89-e945-78a0-9264-a6ad416905a1`.
+- Node exceptions were retained as unlocated compilation evidence while their
+  source headers and application stack frames stayed only in `test.log`; pair
+  bounded Node frames and prefer the test-scoped diagnostic. Thread:
+  `019f6b89-e945-78a0-9264-a6ad416905a1`.

--- a/crates/bazel-mcp-reducer/src/build.rs
+++ b/crates/bazel-mcp-reducer/src/build.rs
@@ -821,6 +821,18 @@ fn bounded_text(value: &str, maximum_bytes: usize) -> String {
 fn add_text_diagnostics(input: &[u8], diagnostics: &mut Vec<Diagnostic>) {
     let normalized = normalize_terminal_text(input);
     diagnostics.extend(parse_java_compiler_diagnostics(&normalized));
+    let mut javascript_parser = JavaScriptTestDiagnosticParser::default();
+    let mut javascript_test_messages = BTreeSet::new();
+    for line in normalized.lines() {
+        if let Some(diagnostic) = javascript_parser.observe_line(line) {
+            javascript_test_messages.insert(diagnostic.message.clone());
+            diagnostics.push(diagnostic);
+        }
+    }
+    if let Some(diagnostic) = javascript_parser.finish() {
+        javascript_test_messages.insert(diagnostic.message.clone());
+        diagnostics.push(diagnostic);
+    }
     let mut java_parser = JavaTestDiagnosticParser::default();
     let mut java_test_messages = BTreeSet::new();
     for line in normalized.lines() {
@@ -841,7 +853,10 @@ fn add_text_diagnostics(input: &[u8], diagnostics: &mut Vec<Diagnostic>) {
     }
     let mut python_parser = PythonDiagnosticParser::default();
     for line in normalized.lines() {
-        if java_exception_message(line).is_some_and(|message| java_test_messages.contains(message))
+        if javascript_exception_message(line)
+            .is_some_and(|message| javascript_test_messages.contains(message))
+            || java_exception_message(line)
+                .is_some_and(|message| java_test_messages.contains(message))
         {
             continue;
         }
@@ -867,6 +882,11 @@ fn add_text_diagnostics(input: &[u8], diagnostics: &mut Vec<Diagnostic>) {
             diagnostics.push(diagnostic);
             continue;
         }
+        if let Some(mut diagnostic) = parse_typescript_diagnostic(&line) {
+            diagnostic.repetition_count = count;
+            diagnostics.push(diagnostic);
+            continue;
+        }
         if let Some(mut diagnostic) = parse_protobuf_diagnostic(&line) {
             diagnostic.repetition_count = count;
             diagnostics.push(diagnostic);
@@ -878,6 +898,8 @@ fn add_text_diagnostics(input: &[u8], diagnostics: &mut Vec<Diagnostic>) {
             continue;
         }
         if parse_java_compiler_diagnostic(&line).is_some()
+            || javascript_exception_message(&line)
+                .is_some_and(|message| javascript_test_messages.contains(message))
             || java_exception_message(&line)
                 .is_some_and(|message| java_test_messages.contains(message))
         {
@@ -927,6 +949,232 @@ fn add_text_diagnostics(input: &[u8], diagnostics: &mut Vec<Diagnostic>) {
             repetition_count: count,
         });
     }
+}
+
+fn parse_typescript_diagnostic(line: &str) -> Option<Diagnostic> {
+    let line = line
+        .trim()
+        .strip_prefix("ERROR: ")
+        .unwrap_or_else(|| line.trim());
+    let (path, line_number, column, message) = parse_typescript_parenthesized_location(line)
+        .or_else(|| parse_typescript_pretty_location(line))?;
+    let message = message.trim().trim_start_matches('-').trim();
+    let (severity, message) = if let Some(message) = message.strip_prefix("error ") {
+        (Severity::Error, message)
+    } else {
+        (Severity::Warning, message.strip_prefix("warning ")?)
+    };
+    let (code, message) = message.split_once(':')?;
+    if !code.strip_prefix("TS").is_some_and(|digits| {
+        !digits.is_empty() && digits.bytes().all(|byte| byte.is_ascii_digit())
+    }) {
+        return None;
+    }
+    let message = message.trim();
+    if message.is_empty() {
+        return None;
+    }
+    Some(Diagnostic {
+        severity,
+        category: DiagnosticCategory::Compilation,
+        message: format!("{code}: {message}"),
+        location: Some(DiagnosticLocation {
+            path: compact_javascript_path(path),
+            line: Some(line_number),
+            column: Some(column),
+        }),
+        target: None,
+        action: None,
+        repetition_count: 1,
+    })
+}
+
+fn parse_typescript_parenthesized_location(line: &str) -> Option<(&str, u32, u32, &str)> {
+    let path_end = typescript_path_end(line, '(')?;
+    let remainder = line[path_end..].strip_prefix('(')?;
+    let (coordinates, message) = remainder.split_once("): ")?;
+    let (line_number, column) = coordinates.split_once(',')?;
+    let line_number = line_number.trim().parse::<u32>().ok()?;
+    let column = column.trim().parse::<u32>().ok()?;
+    Some((&line[..path_end], line_number, column, message))
+}
+
+fn parse_typescript_pretty_location(line: &str) -> Option<(&str, u32, u32, &str)> {
+    let path_end = typescript_path_end(line, ':')?;
+    let (line_number, remainder) = line[path_end + 1..].split_once(':')?;
+    let line_number = line_number.parse::<u32>().ok()?;
+    let (column, message) = remainder
+        .split_once(" - ")
+        .or_else(|| remainder.split_once(':'))?;
+    let column = column.parse::<u32>().ok()?;
+    Some((&line[..path_end], line_number, column, message))
+}
+
+fn typescript_path_end(line: &str, delimiter: char) -> Option<usize> {
+    const EXTENSIONS: [&str; 8] = [".tsx", ".mts", ".cts", ".ts", ".jsx", ".mjs", ".cjs", ".js"];
+    EXTENSIONS
+        .iter()
+        .filter_map(|extension| {
+            let marker = format!("{extension}{delimiter}");
+            line.rfind(&marker).map(|index| index + extension.len())
+        })
+        .max()
+}
+
+/// Stateful extractor for Node.js exceptions and their application frames.
+#[derive(Debug, Default)]
+pub struct JavaScriptTestDiagnosticParser {
+    leading_location: Option<DiagnosticLocation>,
+    pending: Option<Diagnostic>,
+    frames_seen: usize,
+}
+
+impl JavaScriptTestDiagnosticParser {
+    const MAX_STACK_FRAMES: usize = 64;
+
+    /// Observes one normalized test-log line and emits an exception after a
+    /// JavaScript source header or application stack frame confirms it.
+    pub fn observe_line(&mut self, line: &str) -> Option<Diagnostic> {
+        if !line.trim_start().starts_with("at ")
+            && let Some(location) = parse_javascript_location(line.trim())
+        {
+            let previous = self.take_confirmed();
+            self.leading_location = Some(location);
+            return previous;
+        }
+        if let Some(message) = javascript_exception_message(line) {
+            let leading_location = self.leading_location.take();
+            let previous = self.take_confirmed();
+            self.pending = Some(Diagnostic {
+                severity: Severity::Error,
+                category: DiagnosticCategory::Test,
+                message: message.to_owned(),
+                location: leading_location,
+                target: None,
+                action: None,
+                repetition_count: 1,
+            });
+            self.frames_seen = 0;
+            return previous;
+        }
+        self.pending.as_ref()?;
+        if let Some(location) = parse_javascript_stack_frame(line) {
+            self.frames_seen = self.frames_seen.saturating_add(1);
+            if let Some(location) = location {
+                let mut diagnostic = self.pending.take()?;
+                diagnostic.location = Some(location);
+                self.frames_seen = 0;
+                return Some(diagnostic);
+            }
+            if self.frames_seen >= Self::MAX_STACK_FRAMES {
+                return self.take_confirmed();
+            }
+            return None;
+        }
+        if line.trim().is_empty() {
+            return None;
+        }
+        self.take_confirmed()
+    }
+
+    /// Emits a confirmed exception that reached end-of-file.
+    pub fn finish(&mut self) -> Option<Diagnostic> {
+        self.take_confirmed()
+    }
+
+    fn take_confirmed(&mut self) -> Option<Diagnostic> {
+        let confirmed = self
+            .pending
+            .as_ref()
+            .is_some_and(|diagnostic| diagnostic.location.is_some())
+            || self.frames_seen > 0;
+        self.frames_seen = 0;
+        self.leading_location = None;
+        if confirmed {
+            self.pending.take()
+        } else {
+            self.pending = None;
+            None
+        }
+    }
+}
+
+fn javascript_exception_message(line: &str) -> Option<&str> {
+    let line = line.trim();
+    let exception_type = line.split_once(':').map_or(line, |(name, _)| name);
+    let class_name = exception_type.split_whitespace().next()?;
+    (!class_name.is_empty()
+        && class_name
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'_' | b'.' | b'$'))
+        && (class_name.ends_with("Error") || class_name.ends_with("Exception")))
+    .then_some(line)
+}
+
+fn parse_javascript_stack_frame(line: &str) -> Option<Option<DiagnosticLocation>> {
+    let frame = line.trim().strip_prefix("at ")?;
+    let source = if let Some((_, source)) = frame.rsplit_once('(') {
+        source.strip_suffix(')')?
+    } else {
+        frame.split_whitespace().last()?
+    };
+    if source.starts_with("node:") || matches!(source, "native" | "<anonymous>") {
+        return Some(None);
+    }
+    let location = parse_javascript_location(source)?;
+    let framework = location.path.contains("/node_modules/")
+        || location.path.starts_with("node_modules/")
+        || location.path.contains("/external/");
+    Some((!framework).then_some(location))
+}
+
+fn parse_javascript_location(value: &str) -> Option<DiagnosticLocation> {
+    let value = value.trim().trim_matches('"');
+    let path_end = javascript_path_end(value)?;
+    let coordinates = value[path_end..].strip_prefix(':')?;
+    let (line_number, column) = if let Some((line_number, column)) = coordinates.split_once(':') {
+        (
+            line_number.parse::<u32>().ok()?,
+            Some(column.parse::<u32>().ok()?),
+        )
+    } else {
+        (coordinates.parse::<u32>().ok()?, None)
+    };
+    Some(DiagnosticLocation {
+        path: compact_javascript_path(&value[..path_end]),
+        line: Some(line_number),
+        column,
+    })
+}
+
+fn javascript_path_end(value: &str) -> Option<usize> {
+    const EXTENSIONS: [&str; 8] = [".tsx", ".mts", ".cts", ".ts", ".jsx", ".mjs", ".cjs", ".js"];
+    EXTENSIONS
+        .iter()
+        .filter_map(|extension| {
+            let marker = format!("{extension}:");
+            value.rfind(&marker).map(|index| index + extension.len())
+        })
+        .max()
+}
+
+fn compact_javascript_path(path: &str) -> String {
+    let path = path
+        .trim_matches('"')
+        .strip_prefix("file://")
+        .unwrap_or(path)
+        .replace('\\', "/");
+    for marker in [".runfiles/_main/", ".runfiles/__main__/"] {
+        if let Some((_, relative)) = path.rsplit_once(marker) {
+            return relative.to_owned();
+        }
+    }
+    if let Some((_, after_execroot)) = path.rsplit_once("/execroot/")
+        && let Some((_, relative)) = after_execroot.split_once('/')
+    {
+        return relative.to_owned();
+    }
+    path.strip_prefix("./").unwrap_or(&path).to_owned()
 }
 
 fn parse_protobuf_diagnostic(line: &str) -> Option<Diagnostic> {
@@ -1866,6 +2114,142 @@ ERROR: Build did NOT complete successfully
                 .map(|location| location.path.as_str())
                 .collect::<Vec<_>>(),
             vec!["first.go", "second.go"]
+        );
+    }
+
+    #[test]
+    fn structures_typescript_compiler_errors_without_generic_error_markers() {
+        let summary = reduce_invocation(ReductionInput {
+            events: &[],
+            stdout: b"",
+            stderr: b"mcp/js_fixture/type_mismatch.ts(6,3): error TS2322: Type 'string' is not assignable to type 'number'.\nERROR: Build did NOT complete successfully\n",
+            exit_code: Some(1),
+            elapsed_ms: 1,
+            budget: Budget::result_default(),
+        });
+
+        let diagnostic = &summary.diagnostics[0];
+        assert_eq!(
+            diagnostic.message,
+            "TS2322: Type 'string' is not assignable to type 'number'."
+        );
+        assert_eq!(diagnostic.category, DiagnosticCategory::Compilation);
+        assert_eq!(
+            diagnostic.location,
+            Some(DiagnosticLocation {
+                path: "mcp/js_fixture/type_mismatch.ts".into(),
+                line: Some(6),
+                column: Some(3),
+            })
+        );
+        assert!(summary.headline.contains("TS2322"));
+    }
+
+    #[test]
+    fn parses_typescript_pretty_diagnostics_and_javascript_inputs() {
+        let diagnostic = parse_typescript_diagnostic(
+            "/tmp/output/execroot/project/pkg/check.jsx:8:11 - warning TS6133: 'total' is declared but its value is never read.",
+        )
+        .unwrap();
+
+        assert_eq!(diagnostic.severity, Severity::Warning);
+        assert_eq!(
+            diagnostic.message,
+            "TS6133: 'total' is declared but its value is never read."
+        );
+        assert_eq!(diagnostic.location.unwrap().path, "pkg/check.jsx");
+    }
+
+    #[test]
+    fn keeps_distinct_typescript_syntax_diagnostics() {
+        let summary = reduce_invocation(ReductionInput {
+            events: &[],
+            stdout: b"",
+            stderr: br#"mcp/js_fixture/syntax_failure.ts(8,8): error TS1005: ',' expected.
+mcp/js_fixture/syntax_failure.ts(8,21): error TS1005: ',' expected.
+mcp/js_fixture/syntax_failure.ts(9,1): error TS1005: '}' expected.
+"#,
+            exit_code: Some(1),
+            elapsed_ms: 1,
+            budget: Budget::result_default(),
+        });
+
+        assert_eq!(summary.diagnostics.len(), 3);
+        assert_eq!(
+            summary
+                .diagnostics
+                .iter()
+                .filter_map(|diagnostic| diagnostic.location.as_ref()?.column)
+                .collect::<Vec<_>>(),
+            vec![8, 21, 1]
+        );
+    }
+
+    #[test]
+    fn extracts_node_exceptions_from_application_stack_frames() {
+        let summary = reduce_invocation(ReductionInput {
+            events: &[],
+            stdout: b"",
+            stderr: br#"/tmp/output/runtime_type_error.runfiles/_main/mcp/js_fixture/runtime_type_error.js:2
+return invoice.lines.reduce((total, line) => total + line.amount, 0);
+               ^
+
+TypeError: Cannot read properties of undefined (reading 'lines')
+    at calculateInvoiceTotal (/tmp/output/runtime_type_error.runfiles/_main/mcp/js_fixture/runtime_type_error.js:2:18)
+    at Object.<anonymous> (/tmp/output/runtime_type_error.runfiles/_main/mcp/js_fixture/runtime_type_error.js:6:1)
+"#,
+            exit_code: Some(1),
+            elapsed_ms: 1,
+            budget: Budget::result_default(),
+        });
+
+        assert_eq!(summary.diagnostics.len(), 1);
+        let diagnostic = &summary.diagnostics[0];
+        assert_eq!(diagnostic.category, DiagnosticCategory::Test);
+        assert_eq!(
+            diagnostic.message,
+            "TypeError: Cannot read properties of undefined (reading 'lines')"
+        );
+        assert_eq!(
+            diagnostic.location,
+            Some(DiagnosticLocation {
+                path: "mcp/js_fixture/runtime_type_error.js".into(),
+                line: Some(2),
+                column: Some(18),
+            })
+        );
+    }
+
+    #[test]
+    fn pairs_node_syntax_errors_with_the_source_header() {
+        let summary = reduce_invocation(ReductionInput {
+            events: &[],
+            stdout: b"",
+            stderr: br#"/tmp/output/runtime_syntax_error.runfiles/_main/mcp/js_fixture/runtime_syntax_error.js:4
+console.log(invoice);
+       ^
+
+SyntaxError: Unexpected token '.'
+    at wrapSafe (node:internal/modules/cjs/loader:1638:18)
+    at Module._compile (node:internal/modules/cjs/loader:1680:20)
+"#,
+            exit_code: Some(1),
+            elapsed_ms: 1,
+            budget: Budget::result_default(),
+        });
+
+        assert_eq!(summary.diagnostics.len(), 1);
+        assert_eq!(
+            summary.diagnostics[0].message,
+            "SyntaxError: Unexpected token '.'"
+        );
+        assert_eq!(
+            summary.diagnostics[0].location,
+            Some(DiagnosticLocation {
+                path: "mcp/js_fixture/runtime_syntax_error.js".into(),
+                line: Some(4),
+                column: None,
+            })
         );
     }
 

--- a/crates/bazel-mcp-reducer/src/lib.rs
+++ b/crates/bazel-mcp-reducer/src/lib.rs
@@ -11,9 +11,9 @@ mod text;
 
 pub use budget::{Budget, Budgeted};
 pub use build::{
-    BepAccumulator, JavaTestDiagnosticParser, PythonDiagnosticParser, ReductionInput,
-    StreamReductionOutput, extract_canonical_arguments, finalize_diagnostics, parse_go_diagnostic,
-    reduce_artifacts, reduce_invocation,
+    BepAccumulator, JavaScriptTestDiagnosticParser, JavaTestDiagnosticParser,
+    PythonDiagnosticParser, ReductionInput, StreamReductionOutput, extract_canonical_arguments,
+    finalize_diagnostics, parse_go_diagnostic, reduce_artifacts, reduce_invocation,
 };
 pub use coverage::{CoverageError, parse_lcov, parse_lcov_reader};
 pub use extension::{

--- a/crates/bazel-mcp-runner/src/service.rs
+++ b/crates/bazel-mcp-runner/src/service.rs
@@ -16,10 +16,11 @@ use bazel_mcp_policy::{
     validate_workspace,
 };
 use bazel_mcp_reducer::{
-    Budget, JavaTestDiagnosticParser, PythonDiagnosticParser, REDUCER_API_VERSION, ReducerContext,
-    ReducerPipeline, StarlarkReducerConfig, StreamReductionOutput, TestFailureAccumulator,
-    TestFailureEvidence, finalize_diagnostics, load_starlark_reducers, normalize_terminal_text,
-    parse_go_diagnostic, parse_lcov_reader, parse_test_xml,
+    Budget, JavaScriptTestDiagnosticParser, JavaTestDiagnosticParser, PythonDiagnosticParser,
+    REDUCER_API_VERSION, ReducerContext, ReducerPipeline, StarlarkReducerConfig,
+    StreamReductionOutput, TestFailureAccumulator, TestFailureEvidence, finalize_diagnostics,
+    load_starlark_reducers, normalize_terminal_text, parse_go_diagnostic, parse_lcov_reader,
+    parse_test_xml,
 };
 use bazel_mcp_store::{InvocationCompletion, InvocationPaths, Store, StoreError};
 use bazel_mcp_types::{
@@ -1909,6 +1910,7 @@ impl InvocationService {
                 let Ok(file) = tokio::fs::File::open(&path).await else {
                     continue;
                 };
+                let mut javascript_parser = JavaScriptTestDiagnosticParser::default();
                 let mut java_parser = JavaTestDiagnosticParser::default();
                 let mut python_parser = PythonDiagnosticParser::default();
                 let marker = format!("\n===== {} :: {} =====\n", test.label, log.name);
@@ -1945,9 +1947,14 @@ impl InvocationService {
                             4 * 1024,
                         );
                         failure_accumulator.observe_line(&text);
+                        let javascript_diagnostic = javascript_parser.observe_line(&text);
                         let java_diagnostic = java_parser.observe_line(&text);
                         let candidate = if let Some(mut diagnostic) = parse_go_diagnostic(&text) {
                             diagnostic.category = DiagnosticCategory::Test;
+                            diagnostic.target = Some(test.label.clone());
+                            diagnostic.message = bounded_text(&diagnostic.message, 1_000);
+                            Some((0, diagnostic))
+                        } else if let Some(mut diagnostic) = javascript_diagnostic {
                             diagnostic.target = Some(test.label.clone());
                             diagnostic.message = bounded_text(&diagnostic.message, 1_000);
                             Some((0, diagnostic))
@@ -2006,16 +2013,21 @@ impl InvocationService {
                         break;
                     }
                 }
-                if complete && let Some(mut diagnostic) = java_parser.finish() {
-                    diagnostic.target = Some(test.label.clone());
-                    diagnostic.message = bounded_text(&diagnostic.message, 1_000);
-                    if fallback_excerpt.as_ref().is_none_or(|(priority, current)| {
-                        *priority > 0
-                            || (*priority == 0
-                                && diagnostic.location.is_some()
-                                && current.location.is_none())
-                    }) {
-                        fallback_excerpt = Some((0, diagnostic));
+                if complete {
+                    for mut diagnostic in [javascript_parser.finish(), java_parser.finish()]
+                        .into_iter()
+                        .flatten()
+                    {
+                        diagnostic.target = Some(test.label.clone());
+                        diagnostic.message = bounded_text(&diagnostic.message, 1_000);
+                        if fallback_excerpt.as_ref().is_none_or(|(priority, current)| {
+                            *priority > 0
+                                || (*priority == 0
+                                    && diagnostic.location.is_some()
+                                    && current.location.is_none())
+                        }) {
+                            fallback_excerpt = Some((0, diagnostic));
+                        }
                     }
                 }
                 if complete {

--- a/crates/bazel-mcp-runner/tests/process.rs
+++ b/crates/bazel-mcp-runner/tests/process.rs
@@ -845,6 +845,77 @@ async fn failed_java_test_logs_promote_the_located_application_frame() {
 }
 
 #[tokio::test]
+async fn failed_javascript_test_logs_promote_the_located_application_frame() {
+    let root = tempfile::tempdir().unwrap();
+    let workspace = root.path().join("workspace");
+    let output_root = root.path().join("output-user-root");
+    let test_directory = output_root.join("execroot/ws/bazel-out/testlogs/pkg/failing");
+    tokio::fs::create_dir_all(&workspace).await.unwrap();
+    tokio::fs::create_dir_all(&test_directory).await.unwrap();
+    let test_log = test_directory.join("test.log");
+    let test_xml = test_directory.join("test.xml");
+    tokio::fs::write(
+        &test_log,
+        r#"/tmp/output/runtime_type_error.runfiles/_main/mcp/js_fixture/runtime_type_error.js:2
+return invoice.lines.reduce((total, line) => total + line.amount, 0);
+               ^
+
+TypeError: Cannot read properties of undefined (reading 'lines')
+    at calculateInvoiceTotal (/tmp/output/runtime_type_error.runfiles/_main/mcp/js_fixture/runtime_type_error.js:2:18)
+    at Object.<anonymous> (/tmp/output/runtime_type_error.runfiles/_main/mcp/js_fixture/runtime_type_error.js:6:1)
+"#,
+    )
+    .await
+    .unwrap();
+    tokio::fs::write(
+        &test_xml,
+        r#"<testsuites><testsuite><testcase name="calculateInvoiceTotal"><failure message="invoice was undefined"/></testcase></testsuite></testsuites>"#,
+    )
+    .await
+    .unwrap();
+    let bep = root.path().join("failed-javascript-test.bep");
+    tokio::fs::write(
+        &bep,
+        failed_test_bep(
+            &format!("file://{}", test_log.display()),
+            &format!("file://{}", test_xml.display()),
+        ),
+    )
+    .await
+    .unwrap();
+    let script = format!(
+        "#!/bin/sh\nif [ \"${{1:-}}\" = --version ]; then echo 'bazel 9.1.0'; exit 0; fi\nfor arg in \"$@\"; do\n  case \"$arg\" in\n    --build_event_binary_file=*) bep_path=${{arg#*=}} ;;\n  esac\ndone\ncp '{}' \"$bep_path\"\nprintf '%s\\n' \"TypeError: Cannot read properties of undefined (reading 'lines')\" '    at calculateInvoiceTotal (/tmp/output/runtime_type_error.runfiles/_main/mcp/js_fixture/runtime_type_error.js:2:18)' >&2\nexit 1\n",
+        bep.display(),
+    );
+    let service = configured_service(&root, &workspace, &script, |_| {}).await;
+
+    let failed = service
+        .run(InvocationRequest::new(
+            workspace,
+            BazelCommand::Test,
+            vec!["//pkg:failing".into()],
+        ))
+        .await
+        .unwrap();
+    let summary = failed.summary.as_ref().unwrap();
+    assert_eq!(summary.inspect_hint.as_deref(), Some("test_log"));
+    let matching = summary
+        .diagnostics
+        .iter()
+        .filter(|diagnostic| diagnostic.message.contains("undefined (reading 'lines')"))
+        .collect::<Vec<_>>();
+    assert_eq!(matching.len(), 1);
+    assert_eq!(matching[0].category, DiagnosticCategory::Test);
+    assert_eq!(matching[0].target.as_deref(), Some("//pkg:failing"));
+    assert_eq!(
+        matching[0].location.as_ref().unwrap().path,
+        "mcp/js_fixture/runtime_type_error.js"
+    );
+    assert_eq!(matching[0].location.as_ref().unwrap().line, Some(2));
+    assert_eq!(matching[0].location.as_ref().unwrap().column, Some(18));
+}
+
+#[tokio::test]
 async fn failed_rust_test_log_promotes_case_and_assertion_to_initial_summary() {
     let root = tempfile::tempdir().unwrap();
     let workspace = root.path().join("workspace");


### PR DESCRIPTION
## Summary

- parse standard and pretty TypeScript compiler diagnostics into structured compilation evidence, preserving TS error codes and source coordinates
- pair Node.js exception messages with bounded source headers and application stack frames
- promote located Node failures from retained `test.log` evidence and deduplicate the unscoped terminal copy
- add reducer and runner regression coverage plus the observed MCP workflow learnings

## Root cause

The generic reducer only recognized diagnostics containing markers such as `error:`. Standard `tsc` output uses `file(line,column): error TS...`, so the actionable compiler error was discarded in favor of Bazel completion wrappers. Node exception names were recognized by the Python fallback, but their preceding source headers and following JavaScript stack frames were not associated with the exception, producing an unlocated compilation diagnostic and often an `INFO: From Testing` headline.

## Impact

TypeScript failures now lead with the exact TS code, message, and editable source location. JavaScript test failures now lead with one test-scoped Node exception and the first application location, while `test_log` remains available for bounded supporting context.

## Validation

- manually replayed three TypeScript compiler failures and two JavaScript runtime failures against `aspect-build/rules_ts` at `69f856d5dab000deed87c6732bfd93b12df0cf76` using Bazel 9.2.0 through the newly built Bazel MCP server
- `make test`
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo shear`
- Bazel MCP `test //...` (30 targets, 13 tests)
- reducer goldens passed unchanged

`make check` reached and passed fmt and clippy locally, then stopped because `nix` was not on this shell's PATH; its final `cargo shear` step was run directly and passed.
