### PR TITLE
fix(reducer): surface C++ root causes

### DIFF
--- a/LEARNINGS.md
+++ b/LEARNINGS.md
@@ -101,3 +101,15 @@ unrelated to MCP efficiency. Do not include secrets or raw sensitive output.
   source headers and application stack frames stayed only in `test.log`; pair
   bounded Node frames and prefer the test-scoped diagnostic. Thread:
   `019f6b89-e945-78a0-9264-a6ad416905a1`.
+- Clang C++ diagnostics were already selected as headlines, but their source
+  coordinates remained embedded in the message; structure common Clang/GCC
+  and MSVC forms so agents can edit the exact location directly. Thread:
+  `019f6b89-e945-78a0-9264-a6ad416905a1`.
+- C++ link failures promoted `clang: linker command failed` while discarding
+  Apple ld's preceding undefined symbol; pair bounded platform-specific linker
+  evidence before ranking wrappers. Thread:
+  `019f6b89-e945-78a0-9264-a6ad416905a1`.
+- Gtest assertion details and C++ exception descriptions remained only in
+  `test.log`, leaving the initial response at the failed target or `unknown
+  file: Failure`; reduce the bounded gtest failure block into one test-scoped
+  diagnostic. Thread: `019f6b89-e945-78a0-9264-a6ad416905a1`.

--- a/crates/bazel-mcp-reducer/src/build.rs
+++ b/crates/bazel-mcp-reducer/src/build.rs
@@ -820,6 +820,12 @@ fn bounded_text(value: &str, maximum_bytes: usize) -> String {
 
 fn add_text_diagnostics(input: &[u8], diagnostics: &mut Vec<Diagnostic>) {
     let normalized = normalize_terminal_text(input);
+    let mut cpp_linker_parser = CppLinkerDiagnosticParser::default();
+    for line in normalized.lines() {
+        if let Some(diagnostic) = cpp_linker_parser.observe_line(line) {
+            diagnostics.push(diagnostic);
+        }
+    }
     diagnostics.extend(parse_java_compiler_diagnostics(&normalized));
     let mut javascript_parser = JavaScriptTestDiagnosticParser::default();
     let mut javascript_test_messages = BTreeSet::new();
@@ -882,6 +888,11 @@ fn add_text_diagnostics(input: &[u8], diagnostics: &mut Vec<Diagnostic>) {
             diagnostics.push(diagnostic);
             continue;
         }
+        if let Some(mut diagnostic) = parse_cpp_diagnostic(&line) {
+            diagnostic.repetition_count = count;
+            diagnostics.push(diagnostic);
+            continue;
+        }
         if let Some(mut diagnostic) = parse_typescript_diagnostic(&line) {
             diagnostic.repetition_count = count;
             diagnostics.push(diagnostic);
@@ -895,6 +906,9 @@ fn add_text_diagnostics(input: &[u8], diagnostics: &mut Vec<Diagnostic>) {
         if let Some(mut diagnostic) = parse_go_diagnostic(&line) {
             diagnostic.repetition_count = count;
             diagnostics.push(diagnostic);
+            continue;
+        }
+        if parse_cpp_linker_diagnostic(&line).is_some() {
             continue;
         }
         if parse_java_compiler_diagnostic(&line).is_some()
@@ -949,6 +963,217 @@ fn add_text_diagnostics(input: &[u8], diagnostics: &mut Vec<Diagnostic>) {
             repetition_count: count,
         });
     }
+}
+
+fn parse_cpp_diagnostic(line: &str) -> Option<Diagnostic> {
+    let line = line
+        .trim()
+        .strip_prefix("ERROR: ")
+        .unwrap_or_else(|| line.trim());
+    let (path, line_number, column, message) =
+        parse_cpp_colon_location(line).or_else(|| parse_cpp_parenthesized_location(line))?;
+    if path.contains(": ") {
+        return None;
+    }
+    let (severity, message) = parse_cpp_severity_message(message)?;
+    Some(Diagnostic {
+        severity,
+        category: DiagnosticCategory::Compilation,
+        message: message.to_owned(),
+        location: Some(DiagnosticLocation {
+            path: compact_cpp_path(path),
+            line: Some(line_number),
+            column,
+        }),
+        target: None,
+        action: None,
+        repetition_count: 1,
+    })
+}
+
+fn parse_cpp_colon_location(line: &str) -> Option<(&str, u32, Option<u32>, &str)> {
+    let path_end = cpp_path_end(line, ':')?;
+    let (line_number, remainder) = split_u32_prefix(&line[path_end + 1..])?;
+    let (column, message) = split_u32_prefix(remainder)
+        .map_or((None, remainder), |(column, message)| {
+            (Some(column), message)
+        });
+    Some((&line[..path_end], line_number, column, message))
+}
+
+fn parse_cpp_parenthesized_location(line: &str) -> Option<(&str, u32, Option<u32>, &str)> {
+    let path_end = cpp_path_end(line, '(')?;
+    let remainder = line[path_end..].strip_prefix('(')?;
+    let (coordinates, message) = remainder
+        .split_once("): ")
+        .or_else(|| remainder.split_once("):"))?;
+    let (line_number, column) = coordinates.split_once(',').map_or_else(
+        || (coordinates.trim().parse::<u32>().ok(), None),
+        |(line_number, column)| {
+            (
+                line_number.trim().parse::<u32>().ok(),
+                column.trim().parse::<u32>().ok(),
+            )
+        },
+    );
+    Some((&line[..path_end], line_number?, column, message))
+}
+
+fn parse_cpp_severity_message(message: &str) -> Option<(Severity, &str)> {
+    let message = message.trim();
+    for (marker, severity) in [
+        ("fatal error", Severity::Error),
+        ("error", Severity::Error),
+        ("warning", Severity::Warning),
+        ("note", Severity::Note),
+    ] {
+        let Some(remainder) = message.strip_prefix(marker) else {
+            continue;
+        };
+        let remainder = remainder
+            .strip_prefix(':')
+            .or_else(|| remainder.strip_prefix(' '))?
+            .trim();
+        if !remainder.is_empty() {
+            return Some((severity, remainder));
+        }
+    }
+    None
+}
+
+fn cpp_path_end(line: &str, delimiter: char) -> Option<usize> {
+    const EXTENSIONS: [&str; 19] = [
+        ".cpp", ".cxx", ".c++", ".cc", ".hpp", ".hxx", ".h++", ".hh", ".ipp", ".tpp", ".inc",
+        ".cuh", ".cu", ".mm", ".m", ".C", ".H", ".c", ".h",
+    ];
+    EXTENSIONS
+        .iter()
+        .filter_map(|extension| {
+            let marker = format!("{extension}{delimiter}");
+            line.rfind(&marker).map(|index| index + extension.len())
+        })
+        .max()
+}
+
+#[derive(Debug, Default)]
+struct CppLinkerDiagnosticParser {
+    apple_undefined_symbols: bool,
+    symbols_seen: usize,
+}
+
+impl CppLinkerDiagnosticParser {
+    const MAX_SYMBOLS: usize = 64;
+
+    fn observe_line(&mut self, line: &str) -> Option<Diagnostic> {
+        let line = line.trim();
+        if line.starts_with("Undefined symbols for architecture ") {
+            self.apple_undefined_symbols = true;
+            return None;
+        }
+        if self.apple_undefined_symbols {
+            if let Some(symbol) = parse_apple_undefined_symbol(line) {
+                if self.symbols_seen >= Self::MAX_SYMBOLS {
+                    return None;
+                }
+                self.symbols_seen = self.symbols_seen.saturating_add(1);
+                return Some(cpp_linker_diagnostic(
+                    format!("undefined symbol: {}", bounded_text(symbol, 1_000)),
+                    None,
+                ));
+            }
+            if line.starts_with("ld:") || line.starts_with("clang:") {
+                self.apple_undefined_symbols = false;
+            }
+        }
+        parse_cpp_linker_diagnostic(line)
+    }
+}
+
+fn parse_apple_undefined_symbol(line: &str) -> Option<&str> {
+    let symbol = line.strip_prefix('"')?;
+    let (symbol, _) = symbol.split_once("\", referenced from:")?;
+    (!symbol.is_empty()).then_some(symbol)
+}
+
+fn parse_cpp_linker_diagnostic(line: &str) -> Option<Diagnostic> {
+    let line = line.trim();
+    if let Some(index) = line.find("undefined reference to ") {
+        let symbol = trim_linker_symbol(&line[index + "undefined reference to ".len()..]);
+        if symbol.is_empty() {
+            return None;
+        }
+        return Some(cpp_linker_diagnostic(
+            format!("undefined reference to {symbol}"),
+            parse_cpp_linker_location(&line[..index]),
+        ));
+    }
+    if let Some(index) = line.find("undefined symbol:") {
+        let symbol = trim_linker_symbol(&line[index + "undefined symbol:".len()..]);
+        if symbol.is_empty() {
+            return None;
+        }
+        return Some(cpp_linker_diagnostic(
+            format!("undefined symbol: {symbol}"),
+            None,
+        ));
+    }
+    if let Some(index) = line.find("unresolved external symbol ") {
+        let remainder = &line[index + "unresolved external symbol ".len()..];
+        let symbol = remainder
+            .split_once(" referenced in ")
+            .map_or(remainder, |(symbol, _)| symbol)
+            .trim();
+        if symbol.is_empty() {
+            return None;
+        }
+        return Some(cpp_linker_diagnostic(
+            format!("unresolved external symbol {symbol}"),
+            None,
+        ));
+    }
+    None
+}
+
+fn parse_cpp_linker_location(prefix: &str) -> Option<DiagnosticLocation> {
+    let path_end = cpp_path_end(prefix, ':')?;
+    let (line_number, _) = split_u32_prefix(&prefix[path_end + 1..])?;
+    let path = prefix[..path_end]
+        .rsplit_once(": ")
+        .map_or(&prefix[..path_end], |(_, path)| path);
+    Some(DiagnosticLocation {
+        path: compact_cpp_path(path),
+        line: Some(line_number),
+        column: None,
+    })
+}
+
+fn trim_linker_symbol(symbol: &str) -> &str {
+    symbol
+        .trim()
+        .trim_end_matches(':')
+        .trim_matches(|character| matches!(character, '`' | '\'' | '"'))
+}
+
+fn cpp_linker_diagnostic(message: String, location: Option<DiagnosticLocation>) -> Diagnostic {
+    Diagnostic {
+        severity: Severity::Error,
+        category: DiagnosticCategory::Compilation,
+        message,
+        location,
+        target: None,
+        action: None,
+        repetition_count: 1,
+    }
+}
+
+fn compact_cpp_path(path: &str) -> String {
+    let path = path.trim_matches('"').replace('\\', "/");
+    if let Some((_, after_execroot)) = path.rsplit_once("/execroot/")
+        && let Some((_, relative)) = after_execroot.split_once('/')
+    {
+        return relative.to_owned();
+    }
+    path.strip_prefix("./").unwrap_or(&path).to_owned()
 }
 
 fn parse_typescript_diagnostic(line: &str) -> Option<Diagnostic> {
@@ -2114,6 +2339,113 @@ ERROR: Build did NOT complete successfully
                 .map(|location| location.path.as_str())
                 .collect::<Vec<_>>(),
             vec!["first.go", "second.go"]
+        );
+    }
+
+    #[test]
+    fn structures_clang_cpp_diagnostics_with_source_coordinates() {
+        let summary = reduce_invocation(ReductionInput {
+            events: &[],
+            stdout: b"",
+            stderr: b"mcp/cpp_fixture/type_mismatch.cc:5:7: error: no viable conversion from 'std::string' to 'int'\nERROR: Build did NOT complete successfully\n",
+            exit_code: Some(1),
+            elapsed_ms: 1,
+            budget: Budget::result_default(),
+        });
+
+        let diagnostic = &summary.diagnostics[0];
+        assert_eq!(
+            diagnostic.message,
+            "no viable conversion from 'std::string' to 'int'"
+        );
+        assert_eq!(diagnostic.category, DiagnosticCategory::Compilation);
+        assert_eq!(
+            diagnostic.location,
+            Some(DiagnosticLocation {
+                path: "mcp/cpp_fixture/type_mismatch.cc".into(),
+                line: Some(5),
+                column: Some(7),
+            })
+        );
+        assert!(summary.headline.contains("no viable conversion"));
+    }
+
+    #[test]
+    fn structures_msvc_cpp_diagnostics_and_preserves_error_codes() {
+        let diagnostic = parse_cpp_diagnostic(
+            r"C:\workspace\mcp\cpp_fixture\type_mismatch.cpp(12,7): error C2440: 'initializing': cannot convert from 'std::string' to 'int'",
+        )
+        .unwrap();
+
+        assert_eq!(diagnostic.severity, Severity::Error);
+        assert_eq!(
+            diagnostic.message,
+            "C2440: 'initializing': cannot convert from 'std::string' to 'int'"
+        );
+        assert_eq!(
+            diagnostic.location,
+            Some(DiagnosticLocation {
+                path: "C:/workspace/mcp/cpp_fixture/type_mismatch.cpp".into(),
+                line: Some(12),
+                column: Some(7),
+            })
+        );
+    }
+
+    #[test]
+    fn ranks_apple_undefined_symbols_ahead_of_linker_wrappers() {
+        let summary = reduce_invocation(ReductionInput {
+            events: &[],
+            stdout: b"",
+            stderr: br#"Undefined symbols for architecture arm64:
+  "calculate_invoice_total(int)", referenced from:
+      _main in undefined_reference.o
+ld: symbol(s) not found for architecture arm64
+clang: error: linker command failed with exit code 1 (use -v to see invocation)
+"#,
+            exit_code: Some(1),
+            elapsed_ms: 1,
+            budget: Budget::result_default(),
+        });
+
+        assert_eq!(
+            summary.diagnostics[0].message,
+            "undefined symbol: calculate_invoice_total(int)"
+        );
+        assert!(summary.headline.contains("calculate_invoice_total"));
+    }
+
+    #[test]
+    fn parses_gnu_undefined_references_with_source_locations() {
+        let diagnostic = parse_cpp_linker_diagnostic(
+            "/usr/bin/ld: object.o: /tmp/output/execroot/_main/mcp/cpp_fixture/undefined_reference.cc:3: undefined reference to `calculate_invoice_total(int)'",
+        )
+        .unwrap();
+
+        assert_eq!(
+            diagnostic.message,
+            "undefined reference to calculate_invoice_total(int)"
+        );
+        assert_eq!(
+            diagnostic.location,
+            Some(DiagnosticLocation {
+                path: "mcp/cpp_fixture/undefined_reference.cc".into(),
+                line: Some(3),
+                column: None,
+            })
+        );
+    }
+
+    #[test]
+    fn parses_msvc_unresolved_external_symbols() {
+        let diagnostic = parse_cpp_linker_diagnostic(
+            r#"undefined_reference.obj : error LNK2019: unresolved external symbol "int __cdecl calculate_invoice_total(int)" referenced in function main"#,
+        )
+        .unwrap();
+
+        assert_eq!(
+            diagnostic.message,
+            r#"unresolved external symbol "int __cdecl calculate_invoice_total(int)""#
         );
     }
 

--- a/crates/bazel-mcp-reducer/src/test.rs
+++ b/crates/bazel-mcp-reducer/src/test.rs
@@ -13,6 +13,7 @@ const MAX_LOG_FAILURES: usize = 20;
 const MAX_TEST_NAME_BYTES: usize = 512;
 const MAX_FAILURE_MESSAGE_BYTES: usize = 1_000;
 const MAX_FAILURE_DETAIL_BYTES: usize = 256;
+const MAX_GTEST_DETAILS: usize = 8;
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct TestFailureEvidence {
@@ -31,6 +32,8 @@ pub struct TestFailureAccumulator {
     failed_names: Vec<String>,
     failures: Vec<TestFailureEvidence>,
     current: Option<RustFailureBlock>,
+    gtest_running_name: Option<String>,
+    gtest_current: Option<GtestFailureBlock>,
 }
 
 #[derive(Default)]
@@ -43,10 +46,57 @@ struct RustFailureBlock {
     saw_panic: bool,
 }
 
+#[derive(Default)]
+struct GtestFailureBlock {
+    name: String,
+    location: Option<DiagnosticLocation>,
+    details: Vec<String>,
+}
+
 impl TestFailureAccumulator {
     pub fn observe_line(&mut self, line: &str) {
         let line = line.trim();
         if line.is_empty() {
+            return;
+        }
+
+        if let Some(name) = gtest_running_name(line) {
+            self.finish_gtest_current();
+            self.gtest_running_name = Some(bounded_text(name, MAX_TEST_NAME_BYTES));
+            return;
+        }
+
+        if let Some(location) = gtest_failure_location(line) {
+            self.finish_gtest_current();
+            self.gtest_current = Some(GtestFailureBlock {
+                name: self
+                    .gtest_running_name
+                    .clone()
+                    .unwrap_or_else(|| "<unknown gtest>".to_owned()),
+                location,
+                ..GtestFailureBlock::default()
+            });
+            return;
+        }
+
+        if let Some(name) = gtest_failed_name(line) {
+            if self
+                .gtest_running_name
+                .as_deref()
+                .is_some_and(|running| running == name)
+            {
+                self.finish_gtest_current();
+                self.gtest_running_name = None;
+            }
+            return;
+        }
+
+        if let Some(current) = self.gtest_current.as_mut() {
+            if current.details.len() < MAX_GTEST_DETAILS && !is_gtest_framework_status(line) {
+                current
+                    .details
+                    .push(bounded_text(line, MAX_FAILURE_DETAIL_BYTES));
+            }
             return;
         }
 
@@ -113,6 +163,7 @@ impl TestFailureAccumulator {
     #[must_use]
     pub fn finish(mut self) -> Vec<TestFailureEvidence> {
         self.finish_current();
+        self.finish_gtest_current();
         for name in self.failed_names {
             if self.failures.len() >= MAX_LOG_FAILURES {
                 break;
@@ -156,6 +207,34 @@ impl TestFailureAccumulator {
         for detail in current.details {
             message.push_str("; ");
             message.push_str(&detail);
+        }
+        self.failures.push(TestFailureEvidence {
+            name: current.name,
+            message: bounded_text(&message, MAX_FAILURE_MESSAGE_BYTES),
+            location: current.location,
+        });
+    }
+
+    fn finish_gtest_current(&mut self) {
+        let Some(current) = self.gtest_current.take() else {
+            return;
+        };
+        if current.name.is_empty() || self.failures.len() >= MAX_LOG_FAILURES {
+            return;
+        }
+        let mut message = format!("C++ test {} failed", current.name);
+        if !current.details.is_empty() {
+            message.push_str(": ");
+            for (index, detail) in current.details.iter().enumerate() {
+                if index > 0 {
+                    if message.ends_with(':') {
+                        message.push(' ');
+                    } else {
+                        message.push_str("; ");
+                    }
+                }
+                message.push_str(detail);
+            }
         }
         self.failures.push(TestFailureEvidence {
             name: current.name,
@@ -238,6 +317,64 @@ fn rust_failed_status_name(line: &str) -> Option<&str> {
     line.strip_prefix("test ")?
         .strip_suffix(" ... FAILED")
         .filter(|name| !name.is_empty())
+}
+
+fn gtest_running_name(line: &str) -> Option<&str> {
+    line.strip_prefix("[ RUN      ] ")
+        .filter(|name| !name.is_empty())
+}
+
+fn gtest_failed_name(line: &str) -> Option<&str> {
+    let name = line.strip_prefix("[  FAILED  ] ")?;
+    let name = name.rsplit_once(" (").map_or(name, |(name, duration)| {
+        duration
+            .strip_suffix(')')
+            .filter(|duration| duration.ends_with(" ms"))
+            .map_or(name, |_| name)
+    });
+    (!name.is_empty()).then_some(name)
+}
+
+fn gtest_failure_location(line: &str) -> Option<Option<DiagnosticLocation>> {
+    let location = line.strip_suffix(": Failure")?;
+    if location == "unknown file" {
+        return Some(None);
+    }
+    let (path, line_number) = location.rsplit_once(':')?;
+    let line_number = line_number.parse::<u32>().ok()?;
+    (!path.is_empty()).then(|| {
+        Some(DiagnosticLocation {
+            path: compact_test_path(path),
+            line: Some(line_number),
+            column: None,
+        })
+    })
+}
+
+fn compact_test_path(path: &str) -> String {
+    let path = path.trim_matches('"').replace('\\', "/");
+    for marker in [".runfiles/_main/", ".runfiles/__main__/"] {
+        if let Some((_, relative)) = path.rsplit_once(marker) {
+            return relative.to_owned();
+        }
+    }
+    if let Some((_, after_execroot)) = path.rsplit_once("/execroot/")
+        && let Some((_, relative)) = after_execroot.split_once('/')
+    {
+        return relative.to_owned();
+    }
+    path.strip_prefix("./").unwrap_or(&path).to_owned()
+}
+
+fn is_gtest_framework_status(line: &str) -> bool {
+    [
+        "[==========]",
+        "[----------]",
+        "[  PASSED  ]",
+        "[  SKIPPED ]",
+    ]
+    .iter()
+    .any(|prefix| line.starts_with(prefix))
 }
 
 fn rust_failure_block_name(line: &str) -> Option<&str> {
@@ -406,5 +543,64 @@ mod tests {
             failures[0].message,
             "Rust test tests::failed_without_output failed"
         );
+    }
+
+    #[test]
+    fn extracts_gtest_assertion_details_and_locations() {
+        let mut accumulator = TestFailureAccumulator::default();
+        for line in [
+            "[ RUN      ] InvoiceTest.IncludesServiceFee",
+            "mcp/cpp_fixture/assertion_failure_test.cc:8: Failure",
+            "Expected equality of these values:",
+            "CalculateInvoiceTotal(40, 2)",
+            "Which is: 42",
+            "41",
+            "invoice total should include the service fee",
+            "[  FAILED  ] InvoiceTest.IncludesServiceFee (0 ms)",
+        ] {
+            accumulator.observe_line(line);
+        }
+
+        let failures = accumulator.finish();
+        assert_eq!(failures.len(), 1);
+        assert_eq!(failures[0].name, "InvoiceTest.IncludesServiceFee");
+        assert!(failures[0].message.contains("Which is: 42"));
+        assert!(
+            failures[0]
+                .message
+                .contains("invoice total should include the service fee")
+        );
+        assert_eq!(
+            failures[0].location,
+            Some(DiagnosticLocation {
+                path: "mcp/cpp_fixture/assertion_failure_test.cc".into(),
+                line: Some(8),
+                column: None,
+            })
+        );
+    }
+
+    #[test]
+    fn extracts_gtest_cpp_exceptions_without_unknown_file_noise() {
+        let mut accumulator = TestFailureAccumulator::default();
+        for line in [
+            "[ RUN      ] InvoiceTest.RejectsMissingCurrency",
+            "unknown file: Failure",
+            "C++ exception with description \"invoice currency was not configured\" thrown in the test body.",
+            "[  FAILED  ] InvoiceTest.RejectsMissingCurrency (0 ms)",
+        ] {
+            accumulator.observe_line(line);
+        }
+
+        let failures = accumulator.finish();
+        assert_eq!(failures.len(), 1);
+        assert_eq!(failures[0].name, "InvoiceTest.RejectsMissingCurrency");
+        assert!(
+            failures[0]
+                .message
+                .contains("invoice currency was not configured")
+        );
+        assert_eq!(failures[0].location, None);
+        assert!(!failures[0].message.contains("unknown file"));
     }
 }

--- a/crates/bazel-mcp-reducer/tests/fixtures/bazel-8/keep-going-actions.expected.json
+++ b/crates/bazel-mcp-reducer/tests/fixtures/bazel-8/keep-going-actions.expected.json
@@ -3,7 +3,7 @@
   "terminal_error": null,
   "summary": {
     "success": false,
-    "headline": "Bazel failed: fixture.cc:7: error: BAZEL_MCP_CPP_ROOT_CAUSE",
+    "headline": "Bazel failed: BAZEL_MCP_CPP_ROOT_CAUSE",
     "targets": [
       {
         "label": "//:compile_failure",
@@ -27,8 +27,12 @@
       {
         "severity": "error",
         "category": "compilation",
-        "message": "fixture.cc:7: error: BAZEL_MCP_CPP_ROOT_CAUSE",
-        "location": null,
+        "message": "BAZEL_MCP_CPP_ROOT_CAUSE",
+        "location": {
+          "path": "fixture.cc",
+          "line": 7,
+          "column": null
+        },
         "target": null,
         "action": null,
         "repetition_count": 1

--- a/crates/bazel-mcp-reducer/tests/fixtures/bazel-9/keep-going-actions.expected.json
+++ b/crates/bazel-mcp-reducer/tests/fixtures/bazel-9/keep-going-actions.expected.json
@@ -3,7 +3,7 @@
   "terminal_error": null,
   "summary": {
     "success": false,
-    "headline": "Bazel failed: fixture.cc:7: error: BAZEL_MCP_CPP_ROOT_CAUSE",
+    "headline": "Bazel failed: BAZEL_MCP_CPP_ROOT_CAUSE",
     "targets": [
       {
         "label": "//:compile_failure",
@@ -27,8 +27,12 @@
       {
         "severity": "error",
         "category": "compilation",
-        "message": "fixture.cc:7: error: BAZEL_MCP_CPP_ROOT_CAUSE",
-        "location": null,
+        "message": "BAZEL_MCP_CPP_ROOT_CAUSE",
+        "location": {
+          "path": "fixture.cc",
+          "line": 7,
+          "column": null
+        },
         "target": null,
         "action": null,
         "repetition_count": 1

--- a/crates/bazel-mcp-runner/tests/process.rs
+++ b/crates/bazel-mcp-runner/tests/process.rs
@@ -916,6 +916,82 @@ TypeError: Cannot read properties of undefined (reading 'lines')
 }
 
 #[tokio::test]
+async fn failed_gtest_logs_promote_the_located_assertion_block() {
+    let root = tempfile::tempdir().unwrap();
+    let workspace = root.path().join("workspace");
+    let output_root = root.path().join("output-user-root");
+    let test_directory = output_root.join("execroot/ws/bazel-out/testlogs/pkg/failing");
+    tokio::fs::create_dir_all(&workspace).await.unwrap();
+    tokio::fs::create_dir_all(&test_directory).await.unwrap();
+    let test_log = test_directory.join("test.log");
+    let test_xml = test_directory.join("test.xml");
+    tokio::fs::write(
+        &test_log,
+        r#"[ RUN      ] InvoiceTest.IncludesServiceFee
+mcp/cpp_fixture/assertion_failure_test.cc:8: Failure
+Expected equality of these values:
+CalculateInvoiceTotal(40, 2)
+Which is: 42
+41
+invoice total should include the service fee
+[  FAILED  ] InvoiceTest.IncludesServiceFee (0 ms)
+"#,
+    )
+    .await
+    .unwrap();
+    tokio::fs::write(
+        &test_xml,
+        r#"<testsuites><testsuite><testcase name="IncludesServiceFee"><failure message="exited with error code 1"/></testcase></testsuite></testsuites>"#,
+    )
+    .await
+    .unwrap();
+    let bep = root.path().join("failed-gtest.bep");
+    tokio::fs::write(
+        &bep,
+        failed_test_bep(
+            &format!("file://{}", test_log.display()),
+            &format!("file://{}", test_xml.display()),
+        ),
+    )
+    .await
+    .unwrap();
+    let script = format!(
+        "#!/bin/sh\nif [ \"${{1:-}}\" = --version ]; then echo 'bazel 9.1.0'; exit 0; fi\nfor arg in \"$@\"; do\n  case \"$arg\" in\n    --build_event_binary_file=*) bep_path=${{arg#*=}} ;;\n  esac\ndone\ncp '{}' \"$bep_path\"\necho 'test execution failed' >&2\nexit 1\n",
+        bep.display(),
+    );
+    let service = configured_service(&root, &workspace, &script, |_| {}).await;
+
+    let failed = service
+        .run(InvocationRequest::new(
+            workspace,
+            BazelCommand::Test,
+            vec!["//pkg:failing".into()],
+        ))
+        .await
+        .unwrap();
+    let summary = failed.summary.as_ref().unwrap();
+    assert_eq!(summary.inspect_hint.as_deref(), Some("test_log"));
+    let matching = summary
+        .diagnostics
+        .iter()
+        .filter(|diagnostic| {
+            diagnostic
+                .message
+                .contains("invoice total should include the service fee")
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(matching.len(), 1);
+    assert_eq!(matching[0].category, DiagnosticCategory::Test);
+    assert_eq!(matching[0].target.as_deref(), Some("//pkg:failing"));
+    assert_eq!(
+        matching[0].location.as_ref().unwrap().path,
+        "mcp/cpp_fixture/assertion_failure_test.cc"
+    );
+    assert_eq!(matching[0].location.as_ref().unwrap().line, Some(8));
+    assert!(summary.headline.contains("InvoiceTest.IncludesServiceFee"));
+}
+
+#[tokio::test]
 async fn failed_rust_test_log_promotes_case_and_assertion_to_initial_summary() {
     let root = tempfile::tempdir().unwrap();
     let workspace = root.path().join("workspace");


### PR DESCRIPTION
## Summary

- structure common Clang, GCC, and MSVC compiler diagnostics with source locations
- promote Apple ld, GNU ld/lld, and MSVC undefined-symbol evidence ahead of generic linker wrappers
- reduce bounded gTest assertion and exception blocks into named, test-scoped diagnostics
- update Bazel 8 and Bazel 9 goldens and record the observed MCP workflow gaps

## Root cause

C++ compiler coordinates were retained inside unstructured messages, generic linker exit wrappers outranked the missing symbol that caused the failure, and gTest assertion or exception details remained only in `test.log`. Agents therefore needed extra inspection calls before they could identify the file, symbol, or failing test.

## Impact

Initial Bazel MCP responses now identify actionable C++ compiler locations, undefined symbols, and gTest failures while retaining bounded deterministic output.

## Validation

- live Bazel MCP replay against `google/googletest` commit `a25f43576effe4ebe887412a603cddfa8fc3ba64`
  - compiler type mismatch
  - missing header
  - undefined reference
  - gTest assertion failure
  - gTest runtime exception
- `make test`
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo shear`
- Bazel MCP reducer unit and golden targets
- Bazel MCP filtered C++ runner integration target
- `git diff --check`
