### PR TITLE
refactor(runner): unify BEP capture pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -389,6 +389,9 @@ remote BES and BuildBuddy configurations keep working. Set
 `bep_transport = "fifo"` for the measured POSIX named-pipe optimization (with
 automatic file-tail fallback on Windows or setup failure), or
 `bep_transport = "bes"` to use bazel-mcp's loopback gRPC Build Event Service.
+All three modes feed one ordered capture pipeline: raw frames are committed or
+verified in the private evidence file before reduction observes them, and only
+redacted projections may reach metadata, telemetry, or model-visible output.
 See [BEP transport performance](docs/bep-transport-performance.md) for the
 design tradeoffs, measured results, and reproduction commands.
 

--- a/crates/bazel-mcp-benchmark/src/bin/bes-transport-benchmark.rs
+++ b/crates/bazel-mcp-benchmark/src/bin/bes-transport-benchmark.rs
@@ -1,5 +1,6 @@
 use std::{
     fs::File,
+    io::Write,
     path::{Path, PathBuf},
     time::{Duration, Instant},
 };
@@ -211,7 +212,39 @@ async fn run_bes(
     invocation_id: &str,
 ) -> Result<Duration> {
     let start = Instant::now();
-    let capture = server.register(invocation_id, path)?;
+    let mut capture = server.register(invocation_id)?;
+    let mut captured_events = capture.take_events()?;
+    let sink_path = path.to_owned();
+    let sink = tokio::task::spawn_blocking(move || -> Result<()> {
+        let mut file = std::fs::OpenOptions::new()
+            .create(true)
+            .truncate(true)
+            .write(true)
+            .open(&sink_path)?;
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            file.set_permissions(std::fs::Permissions::from_mode(0o600))?;
+        }
+        while let Some(event) = captured_events.blocking_recv() {
+            if event.is_finished() {
+                let result = file.flush().context("flush BES benchmark evidence");
+                event.acknowledge(result.as_ref().map(|_| ()).map_err(ToString::to_string));
+                return result;
+            }
+            let result = event
+                .framed_events()
+                .unwrap()
+                .iter()
+                .try_for_each(|framed| {
+                    file.write_all(framed)
+                        .context("write BES benchmark evidence")
+                });
+            event.acknowledge(result.as_ref().map(|_| ()).map_err(ToString::to_string));
+            result?;
+        }
+        Ok(())
+    });
     let stream_id = StreamId {
         build_id: format!("build-{invocation_id}"),
         invocation_id: invocation_id.to_owned(),
@@ -260,6 +293,7 @@ async fn run_bes(
         "BES acknowledged {acknowledged} of {expected_acknowledgements} requests"
     );
     let stats = capture.finish(Duration::from_secs(30)).await?;
+    sink.await??;
     ensure!(
         stats.event_count == frames.len() * repetitions,
         "BES retained {} of {} events",

--- a/crates/bazel-mcp-bes/src/lib.rs
+++ b/crates/bazel-mcp-bes/src/lib.rs
@@ -10,4 +10,4 @@ pub mod proto {
     buffa::include_proto!("google.devtools.build.v1");
 }
 
-pub use server::{BesCapture, BesError, BesServer, CaptureStats};
+pub use server::{BesCapture, BesError, BesServer, BesStreamEvent, CaptureStats};

--- a/crates/bazel-mcp-bes/src/server.rs
+++ b/crates/bazel-mcp-bes/src/server.rs
@@ -3,7 +3,6 @@ use std::{
     convert::Infallible,
     io,
     net::{IpAddr, Ipv4Addr, SocketAddr},
-    path::{Path, PathBuf},
     sync::{
         Arc, Mutex,
         atomic::{AtomicBool, Ordering},
@@ -14,7 +13,7 @@ use std::{
 use bazel_mcp_bep::{DEFAULT_MAX_FRAME_BYTES, DEFAULT_MAX_STREAM_BYTES, DEFAULT_MAX_STREAM_EVENTS};
 use buffa::MessageField;
 use thiserror::Error;
-use tokio::{fs::OpenOptions, io::AsyncWriteExt, sync::watch};
+use tokio::sync::{mpsc, oneshot, watch};
 use tokio_stream::wrappers::{ReceiverStream, TcpListenerStream};
 use tokio_util::sync::CancellationToken;
 use tonic::{
@@ -41,6 +40,9 @@ const BAZEL_EVENT_TYPE_SUFFIX: &str = "/build_event_stream.BuildEvent";
 const MAX_GRPC_REQUEST_BYTES: usize = DEFAULT_MAX_FRAME_BYTES + 64 * 1024;
 const MAX_STREAM_ID_FIELD_BYTES: usize = 128;
 const MAX_TYPE_URL_BYTES: usize = 256;
+const CAPTURE_CHANNEL_CAPACITY: usize = 2;
+const CAPTURE_BATCH_MAX_EVENTS: usize = 64;
+const CAPTURE_BATCH_MAX_BYTES: usize = 1024 * 1024;
 
 type CaptureResult = Result<CaptureStats, String>;
 
@@ -64,10 +66,12 @@ pub enum BesError {
     CaptureTimeout,
     #[error("BES capture ended without a completion result")]
     CaptureClosed,
+    #[error("BES capture event stream was already taken")]
+    EventStreamTaken,
 }
 
 struct CaptureState {
-    path: PathBuf,
+    events: mpsc::Sender<BesStreamEvent>,
     active: AtomicBool,
     completion: watch::Sender<Option<CaptureResult>>,
 }
@@ -132,15 +136,12 @@ impl BesServer {
         &self.inner.endpoint
     }
 
-    pub fn register(
-        &self,
-        invocation_id: impl Into<String>,
-        path: impl Into<PathBuf>,
-    ) -> Result<BesCapture, BesError> {
+    pub fn register(&self, invocation_id: impl Into<String>) -> Result<BesCapture, BesError> {
         let invocation_id = invocation_id.into();
         let (completion, receiver) = watch::channel(None);
+        let (events, event_stream) = mpsc::channel(CAPTURE_CHANNEL_CAPACITY);
         let state = Arc::new(CaptureState {
-            path: path.into(),
+            events,
             active: AtomicBool::new(false),
             completion,
         });
@@ -162,7 +163,42 @@ impl BesServer {
             captures: self.inner.captures.clone(),
             state,
             completion: receiver,
+            events: Some(event_stream),
         })
+    }
+}
+
+/// One ordered item accepted from Bazel's build-tool event stream.
+///
+/// The receiver must acknowledge each item after its local durability gate has
+/// accepted it. The gRPC service does not acknowledge the corresponding Bazel
+/// request before that acknowledgement arrives.
+pub struct BesStreamEvent {
+    kind: BesStreamEventKind,
+    acknowledgement: oneshot::Sender<Result<(), String>>,
+}
+
+enum BesStreamEventKind {
+    Frames(Vec<Vec<u8>>),
+    Finished,
+}
+
+impl BesStreamEvent {
+    #[must_use]
+    pub fn framed_events(&self) -> Option<&[Vec<u8>]> {
+        match &self.kind {
+            BesStreamEventKind::Frames(events) => Some(events),
+            BesStreamEventKind::Finished => None,
+        }
+    }
+
+    #[must_use]
+    pub fn is_finished(&self) -> bool {
+        matches!(self.kind, BesStreamEventKind::Finished)
+    }
+
+    pub fn acknowledge(self, result: Result<(), String>) {
+        let _ = self.acknowledgement.send(result);
     }
 }
 
@@ -171,9 +207,14 @@ pub struct BesCapture {
     captures: Captures,
     state: Arc<CaptureState>,
     completion: watch::Receiver<Option<CaptureResult>>,
+    events: Option<mpsc::Receiver<BesStreamEvent>>,
 }
 
 impl BesCapture {
+    pub fn take_events(&mut self) -> Result<mpsc::Receiver<BesStreamEvent>, BesError> {
+        self.events.take().ok_or(BesError::EventStreamTaken)
+    }
+
     pub async fn finish(mut self, timeout: Duration) -> Result<CaptureStats, BesError> {
         let result = tokio::time::timeout(timeout, async {
             loop {
@@ -340,7 +381,7 @@ async fn ingest_stream(
         send_status(&responses, Status::already_exists(message)).await;
         return;
     }
-    let result = capture_stream(&state.path, first, &mut input, &responses).await;
+    let result = capture_stream(&state.events, first, &mut input, &responses).await;
     if let Err(error) = &result {
         let _ = responses.send(Err(Status::internal(error.clone()))).await;
     }
@@ -348,23 +389,11 @@ async fn ingest_stream(
 }
 
 async fn capture_stream(
-    path: &Path,
+    capture_events: &mpsc::Sender<BesStreamEvent>,
     first: PublishBuildToolEventStreamRequestOwnedView,
     input: &mut Streaming<PublishBuildToolEventStreamRequestOwnedView>,
     responses: &tokio::sync::mpsc::Sender<Result<PublishBuildToolEventStreamResponse, Status>>,
 ) -> CaptureResult {
-    let file = OpenOptions::new()
-        .create(true)
-        .truncate(true)
-        .write(true)
-        .open(path)
-        .await
-        .map_err(|error| format!("open {}: {error}", path.display()))?;
-    #[cfg(unix)]
-    file.set_permissions(std::os::unix::fs::PermissionsExt::from_mode(0o600))
-        .await
-        .map_err(|error| format!("set permissions on {}: {error}", path.display()))?;
-    let mut writer = file;
     let first_ordered = ordered_event(&first).map_err(|status| status.message().to_owned())?;
     let first_stream_id = first_ordered
         .stream_id
@@ -374,13 +403,34 @@ async fn capture_stream(
     let mut expected_sequence = 1_i64;
     let mut request_count = 0_usize;
     let mut stats = CaptureStats::default();
-    let mut framed_event = Vec::new();
     let mut saw_finished = false;
     let mut current = Some(first);
+    let mut pending_frames = Vec::with_capacity(CAPTURE_BATCH_MAX_EVENTS);
+    let mut pending_responses = Vec::with_capacity(CAPTURE_BATCH_MAX_EVENTS);
+    let mut pending_batch_bytes = 0_usize;
 
     loop {
         let request = if let Some(request) = current.take() {
             request
+        } else if !pending_frames.is_empty() {
+            tokio::select! {
+                biased;
+                request = input.message() => match request {
+                    Ok(Some(request)) => request,
+                    Ok(None) => break,
+                    Err(status) => return Err(format!("receive BES request: {status}")),
+                },
+                () = tokio::task::yield_now() => {
+                    flush_capture_batch(
+                        capture_events,
+                        responses,
+                        &mut pending_frames,
+                        &mut pending_responses,
+                    ).await?;
+                    pending_batch_bytes = 0;
+                    continue;
+                }
+            }
         } else {
             match input.message().await {
                 Ok(Some(request)) => request,
@@ -414,6 +464,10 @@ async fn capture_stream(
         if saw_finished {
             return Err("BES request followed BuildComponentStreamFinished".to_owned());
         }
+        let response = PublishBuildToolEventStreamResponse {
+            stream_id: MessageField::some(identity.to_owned()),
+            sequence_number: ordered.sequence_number,
+        };
         match event.event.as_ref() {
             Some(EventView::BazelEvent(any)) => {
                 if any.type_url.len() > MAX_TYPE_URL_BYTES
@@ -422,7 +476,24 @@ async fn capture_stream(
                 {
                     return Err("unexpected BES Any type URL".to_owned());
                 }
-                write_bep_frame(&mut writer, any.value, &mut framed_event, &mut stats).await?;
+                let framed = frame_bep_payload(any.value, &stats)?;
+                pending_batch_bytes = pending_batch_bytes.saturating_add(framed.len());
+                pending_frames.push(framed);
+                pending_responses.push(response);
+                stats.event_count = stats.event_count.saturating_add(1);
+                stats.bep_bytes = stats.bep_bytes.saturating_add(any.value.len());
+                if pending_frames.len() >= CAPTURE_BATCH_MAX_EVENTS
+                    || pending_batch_bytes >= CAPTURE_BATCH_MAX_BYTES
+                {
+                    flush_capture_batch(
+                        capture_events,
+                        responses,
+                        &mut pending_frames,
+                        &mut pending_responses,
+                    )
+                    .await?;
+                    pending_batch_bytes = 0;
+                }
             }
             Some(EventView::ComponentStreamFinished(finished)) => {
                 if finished.r#type != 1 {
@@ -431,26 +502,47 @@ async fn capture_stream(
                         finished.r#type
                     ));
                 }
+                flush_capture_batch(
+                    capture_events,
+                    responses,
+                    &mut pending_frames,
+                    &mut pending_responses,
+                )
+                .await?;
+                pending_batch_bytes = 0;
+                forward_capture_event(capture_events, BesStreamEventKind::Finished).await?;
+                responses
+                    .send(Ok(response))
+                    .await
+                    .map_err(|_| "BES client stopped accepting acknowledgements".to_owned())?;
                 saw_finished = true;
             }
-            None => {}
+            None => {
+                flush_capture_batch(
+                    capture_events,
+                    responses,
+                    &mut pending_frames,
+                    &mut pending_responses,
+                )
+                .await?;
+                pending_batch_bytes = 0;
+                responses
+                    .send(Ok(response))
+                    .await
+                    .map_err(|_| "BES client stopped accepting acknowledgements".to_owned())?;
+            }
         }
-        let response = PublishBuildToolEventStreamResponse {
-            stream_id: MessageField::some(identity.to_owned()),
-            sequence_number: ordered.sequence_number,
-        };
-        responses
-            .send(Ok(response))
-            .await
-            .map_err(|_| "BES client stopped accepting acknowledgements".to_owned())?;
         expected_sequence = expected_sequence
             .checked_add(1)
             .ok_or_else(|| "BES sequence number overflow".to_owned())?;
     }
-    writer
-        .flush()
-        .await
-        .map_err(|error| format!("flush {}: {error}", path.display()))?;
+    flush_capture_batch(
+        capture_events,
+        responses,
+        &mut pending_frames,
+        &mut pending_responses,
+    )
+    .await?;
     if !saw_finished {
         return Err("BES stream ended without BuildComponentStreamFinished".to_owned());
     }
@@ -514,12 +606,7 @@ fn complete(state: &CaptureState, result: CaptureResult) {
     state.completion.send_replace(Some(result));
 }
 
-async fn write_bep_frame(
-    writer: &mut tokio::fs::File,
-    frame: &[u8],
-    framed_event: &mut Vec<u8>,
-    stats: &mut CaptureStats,
-) -> Result<(), String> {
+fn frame_bep_payload(frame: &[u8], stats: &CaptureStats) -> Result<Vec<u8>, String> {
     if frame.len() > DEFAULT_MAX_FRAME_BYTES {
         return Err(format!(
             "BES frame length {} exceeds limit {}",
@@ -540,16 +627,47 @@ async fn write_bep_frame(
     }
     let mut prefix = [0_u8; 10];
     let prefix_len = encode_varint(frame.len() as u64, &mut prefix);
-    framed_event.clear();
-    framed_event.reserve(prefix_len + frame.len());
+    let mut framed_event = Vec::with_capacity(prefix_len + frame.len());
     framed_event.extend_from_slice(&prefix[..prefix_len]);
     framed_event.extend_from_slice(frame);
-    writer
-        .write_all(framed_event)
+    Ok(framed_event)
+}
+
+async fn forward_capture_event(
+    events: &mpsc::Sender<BesStreamEvent>,
+    kind: BesStreamEventKind,
+) -> Result<(), String> {
+    let (acknowledgement, accepted) = oneshot::channel();
+    events
+        .send(BesStreamEvent {
+            kind,
+            acknowledgement,
+        })
         .await
-        .map_err(|error| format!("write BEP frame: {error}"))?;
-    stats.event_count += 1;
-    stats.bep_bytes = next_bytes;
+        .map_err(|_| "BES capture event receiver closed".to_owned())?;
+    accepted
+        .await
+        .map_err(|_| "BES capture event acknowledgement closed".to_owned())?
+}
+
+async fn flush_capture_batch(
+    events: &mpsc::Sender<BesStreamEvent>,
+    responses: &tokio::sync::mpsc::Sender<Result<PublishBuildToolEventStreamResponse, Status>>,
+    pending_frames: &mut Vec<Vec<u8>>,
+    pending_responses: &mut Vec<PublishBuildToolEventStreamResponse>,
+) -> Result<(), String> {
+    if pending_frames.is_empty() {
+        debug_assert!(pending_responses.is_empty());
+        return Ok(());
+    }
+    let frames = std::mem::replace(pending_frames, Vec::with_capacity(CAPTURE_BATCH_MAX_EVENTS));
+    forward_capture_event(events, BesStreamEventKind::Frames(frames)).await?;
+    for response in pending_responses.drain(..) {
+        responses
+            .send(Ok(response))
+            .await
+            .map_err(|_| "BES client stopped accepting acknowledgements".to_owned())?;
+    }
     Ok(())
 }
 
@@ -611,6 +729,7 @@ mod tests {
 
     use buffa::Message;
     use tempfile::tempdir;
+    use tokio::io::AsyncWriteExt;
     use tonic::{
         client::Grpc as ClientGrpc, codegen::http::uri::PathAndQuery, transport::Endpoint,
     };
@@ -643,7 +762,29 @@ mod tests {
         let path = root.path().join("events.bep");
         let server = BesServer::start().await.unwrap();
         let invocation_id = "019f6b1e-dbf1-7090-9290-747e9021d447";
-        let capture = server.register(invocation_id, &path).unwrap();
+        let mut capture = server.register(invocation_id).unwrap();
+        let mut events = capture.take_events().unwrap();
+        let sink_path = path.clone();
+        let sink = tokio::spawn(async move {
+            let mut file = tokio::fs::OpenOptions::new()
+                .create(true)
+                .truncate(true)
+                .write(true)
+                .open(sink_path)
+                .await
+                .unwrap();
+            while let Some(event) = events.recv().await {
+                if event.is_finished() {
+                    file.flush().await.unwrap();
+                    event.acknowledge(Ok(()));
+                    break;
+                }
+                for framed in event.framed_events().unwrap() {
+                    file.write_all(framed).await.unwrap();
+                }
+                event.acknowledge(Ok(()));
+            }
+        });
         let bep_frame = bazel_mcp_bep::proto::BuildEvent::default().encode_to_vec();
         let stream_id = StreamId {
             build_id: "build-id".to_owned(),
@@ -703,6 +844,7 @@ mod tests {
         );
         assert!(acknowledgements.message().await.unwrap().is_none());
         let stats = capture.finish(Duration::from_secs(1)).await.unwrap();
+        sink.await.unwrap();
         assert_eq!(stats.event_count, 1);
         assert_eq!(stats.bep_bytes, bep_frame.len());
 
@@ -718,6 +860,96 @@ mod tests {
                 .unwrap()
                 .is_none()
         );
+    }
+
+    #[tokio::test]
+    async fn flushes_a_partial_batch_for_stop_and_wait_clients() {
+        let server = BesServer::start().await.unwrap();
+        let invocation_id = "019f6b1e-dbf1-7090-9290-stop-and-wait";
+        let mut capture = server.register(invocation_id).unwrap();
+        let mut events = capture.take_events().unwrap();
+        let sink = tokio::spawn(async move {
+            while let Some(event) = events.recv().await {
+                let finished = event.is_finished();
+                event.acknowledge(Ok(()));
+                if finished {
+                    break;
+                }
+            }
+        });
+
+        let stream_id = StreamId {
+            build_id: "stop-and-wait-build".to_owned(),
+            invocation_id: invocation_id.to_owned(),
+            component: 3,
+        };
+        let uri = server.endpoint().replacen("grpc://", "http://", 1);
+        let channel = Endpoint::from_shared(uri).unwrap().connect().await.unwrap();
+        let client = tokio::spawn(async move {
+            let (requests, request_stream) = tokio::sync::mpsc::channel(1);
+            requests
+                .send(stream_request(
+                    stream_id.clone(),
+                    1,
+                    Event::BazelEvent(Box::new(Any {
+                        type_url: "type.googleapis.com/build_event_stream.BuildEvent".to_owned(),
+                        value: bazel_mcp_bep::proto::BuildEvent::default().encode_to_vec(),
+                    })),
+                ))
+                .await
+                .unwrap();
+            let mut grpc = ClientGrpc::new(channel);
+            grpc.ready().await.unwrap();
+            let response = grpc
+                .streaming(
+                    Request::new(ReceiverStream::new(request_stream)),
+                    PathAndQuery::from_static(BUILD_TOOL_STREAM_PATH),
+                    BuffaCodec::<
+                        PublishBuildToolEventStreamResponseOwnedView,
+                        PublishBuildToolEventStreamRequest,
+                    >::default(),
+                )
+                .await
+                .unwrap();
+            let mut acknowledgements = response.into_inner();
+            assert_eq!(
+                acknowledgements
+                    .message()
+                    .await
+                    .unwrap()
+                    .unwrap()
+                    .sequence_number(),
+                1
+            );
+            requests
+                .send(stream_request(
+                    stream_id,
+                    2,
+                    Event::ComponentStreamFinished(Box::new(BuildComponentStreamFinished {
+                        r#type: 1,
+                    })),
+                ))
+                .await
+                .unwrap();
+            drop(requests);
+            assert_eq!(
+                acknowledgements
+                    .message()
+                    .await
+                    .unwrap()
+                    .unwrap()
+                    .sequence_number(),
+                2
+            );
+        });
+
+        tokio::time::timeout(Duration::from_secs(2), client)
+            .await
+            .expect("stop-and-wait client deadlocked")
+            .unwrap();
+        let stats = capture.finish(Duration::from_secs(1)).await.unwrap();
+        assert_eq!(stats.event_count, 1);
+        sink.await.unwrap();
     }
 
     fn stream_request(

--- a/crates/bazel-mcp-runner/src/capture.rs
+++ b/crates/bazel-mcp-runner/src/capture.rs
@@ -1,6 +1,6 @@
 use std::{
     fs::{File, OpenOptions},
-    io::{self, Read},
+    io::{self, Read, Seek, Write},
     path::{Path, PathBuf},
     process::Stdio,
     sync::{
@@ -12,17 +12,13 @@ use std::{
 };
 
 #[cfg(unix)]
-use std::{
-    io::{Seek, Write},
-    os::unix::{fs::FileTypeExt, fs::OpenOptionsExt},
-};
+use std::os::unix::{fs::FileTypeExt, fs::OpenOptionsExt};
 
-#[cfg(unix)]
-use bazel_mcp_bep::IncrementalStreamControl;
 use bazel_mcp_bep::{
     DEFAULT_MAX_FRAME_BYTES, DEFAULT_MAX_STREAM_BYTES, DEFAULT_MAX_STREAM_EVENTS,
-    IncrementalStreamDecoder, StreamOutcome, visit_stream_partial_bounded,
+    IncrementalStreamControl, IncrementalStreamDecoder, StreamOutcome,
 };
+use bazel_mcp_bes::BesCapture;
 use bazel_mcp_reducer::BepAccumulator;
 use bazel_mcp_store::InvocationPaths;
 use blake3::Hasher;
@@ -41,6 +37,7 @@ const PARALLEL_MMAP_HASH_THRESHOLD: u64 = 1024 * 1024;
 pub(crate) enum BepReductionSource {
     Incremental,
     Fifo,
+    Bes,
     PostHocFallback,
 }
 
@@ -55,14 +52,19 @@ pub(crate) enum LiveBepCapture {
     Tail(IncrementalBepCapture),
     #[cfg(unix)]
     Fifo(FifoBepCapture),
+    Bes(BesBepCapture),
 }
 
 impl LiveBepCapture {
-    pub(crate) async fn finish(self) -> Result<BepReduction, RunnerError> {
+    pub(crate) async fn finish(
+        self,
+        bes_completion_grace: Duration,
+    ) -> Result<BepReduction, RunnerError> {
         match self {
             Self::Tail(capture) => capture.finish().await,
             #[cfg(unix)]
             Self::Fifo(capture) => capture.finish().await,
+            Self::Bes(capture) => capture.finish(bes_completion_grace).await,
         }
     }
 }
@@ -145,6 +147,81 @@ impl IncrementalBepCapture {
 impl Drop for IncrementalBepCapture {
     fn drop(&mut self) {
         self.finishing.store(true, Ordering::Release);
+        if let Some(task) = self.task.take() {
+            task.abort();
+        }
+    }
+}
+
+/// Owns the transport-neutral capture pipeline fed by the loopback BES.
+///
+/// The BES service forwards ordered framed payloads over a bounded channel and
+/// waits for each acknowledgement. This worker acknowledges a frame only after
+/// the private evidence writer has accepted it and before reduction observes
+/// it, keeping durable raw evidence authoritative.
+pub(crate) struct BesBepCapture {
+    control: Option<BesCapture>,
+    task: Option<JoinHandle<Result<BepReduction, RunnerError>>>,
+    evidence_path: PathBuf,
+    extension_limits: Option<(usize, usize)>,
+}
+
+impl BesBepCapture {
+    pub(crate) fn start(
+        mut control: BesCapture,
+        evidence_path: PathBuf,
+        extension_limits: Option<(usize, usize)>,
+    ) -> Result<Self, RunnerError> {
+        let events = control.take_events()?;
+        let task_path = evidence_path.clone();
+        let task = task::spawn_blocking(move || read_bes_bep(events, task_path, extension_limits));
+        Ok(Self {
+            control: Some(control),
+            task: Some(task),
+            evidence_path,
+            extension_limits,
+        })
+    }
+
+    async fn finish(mut self, completion_grace: Duration) -> Result<BepReduction, RunnerError> {
+        let started = Instant::now();
+        let capture_result = self
+            .control
+            .take()
+            .expect("BES capture control must exist")
+            .finish(completion_grace)
+            .await;
+        if let Err(error) = &capture_result {
+            tracing::warn!(%error, "BES capture did not complete cleanly; reducing retained prefix");
+        }
+        let result = match self.task.take().expect("BES capture task must exist").await {
+            Ok(Ok(result)) => result,
+            Ok(Err(error)) => {
+                tracing::warn!(%error, "BES pipeline failed; decoding retained prefix");
+                post_hoc_reduction(self.evidence_path.clone(), self.extension_limits).await?
+            }
+            Err(error) => {
+                tracing::warn!(%error, "BES pipeline task failed; decoding retained prefix");
+                post_hoc_reduction(self.evidence_path.clone(), self.extension_limits).await?
+            }
+        };
+        if let Ok(stats) = capture_result {
+            tracing::debug!(
+                events = stats.event_count,
+                bytes = stats.bep_bytes,
+                "completed BES capture"
+            );
+        }
+        Ok(BepReduction {
+            finalize_ms: duration_millis(started.elapsed()),
+            ..result
+        })
+    }
+}
+
+impl Drop for BesBepCapture {
+    fn drop(&mut self) {
+        self.control.take();
         if let Some(task) = self.task.take() {
             task.abort();
         }
@@ -315,39 +392,25 @@ impl Drop for FifoBepCapture {
     }
 }
 
-#[cfg(unix)]
-struct FifoAttempt {
+struct ReductionSubscriber {
     accumulator: BepAccumulator,
-    hasher: Hasher,
-    framed_bytes: u64,
     decoded_bytes: usize,
     event_count: usize,
 }
 
-#[cfg(unix)]
-impl FifoAttempt {
+impl ReductionSubscriber {
     fn new(extension_limits: Option<(usize, usize)>) -> Self {
         Self {
             accumulator: new_accumulator(extension_limits),
-            hasher: Hasher::new(),
-            framed_bytes: 0,
             decoded_bytes: 0,
             event_count: 0,
         }
     }
 
-    fn observe(&mut self, event: bazel_mcp_bep::BepEvent, framed: &[u8]) {
-        self.retain_raw(framed);
+    fn observe(&mut self, event: bazel_mcp_bep::BepEvent) {
         self.decoded_bytes = self.decoded_bytes.saturating_add(event.frame_bytes().len());
         self.event_count = self.event_count.saturating_add(1);
         self.accumulator.observe(event);
-    }
-
-    fn retain_raw(&mut self, bytes: &[u8]) {
-        self.hasher.update(bytes);
-        self.framed_bytes = self
-            .framed_bytes
-            .saturating_add(u64::try_from(bytes.len()).unwrap_or(u64::MAX));
     }
 
     fn outcome(&self) -> StreamOutcome {
@@ -359,95 +422,256 @@ impl FifoAttempt {
     }
 }
 
+enum DurableBepWriter {
+    /// Tail and post-hoc sources read bytes only after Bazel has written them to
+    /// the private evidence file. The gate still accounts and hashes those
+    /// exact bytes before downstream subscribers observe decoded events.
+    AlreadyPersisted { hasher: Hasher, bytes: u64 },
+    /// FIFO and BES sources must append exact framed bytes before reduction or
+    /// any future externally visible subscriber can observe them.
+    Append {
+        file: File,
+        hasher: Hasher,
+        bytes: u64,
+    },
+}
+
+impl DurableBepWriter {
+    fn already_persisted() -> Self {
+        Self::AlreadyPersisted {
+            hasher: Hasher::new(),
+            bytes: 0,
+        }
+    }
+
+    fn append(file: File) -> Self {
+        Self::Append {
+            file,
+            hasher: Hasher::new(),
+            bytes: 0,
+        }
+    }
+
+    fn commit(&mut self, raw: &[u8]) -> io::Result<()> {
+        match self {
+            Self::AlreadyPersisted { hasher, bytes } => {
+                hasher.update(raw);
+                *bytes = bytes.saturating_add(u64::try_from(raw.len()).unwrap_or(u64::MAX));
+            }
+            Self::Append {
+                file,
+                hasher,
+                bytes,
+            } => {
+                file.write_all(raw)?;
+                hasher.update(raw);
+                *bytes = bytes.saturating_add(u64::try_from(raw.len()).unwrap_or(u64::MAX));
+            }
+        }
+        Ok(())
+    }
+
+    fn begin_retry(&mut self) -> io::Result<()> {
+        if let Self::Append {
+            file,
+            hasher,
+            bytes,
+        } = self
+        {
+            file.flush()?;
+            file.set_len(0)?;
+            file.seek(io::SeekFrom::Start(0))?;
+            *hasher = Hasher::new();
+            *bytes = 0;
+        }
+        Ok(())
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        if let Self::Append { file, .. } = self {
+            file.flush()?;
+        }
+        Ok(())
+    }
+
+    fn bytes(&self) -> u64 {
+        match self {
+            Self::AlreadyPersisted { bytes, .. } | Self::Append { bytes, .. } => *bytes,
+        }
+    }
+
+    fn digest(&self) -> [u8; 32] {
+        match self {
+            Self::AlreadyPersisted { hasher, .. } | Self::Append { hasher, .. } => {
+                *hasher.clone().finalize().as_bytes()
+            }
+        }
+    }
+}
+
+struct CapturePipeline {
+    decoder: IncrementalStreamDecoder,
+    durable: DurableBepWriter,
+    reduction: ReductionSubscriber,
+    saved_attempt: Option<ReductionSubscriber>,
+    expecting_retry: bool,
+    pending_raw: Vec<u8>,
+    extension_limits: Option<(usize, usize)>,
+}
+
+struct CapturePipelineOutput {
+    reduction: BepReduction,
+    durable_bytes: u64,
+    durable_digest: [u8; 32],
+}
+
+impl CapturePipeline {
+    fn new(durable: DurableBepWriter, extension_limits: Option<(usize, usize)>) -> Self {
+        Self {
+            decoder: IncrementalStreamDecoder::new(
+                DEFAULT_MAX_FRAME_BYTES,
+                DEFAULT_MAX_STREAM_BYTES,
+                DEFAULT_MAX_STREAM_EVENTS,
+            ),
+            durable,
+            reduction: ReductionSubscriber::new(extension_limits),
+            saved_attempt: None,
+            expecting_retry: false,
+            pending_raw: Vec::new(),
+            extension_limits,
+        }
+    }
+
+    fn ingest(&mut self, input: &[u8]) -> Result<(), RunnerError> {
+        use bazel_mcp_bep::view::build_event::Payload;
+
+        if input.is_empty() {
+            return Ok(());
+        }
+        if self.decoder.is_terminal() {
+            self.durable.commit(input)?;
+            return Ok(());
+        }
+
+        self.pending_raw.extend_from_slice(input);
+        let durable = &mut self.durable;
+        let reduction = &mut self.reduction;
+        let saved_attempt = &mut self.saved_attempt;
+        let expecting_retry = &mut self.expecting_retry;
+        let pending_raw = &mut self.pending_raw;
+        let extension_limits = self.extension_limits;
+        let mut pipeline_error = None;
+        self.decoder.push_framed(input, |event, framed| {
+            if pipeline_error.is_some() {
+                return IncrementalStreamControl::Continue;
+            }
+            let is_started = matches!(event.view().payload.as_ref(), Some(Payload::Started(_)));
+            let is_remote_cache_evicted = matches!(
+                event.view().payload.as_ref(),
+                Some(Payload::Finished(finished))
+                    if finished.exit_code.as_option().is_some_and(|code| code.code == 39)
+            );
+            let Some(raw) = pending_raw.get(..framed.len()) else {
+                pipeline_error = Some(io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    "BEP frame exceeded retained source bytes",
+                ));
+                return IncrementalStreamControl::Continue;
+            };
+            if raw != framed {
+                pipeline_error = Some(io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    "decoded BEP frame did not match retained source bytes",
+                ));
+                return IncrementalStreamControl::Continue;
+            }
+            if *expecting_retry && is_started {
+                if let Err(error) = durable.begin_retry() {
+                    pipeline_error = Some(error);
+                    return IncrementalStreamControl::Continue;
+                }
+                *saved_attempt = None;
+                *expecting_retry = false;
+            }
+            // This is the security boundary: exact raw bytes are accepted by
+            // the local durable writer before reduction observes the event.
+            if let Err(error) = durable.commit(raw) {
+                pipeline_error = Some(error);
+                return IncrementalStreamControl::Continue;
+            }
+            reduction.observe(event);
+            pending_raw.drain(..framed.len());
+            if is_remote_cache_evicted {
+                *saved_attempt = Some(std::mem::replace(
+                    reduction,
+                    ReductionSubscriber::new(extension_limits),
+                ));
+                *expecting_retry = true;
+                IncrementalStreamControl::ResetAfterFrame
+            } else {
+                IncrementalStreamControl::Continue
+            }
+        });
+        if let Some(error) = pipeline_error {
+            return Err(error.into());
+        }
+        if self.decoder.is_terminal() && !self.pending_raw.is_empty() {
+            self.durable.commit(&self.pending_raw)?;
+            self.pending_raw.clear();
+        }
+        Ok(())
+    }
+
+    fn durable_bytes(&self) -> u64 {
+        self.durable.bytes()
+    }
+
+    fn finish(mut self, source: BepReductionSource) -> Result<CapturePipelineOutput, RunnerError> {
+        if !self.pending_raw.is_empty() {
+            self.durable.commit(&self.pending_raw)?;
+            self.pending_raw.clear();
+        }
+        self.durable.flush()?;
+        let decoder_outcome = self.decoder.finish();
+        let (reduction, outcome) = if self.expecting_retry && self.reduction.event_count == 0 {
+            let saved = self.saved_attempt.unwrap_or(self.reduction);
+            let outcome = saved.outcome();
+            (saved, outcome)
+        } else {
+            (self.reduction, decoder_outcome)
+        };
+        Ok(CapturePipelineOutput {
+            reduction: BepReduction {
+                accumulator: reduction.accumulator,
+                outcome,
+                source,
+                finalize_ms: 0,
+            },
+            durable_bytes: self.durable.bytes(),
+            durable_digest: self.durable.digest(),
+        })
+    }
+}
+
 #[cfg(unix)]
 fn read_fifo_bep(
     mut reader: File,
-    mut evidence: File,
+    evidence: File,
     extension_limits: Option<(usize, usize)>,
     finishing: &AtomicBool,
     observed_bytes: &AtomicU64,
     server_pid: u32,
     client_pid: u32,
 ) -> Result<BepReduction, RunnerError> {
-    use bazel_mcp_bep::view::build_event::Payload;
-
-    let mut decoder = IncrementalStreamDecoder::new(
-        DEFAULT_MAX_FRAME_BYTES,
-        DEFAULT_MAX_STREAM_BYTES,
-        DEFAULT_MAX_STREAM_EVENTS,
-    );
-    let mut attempt = FifoAttempt::new(extension_limits);
-    let mut saved_attempt = None;
-    let mut expecting_retry = false;
+    let verification_file = evidence.try_clone()?;
+    let mut pipeline = CapturePipeline::new(DurableBepWriter::append(evidence), extension_limits);
     let mut buffer = [0_u8; 64 * 1024];
-    let mut unwritten = Vec::new();
     let mut server_exit_observed = false;
     loop {
         match reader.read(&mut buffer) {
             Ok(read) if read > 0 => {
-                unwritten.extend_from_slice(&buffer[..read]);
-                let mut write_error = None;
-                decoder.push_framed(&buffer[..read], |event, framed| {
-                    let is_started =
-                        matches!(event.view().payload.as_ref(), Some(Payload::Started(_)));
-                    let is_remote_cache_evicted = matches!(
-                        event.view().payload.as_ref(),
-                        Some(Payload::Finished(finished))
-                            if finished.exit_code.as_option().is_some_and(|code| code.code == 39)
-                    );
-
-                    if expecting_retry && is_started {
-                        if let Err(error) = evidence
-                            .flush()
-                            .and_then(|()| evidence.set_len(0))
-                            .and_then(|()| evidence.seek(io::SeekFrom::Start(0)).map(|_| ()))
-                        {
-                            write_error = Some(error);
-                            return IncrementalStreamControl::Continue;
-                        }
-                        saved_attempt = None;
-                        expecting_retry = false;
-                    }
-                    let Some(raw) = unwritten.get(..framed.len()) else {
-                        write_error = Some(io::Error::new(
-                            io::ErrorKind::InvalidData,
-                            "FIFO BEP frame exceeded retained input",
-                        ));
-                        return IncrementalStreamControl::Continue;
-                    };
-                    if raw != framed {
-                        write_error = Some(io::Error::new(
-                            io::ErrorKind::InvalidData,
-                            "FIFO BEP frame did not match retained input",
-                        ));
-                        return IncrementalStreamControl::Continue;
-                    }
-                    if let Err(error) = evidence.write_all(raw) {
-                        write_error = Some(error);
-                        return IncrementalStreamControl::Continue;
-                    }
-                    attempt.observe(event, framed);
-                    unwritten.drain(..framed.len());
-                    if is_remote_cache_evicted {
-                        saved_attempt = Some(std::mem::replace(
-                            &mut attempt,
-                            FifoAttempt::new(extension_limits),
-                        ));
-                        expecting_retry = true;
-                        IncrementalStreamControl::ResetAfterFrame
-                    } else {
-                        IncrementalStreamControl::Continue
-                    }
-                });
-                if let Some(error) = write_error {
-                    return Err(error.into());
-                }
-                if decoder.is_terminal() && !unwritten.is_empty() {
-                    evidence.write_all(&unwritten)?;
-                    attempt.retain_raw(&unwritten);
-                    unwritten.clear();
-                }
-                observed_bytes.store(attempt.framed_bytes, Ordering::Release);
+                pipeline.ingest(&buffer[..read])?;
+                observed_bytes.store(pipeline.durable_bytes(), Ordering::Release);
             }
             Ok(0) => {
                 let client_alive = is_process_alive(client_pid);
@@ -484,31 +708,57 @@ fn read_fifo_bep(
             Err(error) => return Err(error.into()),
         }
     }
-    if !unwritten.is_empty() {
-        evidence.write_all(&unwritten)?;
-        attempt.retain_raw(&unwritten);
-    }
-    evidence.flush()?;
-    let decoder_outcome = decoder.finish();
-    let (attempt, outcome) = if expecting_retry && attempt.event_count == 0 {
-        let saved = saved_attempt.unwrap_or(attempt);
-        let outcome = saved.outcome();
-        (saved, outcome)
-    } else {
-        (attempt, decoder_outcome)
-    };
-    let retained_digest = *attempt.hasher.finalize().as_bytes();
-    let (final_bytes, final_digest) = hash_open_file(&evidence)?;
-    if attempt.framed_bytes != final_bytes || retained_digest != final_digest {
+    let output = pipeline.finish(BepReductionSource::Fifo)?;
+    let (final_bytes, final_digest) = hash_open_file(&verification_file)?;
+    if output.durable_bytes != final_bytes || output.durable_digest != final_digest {
         return Err(io::Error::other("FIFO BEP evidence did not match captured bytes").into());
     }
-    observed_bytes.store(attempt.framed_bytes, Ordering::Release);
-    Ok(BepReduction {
-        accumulator: attempt.accumulator,
-        outcome,
-        source: BepReductionSource::Fifo,
-        finalize_ms: 0,
-    })
+    observed_bytes.store(output.durable_bytes, Ordering::Release);
+    Ok(output.reduction)
+}
+
+fn read_bes_bep(
+    mut events: tokio::sync::mpsc::Receiver<bazel_mcp_bes::BesStreamEvent>,
+    evidence_path: PathBuf,
+    extension_limits: Option<(usize, usize)>,
+) -> Result<BepReduction, RunnerError> {
+    let evidence = private_file(&evidence_path)?;
+    let mut pipeline = Some(CapturePipeline::new(
+        DurableBepWriter::append(evidence),
+        extension_limits,
+    ));
+    while let Some(event) = events.blocking_recv() {
+        if event.is_finished() {
+            let result = pipeline
+                .take()
+                .expect("BES pipeline must exist before finish")
+                .finish(BepReductionSource::Bes);
+            event.acknowledge(result.as_ref().map(|_| ()).map_err(ToString::to_string));
+            return result.map(|output| output.reduction);
+        }
+
+        let pipeline = pipeline
+            .as_mut()
+            .expect("BES pipeline must exist while receiving frames");
+        let mut result = Ok(());
+        for framed in event
+            .framed_events()
+            .expect("non-terminal BES events must carry framed bytes")
+        {
+            if let Err(error) = pipeline.ingest(framed) {
+                result = Err(error);
+                break;
+            }
+        }
+        event.acknowledge(result.as_ref().map(|_| ()).map_err(ToString::to_string));
+        result?;
+    }
+
+    pipeline
+        .take()
+        .expect("BES pipeline must exist when event channel closes")
+        .finish(BepReductionSource::Bes)
+        .map(|output| output.reduction)
 }
 
 #[cfg(unix)]
@@ -584,22 +834,14 @@ fn tail_bep(
     observed_bytes: &AtomicU64,
 ) -> Result<BepReduction, RunnerError> {
     let mut file = File::open(&path)?;
-    let mut accumulator = new_accumulator(extension_limits);
-    let mut decoder = IncrementalStreamDecoder::new(
-        DEFAULT_MAX_FRAME_BYTES,
-        DEFAULT_MAX_STREAM_BYTES,
-        DEFAULT_MAX_STREAM_EVENTS,
-    );
+    let mut pipeline =
+        CapturePipeline::new(DurableBepWriter::already_persisted(), extension_limits);
     let mut buffer = [0_u8; 64 * 1024];
-    let mut hasher = Hasher::new();
-    let mut tailed_bytes = 0_u64;
     loop {
         let read = file.read(&mut buffer)?;
         if read > 0 {
-            hasher.update(&buffer[..read]);
-            tailed_bytes = tailed_bytes.saturating_add(u64::try_from(read).unwrap_or(u64::MAX));
-            decoder.push(&buffer[..read], |event| accumulator.observe(event));
-            observed_bytes.store(tailed_bytes, Ordering::Release);
+            pipeline.ingest(&buffer[..read])?;
+            observed_bytes.store(pipeline.durable_bytes(), Ordering::Release);
             continue;
         }
         if finishing.load(Ordering::Acquire) {
@@ -608,20 +850,14 @@ fn tail_bep(
         thread::sleep(BEP_TAIL_POLL_INTERVAL);
     }
 
-    let outcome = decoder.finish();
-    let tailed_digest = *hasher.finalize().as_bytes();
+    let output = pipeline.finish(BepReductionSource::Incremental)?;
     let (final_bytes, final_digest) = hash_file(&path)?;
-    if tailed_bytes == final_bytes && tailed_digest == final_digest {
-        return Ok(BepReduction {
-            accumulator,
-            outcome,
-            source: BepReductionSource::Incremental,
-            finalize_ms: 0,
-        });
+    if output.durable_bytes == final_bytes && output.durable_digest == final_digest {
+        return Ok(output.reduction);
     }
 
     tracing::debug!(
-        tailed_bytes,
+        tailed_bytes = output.durable_bytes,
         final_bytes,
         "BEP file changed while it was tailed; decoding retained file"
     );
@@ -659,16 +895,19 @@ fn reduce_bep_file(
     extension_limits: Option<(usize, usize)>,
 ) -> Result<(BepAccumulator, StreamOutcome), RunnerError> {
     match File::open(path) {
-        Ok(file) => {
-            let mut accumulator = new_accumulator(extension_limits);
-            let outcome = visit_stream_partial_bounded(
-                file,
-                DEFAULT_MAX_FRAME_BYTES,
-                DEFAULT_MAX_STREAM_BYTES,
-                DEFAULT_MAX_STREAM_EVENTS,
-                |event| accumulator.observe(event),
-            );
-            Ok((accumulator, outcome))
+        Ok(mut file) => {
+            let mut pipeline =
+                CapturePipeline::new(DurableBepWriter::already_persisted(), extension_limits);
+            let mut buffer = [0_u8; 64 * 1024];
+            loop {
+                let read = file.read(&mut buffer)?;
+                if read == 0 {
+                    break;
+                }
+                pipeline.ingest(&buffer[..read])?;
+            }
+            let output = pipeline.finish(BepReductionSource::PostHocFallback)?;
+            Ok((output.reduction.accumulator, output.reduction.outcome))
         }
         Err(error) if error.kind() == io::ErrorKind::NotFound => Ok((
             BepAccumulator::default(),
@@ -820,6 +1059,52 @@ mod tests {
         assert_reductions_match(incremental.accumulator, post_hoc);
     }
 
+    #[test]
+    fn persisted_and_streamed_sources_share_one_ordered_capture_pipeline() {
+        let root = tempdir().unwrap();
+        let fixture =
+            include_bytes!("../../bazel-mcp-reducer/tests/fixtures/bazel-9/test-outcomes.bep");
+
+        let mut persisted = CapturePipeline::new(DurableBepWriter::already_persisted(), None);
+        for chunk in fixture.chunks(113) {
+            persisted.ingest(chunk).unwrap();
+        }
+        let persisted = persisted.finish(BepReductionSource::Incremental).unwrap();
+
+        let streamed_path = root.path().join("streamed.bep");
+        let mut streamed = CapturePipeline::new(
+            DurableBepWriter::append(private_file(&streamed_path).unwrap()),
+            None,
+        );
+        for chunk in fixture.chunks(97) {
+            streamed.ingest(chunk).unwrap();
+        }
+        let streamed = streamed.finish(BepReductionSource::Bes).unwrap();
+
+        assert_eq!(std::fs::read(streamed_path).unwrap(), fixture);
+        assert_eq!(persisted.durable_bytes, streamed.durable_bytes);
+        assert_eq!(persisted.durable_digest, streamed.durable_digest);
+        assert_outcomes_match(&persisted.reduction.outcome, &streamed.reduction.outcome);
+        assert_reductions_match(
+            persisted.reduction.accumulator,
+            streamed.reduction.accumulator,
+        );
+    }
+
+    #[test]
+    fn durability_failure_prevents_reduction_from_observing_the_frame() {
+        let root = tempdir().unwrap();
+        let path = root.path().join("read-only.bep");
+        std::fs::write(&path, []).unwrap();
+        let read_only = File::open(path).unwrap();
+        let mut pipeline = CapturePipeline::new(DurableBepWriter::append(read_only), None);
+        let frame = retry_attempt(0, "must-not-be-reduced");
+
+        assert!(pipeline.ingest(&frame).is_err());
+        assert_eq!(pipeline.reduction.event_count, 0);
+        assert_eq!(pipeline.durable_bytes(), 0);
+    }
+
     #[cfg(unix)]
     #[tokio::test]
     async fn fifo_capture_reconnects_and_retains_only_the_successful_retry() {
@@ -920,7 +1205,6 @@ mod tests {
         assert!(!fifo_path.exists());
     }
 
-    #[cfg(unix)]
     fn retry_attempt(code: i32, marker: &str) -> Vec<u8> {
         use bazel_mcp_bep::{
             encode_frame,

--- a/crates/bazel-mcp-runner/src/service.rs
+++ b/crates/bazel-mcp-runner/src/service.rs
@@ -1185,9 +1185,19 @@ impl InvocationService {
         if cancellation.is_cancelled() {
             return self.finish_cancelled(queued.request.id).await;
         }
-        let bes_capture = if queued.request.command.class() == CommandClass::BuildLike {
+        let extension_limits = (!self.reducers.is_empty()).then_some({
+            (
+                self.config.starlark_reducers.limits.max_events,
+                self.config.starlark_reducers.limits.max_input_bytes,
+            )
+        });
+        let bes_bep = if queued.request.command.class() == CommandClass::BuildLike {
             match &self.bes {
-                Some(server) => Some(server.register(queued.request.id.to_string(), &paths.bep)?),
+                Some(server) => Some(capture::LiveBepCapture::Bes(capture::BesBepCapture::start(
+                    server.register(queued.request.id.to_string())?,
+                    paths.bep.clone(),
+                    extension_limits,
+                )?)),
                 None => None,
             }
         } else {
@@ -1284,12 +1294,6 @@ impl InvocationService {
                     .map_err(Into::into);
             }
         };
-        let extension_limits = (!self.reducers.is_empty()).then_some({
-            (
-                self.config.starlark_reducers.limits.max_events,
-                self.config.starlark_reducers.limits.max_input_bytes,
-            )
-        });
         #[cfg(unix)]
         let fifo_bep = prepared_fifo.take().map(|(prepared, server_pid)| {
             let client_pid = child.id().unwrap_or_default();
@@ -1354,7 +1358,7 @@ impl InvocationService {
             return Err(error.into());
         }
         #[cfg(unix)]
-        let incremental_bep = fifo_bep.or_else(|| {
+        let incremental_bep = fifo_bep.or(bes_bep).or_else(|| {
             (queued.request.command.class() == CommandClass::BuildLike
                 && self.config.bep_transport != BepTransport::Bes)
                 .then(|| {
@@ -1365,14 +1369,16 @@ impl InvocationService {
                 })
         });
         #[cfg(not(unix))]
-        let incremental_bep = (queued.request.command.class() == CommandClass::BuildLike
-            && self.config.bep_transport != BepTransport::Bes)
-            .then(|| {
-                capture::LiveBepCapture::Tail(capture::IncrementalBepCapture::start(
-                    paths.bep.clone(),
-                    extension_limits,
-                ))
-            });
+        let incremental_bep = bes_bep.or_else(|| {
+            (queued.request.command.class() == CommandClass::BuildLike
+                && self.config.bep_transport != BepTransport::Bes)
+                .then(|| {
+                    capture::LiveBepCapture::Tail(capture::IncrementalBepCapture::start(
+                        paths.bep.clone(),
+                        extension_limits,
+                    ))
+                })
+        });
         let started = Instant::now();
         let timeout = queued
             .request
@@ -1404,30 +1410,11 @@ impl InvocationService {
         };
         process_group.disarm();
         let bazel_wall_ms = duration_millis(started.elapsed());
-        if let Some(capture) = bes_capture {
-            match capture.finish(BES_COMPLETION_GRACE).await {
-                Ok(stats) => {
-                    tracing::debug!(
-                        invocation_id = %queued.request.id,
-                        events = stats.event_count,
-                        bytes = stats.bep_bytes,
-                        "completed BES capture"
-                    );
-                }
-                Err(error) => {
-                    tracing::warn!(
-                        invocation_id = %queued.request.id,
-                        %error,
-                        "BES capture did not complete cleanly; reducing retained prefix"
-                    );
-                }
-            }
-        }
         let postprocess: Result<InvocationRecord, RunnerError> = async {
             let reduction_started = Instant::now();
             let incremental_reduction = match incremental_bep {
                 Some(capture) => {
-                    let reduction = capture.finish().await?;
+                    let reduction = capture.finish(BES_COMPLETION_GRACE).await?;
                     tracing::debug!(
                         invocation_id = %queued.request.id,
                         source = ?reduction.source,

--- a/crates/bazel-mcp-runner/tests/process.rs
+++ b/crates/bazel-mcp-runner/tests/process.rs
@@ -7,8 +7,8 @@ use std::{
 };
 
 use bazel_mcp_bep::proto::{
-    BuildEvent, BuildEventId, File, TestResult as BepTestResult, TestSummary as BepTestSummary,
-    build_event, build_event_id, file,
+    ActionExecuted, BuildEvent, BuildEventId, File, TestResult as BepTestResult,
+    TestSummary as BepTestSummary, build_event, build_event_id, file,
 };
 use bazel_mcp_bep::{encode_event_id, encode_frame};
 use bazel_mcp_policy::PolicyConfig;
@@ -395,6 +395,70 @@ async fn redacts_secrets_from_metadata_normalized_rows_and_log_inspection() {
             .unwrap()
             .contains("remote_artifact_unavailable")
     );
+}
+
+#[tokio::test]
+async fn preserves_raw_bep_before_redacting_every_persisted_and_visible_projection() {
+    let root = tempfile::tempdir().unwrap();
+    let workspace = root.path().join("workspace");
+    tokio::fs::create_dir(&workspace).await.unwrap();
+    let secret = "token=PIPELINESECRET";
+    let raw_bep = encode_frame(&BuildEvent {
+        payload: Some(build_event::Payload::Action(Box::new(ActionExecuted {
+            success: false,
+            exit_code: 1,
+            r#type: secret.to_owned(),
+            ..Default::default()
+        }))),
+        ..Default::default()
+    });
+    let fixture = root.path().join("secret.bep");
+    tokio::fs::write(&fixture, &raw_bep).await.unwrap();
+    let script = format!(
+        "#!/bin/sh\nfor arg in \"$@\"; do case \"$arg\" in --build_event_binary_file=*) bep_path=${{arg#*=}} ;; esac; done\ncp '{}' \"$bep_path\"\nexit 1\n",
+        fixture.display()
+    );
+    let service =
+        service_with_redaction(&root, &workspace, &script, vec![r"token=[^\s]+".to_owned()]).await;
+    let request = InvocationRequest::new(workspace, BazelCommand::Build, vec!["//:secret".into()]);
+    let id = request.id;
+    let record = service.run(request).await.unwrap();
+    assert_eq!(record.state, InvocationState::Failed);
+    assert!(!serde_json::to_string(&record).unwrap().contains(secret));
+
+    let paths = service.store().paths_for(&record);
+    let retained = std::fs::read(&paths.bep).unwrap();
+    assert_eq!(retained, raw_bep);
+    assert!(
+        retained
+            .windows(secret.len())
+            .any(|bytes| bytes == secret.as_bytes())
+    );
+    for path in [&paths.manifest, &paths.details, &paths.artifacts] {
+        if path.exists() {
+            assert!(
+                !String::from_utf8_lossy(&std::fs::read(path).unwrap()).contains(secret),
+                "{} retained an unredacted projection",
+                path.display()
+            );
+        }
+    }
+
+    let inspected = service
+        .inspect(InspectRequest {
+            invocation_id: Some(id),
+            workspace: None,
+            state: None,
+            command: None,
+            view: InspectView::Diagnostics,
+            cursor: None,
+            filter: None,
+            limit: 20,
+            max_bytes: 8 * 1024,
+        })
+        .await
+        .unwrap();
+    assert!(!serde_json::to_string(&inspected).unwrap().contains(secret));
 }
 
 #[tokio::test]

--- a/docs/bep-transport-performance.md
+++ b/docs/bep-transport-performance.md
@@ -29,40 +29,47 @@ The live benchmark starts persistent tail, FIFO, and BES MCP servers that share
 one Bazel output user root. After two warmups per mode, it rotates the order of
 the modes across `bazel.run build //:bazel-mcp` calls and compares the invocation
 durations reported by Bazel MCP. This includes FIFO creation, the Bazel server
-PID probe, evidence spooling, reduction, and cleanup.
+PID probe, evidence spooling, reduction, and cleanup. The capture-pipeline
+comparison uses nine measured samples and `--lockfile_mode=error` for both the
+clean `109e183` baseline and the refactored working tree.
 
 Results below were measured on macOS arm64 on 2026-07-16.
 
 ## Results
 
-The first BES implementation performed two asynchronous file writes for each
-event: one for the varint length and one for the payload. The optimized pass
-reuses a framing buffer and writes each complete frame once before sending its
-acknowledgement.
+Tail, FIFO, and BES now feed one ordered capture pipeline. Tail frames enter
+after Bazel has written them to the private evidence file. FIFO and BES frames
+pass through an authoritative durable writer first; only then does the reducer
+subscriber observe them. BES hands off at most 64 events or 1 MiB per bounded
+batch. It flushes a partial batch after one scheduler yield, so a valid
+stop-and-wait BES client cannot deadlock, and sends each protocol
+acknowledgement only after the batch is accepted by the durable writer.
 
 | Isolated capture | Median | p95 | Throughput |
 | --- | ---: | ---: | ---: |
-| Bulk `tail` baseline, final run | 1.17 ms | 1.58 ms | 5,342 MiB/s |
-| BES, first pass | 389.85 ms | 394.95 ms | 15.98 MiB/s |
-| BES, optimized | 203.59 ms | 211.99 ms | 30.60 MiB/s |
+| Bulk `tail`, `109e183` baseline | 1.012 ms | 1.532 ms | 6,154 MiB/s |
+| Bulk `tail`, capture pipeline | 1.078 ms | 1.515 ms | 5,781 MiB/s |
+| BES, `109e183` baseline | 200.496 ms | 203.570 ms | 31.07 MiB/s |
+| BES, capture pipeline | 43.953 ms | 46.033 ms | 141.73 MiB/s |
 
-The second pass reduced isolated BES capture time by 47.8%. Its remaining cost
-is primarily per-event gRPC decoding, validation, file-write submission, and
-acknowledgement. Dividing the optimized median by the event count gives about
-12.9 microseconds per event.
+The common pipeline plus bounded handoff reduced isolated BES capture time by
+78.1%, a 4.56x speedup. The bulk-tail control moved by 0.065 ms at the median
+while its p95 improved slightly; that control path is unchanged and the
+sub-millisecond difference is treated as run-to-run noise.
 
-| Warm `build //:bazel-mcp` (7 samples) | Median | p95 |
-| --- | ---: | ---: |
-| `tail` | 275 ms | 277 ms |
-| `fifo` | 271 ms | 273 ms |
-| `bes` | 275 ms | 282 ms |
+| Warm `build //:bazel-mcp` (9 samples) | Baseline median | Pipeline median | Change |
+| --- | ---: | ---: | ---: |
+| `tail` | 273 ms | 269 ms | -4 ms (-1.5%) |
+| `fifo` | 268 ms | 269 ms | +1 ms (+0.4%) |
+| `bes` | 271 ms | 272 ms | +1 ms (+0.4%) |
 
-FIFO was 4 ms (1.5%) faster than regular-file tailing at the median on this
-workload, while BES matched the tail median. The FIFO improvement is modest,
-so FIFO remains an explicit POSIX optimization rather than replacing the
-portable default. The isolated bulk-write comparison still makes BES's
-per-event protocol overhead visible even though it overlaps with the build in
-the live workload.
+Whole-invocation performance is effectively flat. Tail and FIFO p95 improved
+or stayed equal; BES p95 moved from 280 ms to 289 ms in this nine-sample run,
+while its median changed by only 1 ms. FIFO therefore remains an explicit
+POSIX optimization rather than replacing the portable default. The isolated
+result shows the reduced BES ingestion cost clearly, while the live result
+shows that incremental reduction and the durability gate do not materially
+change ordinary build latency.
 
 ## Reproduce
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -102,8 +102,9 @@ BEP file directly, so an existing remote `--bes_backend` or BuildBuddy setup
 continues to receive events.
 
 `fifo` is an opt-in POSIX optimization. bazel-mcp creates a private named pipe,
-streams and reduces events from it, and mirrors the exact bytes into the same
-retained `events.bep` evidence file. It probes the persistent Bazel server PID
+feeds its ordered frames through the shared capture pipeline, and commits the
+exact bytes to `events.bep` before the reduction subscriber observes them. It
+probes the persistent Bazel server PID
 and separately tracks the spawned invocation-client PID so a writer may close
 and reconnect during a Bazel retry without EOF ending the capture. FIFO setup
 or PID-discovery failures fall back to `tail`; Windows always uses that portable
@@ -113,7 +114,10 @@ fallback.
 port and configures Bazel to publish to it with
 `--bes_upload_mode=wait_for_upload_complete`. The service validates the
 invocation ID and stream sequence with Buffa views, then reconstructs the same
-private varint-delimited `events.bep` file used by reducers and inspection.
+private varint-delimited `events.bep` file through the shared capture pipeline.
+Small bounded event batches amortize transport handoff, but Bazel receives no
+acknowledgement until the corresponding raw frames have been accepted by the
+private evidence writer. Reduction observes those frames only afterward.
 Select this mode explicitly because Bazel supports only one `--bes_backend`;
 caller-supplied remote BES flags are rejected in this mode. The listener is
 never exposed outside the local host.

--- a/docs/storage-performance.md
+++ b/docs/storage-performance.md
@@ -43,13 +43,16 @@ reader because no released installation uses the previous layout.
       v
 3. Bazel execution
    disk:   stdout.log / stderr.log (raw bytes, direct child output)
-           events.bep (varint-length-delimited protobuf, direct Bazel output)
-   memory: only process state, cancellation handle, progress counters
+           events.bep (varint-length-delimited protobuf, authoritative raw BEP)
+   flow:   tail verifies already-written frames; FIFO/BES write frames through
+           the same durability gate before ordered reduction observes them
+   memory: bounded framing state, reducer state, process state, cancellation
       |
       | process exits, is cancelled, or times out
       v
 4. Bounded reduction
-   reads:  events.bep frame by frame into BepAccumulator
+   input:  the same ordered frame stream after its durability gate; a post-hoc
+           events.bep replay remains the fallback after capture inconsistency
            stdout.log query rows in 1 MiB byte chunks for newline counting
            returned query rows only, capped at 64 KiB retained / 4 KiB visible
            2 MiB log tails with complete BEP, otherwise 8 MiB tails

--- a/specs/002-project-architecture.md
+++ b/specs/002-project-architecture.md
@@ -638,8 +638,9 @@ bazel-mcp-runner
       ├────────────► Bazel/Bazelisk/repo wrapper
       │               stdout.log + stderr.log + tail events.bep
       ├────────────► bazel-mcp-bes (optional loopback gRPC)
-      │               BES stream -> events.bep
-      ├─ spawn_blocking ─► bazel-mcp-bep + bazel-mcp-reducer
+      │               validated ordered BES frame batches
+      ├─ spawn_blocking ─► shared BEP capture pipeline
+      │                     durable raw frame gate -> reducer subscriber
       └────── await ─────► bazel-mcp-store
                               atomic manifest + detail sidecars
 ```


### PR DESCRIPTION
## Summary

- route tail, FIFO, post-hoc replay, and BES through one ordered capture pipeline
- persist exact raw BEP bytes before reduction, redaction, metadata, telemetry, or other subscribers
- remove durable file ownership from the BES server and acknowledge gRPC batches only after runner durability
- centralize remote-cache retry handling while preserving POSIX FIFO as an opt-in optimization
- add transport-parity, durability-ordering, retry, truncation, stop-and-wait, and raw-byte/redaction coverage

## Why

Capture behavior was split by transport: tail and FIFO performed runner-side processing while BES owned its durable file sink and was reduced after capture. That made ordering and durability guarantees transport-specific and complicated future subscribers such as progress reporting.

This refactor makes the durable writer the authoritative first path and feeds the same reduction subscriber from every capture source. Raw evidence stays byte-exact locally, while all persisted projections and model-visible output continue through redaction.

## Performance

Paired measurements compare this branch with baseline commit `109e183`.

| Benchmark | Baseline median | Refactor median | Change |
| --- | ---: | ---: | ---: |
| Isolated tail, 15,800 events | 1.012 ms | 1.078 ms | +0.065 ms |
| Isolated BES, 15,800 events | 200.496 ms | 43.953 ms | 78.1% lower; 4.56x throughput |
| Live Bazel tail | 273 ms | 269 ms | -1.5% |
| Live Bazel FIFO | 268 ms | 269 ms | +0.4% |
| Live Bazel BES | 271 ms | 272 ms | +0.4% |

Live medians are effectively flat. The isolated BES improvement comes from bounded batching with durability acknowledgement rather than per-event sink work. The complete methodology and p95 results are in `docs/bep-transport-performance.md`.

## Validation

- `make build`
- `make test`
- `cargo check --workspace --all-targets --all-features`
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo shear`
- `cargo deny check advisories bans licenses sources`
- `npm run check --prefix website`
- `npm run build --prefix website`
- `npm run check:links --prefix website`
- live MCP benchmark covering tail, FIFO, and BES

`make check` reached its Nix wrapper and stopped because Nix was unavailable on PATH; the underlying `cargo shear` check passed directly. A Windows cross-target was not installed locally, so Windows compilation is left to CI.
