### PR TITLE
fix(release): upload assets to existing releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -312,12 +312,21 @@ jobs:
           ANNOUNCEMENT_TITLE: "${{ fromJson(steps.host.outputs.manifest).announcement_title }}"
           ANNOUNCEMENT_BODY: "${{ fromJson(steps.host.outputs.manifest).announcement_github_body }}"
         run: |
-          if gh release view "$RELEASE_TAG" >/dev/null 2>&1; then
-            gh release upload "$RELEASE_TAG" artifacts/* --clobber
-          else
+          release_tag_uri="$(jq -rn --arg tag "$RELEASE_TAG" '$tag | @uri')"
+          lookup_error="$RUNNER_TEMP/release-lookup-error.txt"
+
+          if gh api --silent "repos/$GITHUB_REPOSITORY/releases/tags/$release_tag_uri" 2>"$lookup_error"; then
+            gh release upload "$RELEASE_TAG" artifacts/* --clobber --repo "$GITHUB_REPOSITORY"
+          elif grep -q '(HTTP 404)' "$lookup_error"; then
+            cat "$lookup_error" >&2
+            echo "No GitHub release exists for $RELEASE_TAG; creating it now."
             # Write and read notes from a file to avoid quoting breaking things.
             echo "$ANNOUNCEMENT_BODY" > "$RUNNER_TEMP/notes.txt"
-            gh release create "$RELEASE_TAG" $PRERELEASE_FLAG --title "$ANNOUNCEMENT_TITLE" --notes-file "$RUNNER_TEMP/notes.txt" artifacts/*
+            gh release create "$RELEASE_TAG" $PRERELEASE_FLAG --title "$ANNOUNCEMENT_TITLE" --notes-file "$RUNNER_TEMP/notes.txt" --repo "$GITHUB_REPOSITORY" artifacts/*
+          else
+            cat "$lookup_error" >&2
+            echo "Unable to determine whether the GitHub release exists; refusing to create a duplicate." >&2
+            exit 1
           fi
 
   publish-homebrew-formula:


### PR DESCRIPTION
## Summary

- replace the ambiguous `gh release view` preflight with an explicit REST lookup
- upload cargo-dist artifacts to releases already created by Release Please
- create a release only after a confirmed HTTP 404 and preserve other lookup errors
- target the repository explicitly for both upload and create operations

## Root cause

The v1.0.0 host job suppressed the error from `gh release view`. That probe returned nonzero even though Release Please had already created the release, so the workflow attempted `gh release create` and failed with `a release with the same tag name already exists` before attaching any assets.

## Validation

- `yq eval '.' .github/workflows/release.yml`
- extracted publish-step script passed `bash -n`
- `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.7 .github/workflows/release.yml`
- `uvx zizmor .github/workflows/release.yml`
- `python3 scripts/check-release-security.py`
- `git diff --check`

Tracks #63. The issue should be closed after the v1.0.0 artifacts are backfilled and verified.
