### PR TITLE
fix(release): publish assets through REST API

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,6 +104,7 @@ jobs:
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with: { persist-credentials: false }
+      - run: python3 -m unittest scripts/test_publish_github_release_assets.py
       - run: pipx run zizmor .github/workflows
   bazel-matrix:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -271,6 +271,16 @@ jobs:
           persist-credentials: false
           ref: ${{ env.RELEASE_TAG }}
           submodules: recursive
+      # Keep the publisher tied to the workflow revision so manual backfills of
+      # older tags still get the current release-upload behavior.
+      - name: Checkout release publisher
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: false
+          ref: ${{ github.workflow_sha }}
+          path: .release-workflow
+          sparse-checkout: scripts/publish_github_release_assets.py
+          sparse-checkout-cone-mode: false
       - name: Install dist
         shell: bash
         run: "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/v0.31.0/cargo-dist-installer.sh | sh"
@@ -308,26 +318,22 @@ jobs:
           rm -f artifacts/*-dist-manifest.json
       - name: Publish GitHub release artifacts
         env:
-          PRERELEASE_FLAG: "${{ fromJson(steps.host.outputs.manifest).announcement_is_prerelease && '--prerelease' || '' }}"
+          ANNOUNCEMENT_IS_PRERELEASE: "${{ fromJson(steps.host.outputs.manifest).announcement_is_prerelease }}"
           ANNOUNCEMENT_TITLE: "${{ fromJson(steps.host.outputs.manifest).announcement_title }}"
           ANNOUNCEMENT_BODY: "${{ fromJson(steps.host.outputs.manifest).announcement_github_body }}"
         run: |
-          release_tag_uri="$(jq -rn --arg tag "$RELEASE_TAG" '$tag | @uri')"
-          lookup_error="$RUNNER_TEMP/release-lookup-error.txt"
-
-          if gh api --silent "repos/$GITHUB_REPOSITORY/releases/tags/$release_tag_uri" 2>"$lookup_error"; then
-            gh release upload "$RELEASE_TAG" artifacts/* --clobber --repo "$GITHUB_REPOSITORY"
-          elif grep -q '(HTTP 404)' "$lookup_error"; then
-            cat "$lookup_error" >&2
-            echo "No GitHub release exists for $RELEASE_TAG; creating it now."
-            # Write and read notes from a file to avoid quoting breaking things.
-            echo "$ANNOUNCEMENT_BODY" > "$RUNNER_TEMP/notes.txt"
-            gh release create "$RELEASE_TAG" $PRERELEASE_FLAG --title "$ANNOUNCEMENT_TITLE" --notes-file "$RUNNER_TEMP/notes.txt" --repo "$GITHUB_REPOSITORY" artifacts/*
-          else
-            cat "$lookup_error" >&2
-            echo "Unable to determine whether the GitHub release exists; refusing to create a duplicate." >&2
-            exit 1
+          echo "$ANNOUNCEMENT_BODY" > "$RUNNER_TEMP/notes.txt"
+          publish_args=(
+            --repository "$GITHUB_REPOSITORY"
+            --tag "$RELEASE_TAG"
+            --artifacts artifacts
+            --title "$ANNOUNCEMENT_TITLE"
+            --notes-file "$RUNNER_TEMP/notes.txt"
+          )
+          if [[ "$ANNOUNCEMENT_IS_PRERELEASE" == "true" ]]; then
+            publish_args+=(--prerelease)
           fi
+          python3 .release-workflow/scripts/publish_github_release_assets.py "${publish_args[@]}"
 
   publish-homebrew-formula:
     needs:

--- a/scripts/publish_github_release_assets.py
+++ b/scripts/publish_github_release_assets.py
@@ -1,0 +1,283 @@
+#!/usr/bin/env python3
+"""Publish cargo-dist artifacts without GitHub CLI release discovery."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Callable
+from urllib.error import HTTPError, URLError
+from urllib.parse import quote, urlencode
+from urllib.request import Request, urlopen
+
+RETRYABLE_STATUSES = {0, 429, 500, 502, 503, 504}
+
+
+class PublishError(RuntimeError):
+    pass
+
+
+@dataclass(frozen=True)
+class HttpResult:
+    status: int
+    body: bytes
+
+    def json(self) -> Any:
+        return json.loads(self.body)
+
+
+class GitHubClient:
+    def __init__(
+        self,
+        token: str,
+        *,
+        max_attempts: int = 5,
+        sleep: Callable[[float], None] = time.sleep,
+    ) -> None:
+        self.token = token
+        self.max_attempts = max_attempts
+        self.sleep = sleep
+
+    def request_once(
+        self,
+        method: str,
+        url: str,
+        *,
+        authenticated: bool = True,
+        body: bytes | None = None,
+        content_type: str = "application/vnd.github+json",
+    ) -> HttpResult:
+        headers = {
+            "Accept": "application/vnd.github+json",
+            "Content-Type": content_type,
+            "X-GitHub-Api-Version": "2022-11-28",
+        }
+        if authenticated:
+            headers["Authorization"] = f"Bearer {self.token}"
+        request = Request(
+            url,
+            data=body,
+            method=method,
+            headers=headers,
+        )
+        try:
+            with urlopen(request, timeout=120) as response:
+                return HttpResult(response.status, response.read())
+        except HTTPError as error:
+            try:
+                return HttpResult(error.code, error.read())
+            finally:
+                error.close()
+        except URLError as error:
+            return HttpResult(0, str(error).encode())
+
+    def request(
+        self,
+        method: str,
+        url: str,
+        *,
+        authenticated: bool = True,
+        body: bytes | None = None,
+        content_type: str = "application/vnd.github+json",
+    ) -> HttpResult:
+        for attempt in range(1, self.max_attempts + 1):
+            result = self.request_once(
+                method,
+                url,
+                authenticated=authenticated,
+                body=body,
+                content_type=content_type,
+            )
+            if result.status not in RETRYABLE_STATUSES or attempt == self.max_attempts:
+                return result
+            self.sleep(attempt * 3)
+        raise AssertionError("unreachable")
+
+
+class ReleasePublisher:
+    def __init__(
+        self,
+        client: GitHubClient,
+        repository: str,
+        tag: str,
+        *,
+        api_url: str = "https://api.github.com",
+    ) -> None:
+        self.client = client
+        self.repository = repository
+        self.tag = tag
+        self.api_url = api_url.rstrip("/")
+        self.release_by_tag_url = (
+            f"{self.api_url}/repos/{repository}/releases/tags/{quote(tag, safe='')}"
+        )
+        self.releases_url = f"{self.api_url}/repos/{repository}/releases"
+
+    @staticmethod
+    def _require(result: HttpResult, expected: set[int], operation: str) -> None:
+        if result.status in expected:
+            return
+        detail = result.body.decode("utf-8", errors="replace")[:1000]
+        raise PublishError(f"{operation} failed with HTTP {result.status}: {detail}")
+
+    def lookup_release(self, *, authenticated: bool = False) -> dict[str, Any] | None:
+        result = self.client.request(
+            "GET", self.release_by_tag_url, authenticated=authenticated
+        )
+        if result.status == 404:
+            return None
+        self._require(result, {200}, "release lookup")
+        return result.json()
+
+    def create_draft_release(
+        self, title: str, notes: str, prerelease: bool
+    ) -> dict[str, Any]:
+        payload = json.dumps(
+            {
+                "tag_name": self.tag,
+                "name": title,
+                "body": notes,
+                "draft": True,
+                "prerelease": prerelease,
+            }
+        ).encode()
+        for attempt in range(1, self.client.max_attempts + 1):
+            result = self.client.request_once("POST", self.releases_url, body=payload)
+            if result.status == 201:
+                return result.json()
+            if result.status in RETRYABLE_STATUSES:
+                existing = self.lookup_release(authenticated=True)
+                if existing is not None:
+                    return existing
+                if attempt < self.client.max_attempts:
+                    self.client.sleep(attempt * 3)
+                    continue
+            self._require(result, {201}, "draft release creation")
+        raise AssertionError("unreachable")
+
+    def list_assets(self, release_id: int) -> list[dict[str, Any]]:
+        assets: list[dict[str, Any]] = []
+        page = 1
+        while True:
+            url = f"{self.releases_url}/{release_id}/assets?" + urlencode(
+                {"per_page": 100, "page": page}
+            )
+            result = self.client.request("GET", url, authenticated=False)
+            self._require(result, {200}, "release asset listing")
+            batch = result.json()
+            assets.extend(batch)
+            if len(batch) < 100:
+                return assets
+            page += 1
+
+    def delete_asset(self, asset_id: int) -> None:
+        url = f"{self.api_url}/repos/{self.repository}/releases/assets/{asset_id}"
+        result = self.client.request("DELETE", url)
+        self._require(result, {204, 404}, "release asset deletion")
+
+    def upload_asset(self, release: dict[str, Any], artifact: Path) -> None:
+        release_id = int(release["id"])
+        for asset in self.list_assets(release_id):
+            if asset["name"] == artifact.name:
+                self.delete_asset(int(asset["id"]))
+
+        upload_base = str(release["upload_url"]).split("{", 1)[0]
+        upload_url = f"{upload_base}?{urlencode({'name': artifact.name})}"
+        content = artifact.read_bytes()
+        for attempt in range(1, self.client.max_attempts + 1):
+            result = self.client.request_once(
+                "POST",
+                upload_url,
+                body=content,
+                content_type="application/octet-stream",
+            )
+            if result.status == 201:
+                print(f"uploaded: {artifact.name}")
+                return
+
+            if result.status in RETRYABLE_STATUSES | {422}:
+                matching = [
+                    asset
+                    for asset in self.list_assets(release_id)
+                    if asset["name"] == artifact.name
+                ]
+                if any(
+                    asset.get("state") == "uploaded"
+                    and int(asset.get("size", -1)) == len(content)
+                    for asset in matching
+                ):
+                    print(f"uploaded after HTTP {result.status}: {artifact.name}")
+                    return
+                for asset in matching:
+                    self.delete_asset(int(asset["id"]))
+                if attempt < self.client.max_attempts:
+                    self.client.sleep(attempt * 3)
+                    continue
+
+            self._require(result, {201}, f"upload of {artifact.name}")
+        raise AssertionError("unreachable")
+
+    def publish_release(self, release_id: int) -> None:
+        url = f"{self.releases_url}/{release_id}"
+        result = self.client.request("PATCH", url, body=b'{"draft":false}')
+        self._require(result, {200}, "draft release publication")
+
+    def publish(
+        self, artifacts: Path, *, title: str, notes: str, prerelease: bool
+    ) -> None:
+        release = self.lookup_release()
+        if release is None:
+            release = self.create_draft_release(title, notes, prerelease)
+        should_publish = bool(release.get("draft"))
+
+        files = sorted(path for path in artifacts.iterdir() if path.is_file())
+        if not files:
+            raise PublishError(f"no release artifacts found in {artifacts}")
+        for artifact in files:
+            self.upload_asset(release, artifact)
+
+        if should_publish:
+            self.publish_release(int(release["id"]))
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--repository", required=True)
+    parser.add_argument("--tag", required=True)
+    parser.add_argument("--artifacts", required=True, type=Path)
+    parser.add_argument("--title", required=True)
+    parser.add_argument("--notes-file", required=True, type=Path)
+    parser.add_argument("--prerelease", action="store_true")
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    token = os.environ.get("GH_TOKEN")
+    if not token:
+        raise PublishError("GH_TOKEN is required")
+    publisher = ReleasePublisher(
+        GitHubClient(token),
+        args.repository,
+        args.tag,
+        api_url=os.environ.get("GITHUB_API_URL", "https://api.github.com"),
+    )
+    publisher.publish(
+        args.artifacts,
+        title=args.title,
+        notes=args.notes_file.read_text(),
+        prerelease=args.prerelease,
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        sys.exit(main())
+    except PublishError as error:
+        print(error, file=sys.stderr)
+        sys.exit(1)

--- a/scripts/test_publish_github_release_assets.py
+++ b/scripts/test_publish_github_release_assets.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env python3
+
+import io
+import json
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import Mock, patch
+from urllib.error import HTTPError
+
+from scripts.publish_github_release_assets import (
+    GitHubClient,
+    HttpResult,
+    ReleasePublisher,
+)
+
+
+def release(*, draft: bool = False) -> dict[str, object]:
+    return {
+        "id": 42,
+        "draft": draft,
+        "upload_url": "https://uploads.github.com/repos/o/r/releases/42/assets{?name,label}",
+    }
+
+
+class ReleasePublisherTests(unittest.TestCase):
+    def artifact_dir(self) -> tuple[tempfile.TemporaryDirectory[str], Path]:
+        directory = tempfile.TemporaryDirectory()
+        root = Path(directory.name)
+        (root / "artifact.tar.xz").write_bytes(b"artifact")
+        return directory, root
+
+    def test_uploads_to_existing_release(self) -> None:
+        directory, root = self.artifact_dir()
+        self.addCleanup(directory.cleanup)
+        client = Mock(max_attempts=5, sleep=Mock())
+        client.request.side_effect = [
+            HttpResult(200, json.dumps(release()).encode()),
+            HttpResult(200, b"[]"),
+        ]
+        client.request_once.return_value = HttpResult(201, b"{}")
+
+        ReleasePublisher(client, "o/r", "v1").publish(
+            root, title="v1", notes="notes", prerelease=False
+        )
+
+        self.assertEqual(client.request_once.call_count, 1)
+
+    def test_accepts_ambiguous_upload_when_asset_is_present(self) -> None:
+        directory, root = self.artifact_dir()
+        self.addCleanup(directory.cleanup)
+        client = Mock(max_attempts=5, sleep=Mock())
+        client.request.side_effect = [
+            HttpResult(200, json.dumps(release()).encode()),
+            HttpResult(200, b"[]"),
+            HttpResult(
+                200,
+                b'[{"id":7,"name":"artifact.tar.xz","state":"uploaded","size":8}]',
+            ),
+        ]
+        client.request_once.return_value = HttpResult(503, b"unavailable")
+
+        ReleasePublisher(client, "o/r", "v1").publish(
+            root, title="v1", notes="notes", prerelease=False
+        )
+
+        client.sleep.assert_not_called()
+
+    def test_creates_draft_then_publishes_after_upload(self) -> None:
+        directory, root = self.artifact_dir()
+        self.addCleanup(directory.cleanup)
+        client = Mock(max_attempts=5, sleep=Mock())
+        client.request.side_effect = [
+            HttpResult(404, b"{}"),
+            HttpResult(200, b"[]"),
+            HttpResult(200, b"{}"),
+        ]
+        client.request_once.side_effect = [
+            HttpResult(201, json.dumps(release(draft=True)).encode()),
+            HttpResult(201, b"{}"),
+        ]
+
+        ReleasePublisher(client, "o/r", "v1").publish(
+            root, title="v1", notes="notes", prerelease=False
+        )
+
+        patch_call = client.request.call_args_list[-1]
+        self.assertEqual(patch_call.args[0], "PATCH")
+
+    @patch("scripts.publish_github_release_assets.urlopen")
+    def test_client_retries_http_503(self, mocked_urlopen: Mock) -> None:
+        unavailable = HTTPError(
+            "https://api.github.test/release",
+            503,
+            "unavailable",
+            {},
+            io.BytesIO(b"unavailable"),
+        )
+        response = Mock(status=200)
+        response.read.return_value = b"{}"
+        response.__enter__ = Mock(return_value=response)
+        response.__exit__ = Mock(return_value=False)
+        mocked_urlopen.side_effect = [unavailable, response]
+        sleep = Mock()
+
+        result = GitHubClient("token", sleep=sleep).request(
+            "GET", "https://api.github.test/release"
+        )
+
+        self.assertEqual(result.status, 200)
+        sleep.assert_called_once_with(3)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- bypass the GitHub CLI release discovery path that cannot see the existing v1.0.0 release
- publish release assets through the documented REST and upload endpoints
- retry transient 429 and 5xx responses with bounded backoff
- make uploads idempotent after ambiguous responses and clean up incomplete starter assets
- create independent tag releases as drafts, attach all assets, then publish them
- check out the publisher from the workflow revision so old-tag backfills use the current upload logic
- run the publisher unit tests in CI

## Root cause

The original host job suppressed a failure from `gh release view` and then tried to create a duplicate release. PR #64 made that lookup fail closed and exposed the underlying response: authenticated release reads were returning GitHub HTTP 503 Unicorn pages. The same credential could write release assets directly, while public release metadata reads succeeded. The `gh release upload` command therefore remained unable to discover v1.0.0 even though the release existed.

This change separates public release metadata reads from authenticated writes and uses the documented release asset API directly.

## Validation

- four publisher unit tests cover existing releases, draft creation/publication, 503 retry, and ambiguous upload recovery
- production smoke test replaced `dist-manifest.json` on v1.0.0 through the new publisher and verified the stable download byte-for-byte
- `actionlint` passed for CI and release workflows
- `zizmor` reported no findings
- Ruff check and format validation passed
- release security, YAML parsing, extracted shell syntax, Python compilation, and `git diff --check` passed

The v1.0.0 release has also been manually repaired with all 22 generated assets; ARM64 macOS and Linux downloads match their published SHA-256 files.

Tracks #63; close after this durable fix is merged.
