### PR TITLE
ci: speed up Windows validation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,6 +66,17 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with: { persist-credentials: false }
       - run: cargo check --workspace --all-targets --all-features
+  windows-release-smoke:
+    runs-on: windows-latest
+    timeout-minutes: 30
+    # PR CI validates native linking, archive layout, and startup. Tagged releases
+    # retain the fully optimized dist profile from Cargo.toml.
+    env:
+      CARGO_PROFILE_DIST_CODEGEN_UNITS: "16"
+      CARGO_PROFILE_DIST_LTO: "off"
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with: { persist-credentials: false }
       - name: Install dist
         shell: pwsh
         run: irm https://github.com/axodotdev/cargo-dist/releases/download/v0.31.0/cargo-dist-installer.ps1 | iex


### PR DESCRIPTION
## Summary

- run the all-targets Windows check and native release archive smoke as independent jobs so they execute in parallel
- disable LTO and restore 16 codegen units only for the PR archive smoke build
- preserve the fully optimized `[profile.dist]` settings for tagged releases

## Why

Recent Windows CI runs took roughly 10-12 minutes. In the latest baseline, `cargo check` took 2m35s, the optimized archive build took 9m27s, and extracting the archive plus running `bazel-mcp.exe --version` took one second.

The PR job is validating Windows linking, cargo-dist archive layout, and executable startup. It does not need the production release's thin LTO and single codegen unit. Running the compile-coverage and archive checks in parallel also removes the check phase from the packaging job's critical path.

## Results

| Measurement | Before | After | Change |
| --- | ---: | ---: | ---: |
| Windows critical path | 12m16s | 6m08s | 50% faster |
| Archive build | 9m27s | 5m44s | 39% faster |
| All-targets check | 2m35s sequential | 2m27s parallel | removed from critical path |
| Archive smoke | 1s | 1s | unchanged |

The new `windows-release-smoke` and `cargo-check-windows` jobs both passed on the first PR run.

## Validation

- `CARGO_PROFILE_DIST_CODEGEN_UNITS=16 CARGO_PROFILE_DIST_LTO=off cargo build -p bazel-mcp-server --bin bazel-mcp --profile dist`
- `python3 scripts/check-release-please-config.py`
- `uvx zizmor .github/workflows`
- `git diff --check`
- full GitHub CI, including native Windows archive build and smoke test
