### PR TITLE
fix(runner): coordinate shared Bazel output bases

### DIFF
--- a/LEARNINGS.md
+++ b/LEARNINGS.md
@@ -19,6 +19,12 @@ unrelated to MCP efficiency. Do not include secrets or raw sensitive output.
 
 ### 2026-07-16
 
+- Separate bazel-mcp processes sharing an output base bypassed the in-memory
+  scheduler, while direct Bazel contention remained an opaque portion of wall
+  time; coordinate every known output-base request with a user-scoped advisory
+  lock, preserve Bazel's native wait-and-takeover behavior, and expose only a
+  bounded owner label plus the combined wait duration. Thread:
+  `019f6db5-c3bf-77c1-9524-4fed404237c0`.
 - Listing full durable invocation records exhausted 8 KiB and destructive byte
   shrinking erased IDs and states; keep ledger rows compact and direct users to
   per-invocation views for canonical arguments and detailed diagnostics.

--- a/crates/bazel-mcp-runner/src/lib.rs
+++ b/crates/bazel-mcp-runner/src/lib.rs
@@ -2,11 +2,12 @@
 
 mod cancel;
 mod capture;
+mod output_base_lock;
 mod service;
 mod version;
 
 pub use bazel_mcp_reducer::{StarlarkLimits, StarlarkReducerConfig};
 pub use service::{
-    BepTransport, CancelResult, InspectRequest, InspectResult, InspectView, InvocationService,
-    RunnerConfig, RunnerError,
+    BepTransport, CancelResult, InspectRequest, InspectResult, InspectView, InvocationProgress,
+    InvocationService, RunnerConfig, RunnerError,
 };

--- a/crates/bazel-mcp-runner/src/output_base_lock.rs
+++ b/crates/bazel-mcp-runner/src/output_base_lock.rs
@@ -1,0 +1,457 @@
+use std::{
+    fs::{File, OpenOptions},
+    io::{self, Read, Seek, SeekFrom, Write},
+    path::{Path, PathBuf},
+    sync::{Arc, Mutex as StdMutex},
+    time::{Duration, Instant},
+};
+
+use bazel_mcp_types::{InvocationId, unix_timestamp_ms};
+use serde::{Deserialize, Serialize};
+use tokio::{task, task::JoinHandle};
+use tokio_util::sync::CancellationToken;
+
+const LOCK_POLL_INTERVAL: Duration = Duration::from_millis(50);
+const NATIVE_WAIT_POLL_INTERVAL: Duration = Duration::from_millis(100);
+const NATIVE_WAIT_DETECTION_WINDOW: Duration = Duration::from_secs(2);
+const NATIVE_LOCK_MARKER: &[u8] = b"Another command holds the output base lock:";
+const NATIVE_WAIT_MARKER: &[u8] = b"Waiting for it to complete...";
+const NATIVE_WAIT_TAIL_BYTES: usize = 32 * 1024;
+const OWNER_BYTES_LIMIT: u64 = 4 * 1024;
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) struct OutputBaseWaitSnapshot {
+    pub(crate) active: bool,
+    pub(crate) elapsed_ms: u64,
+    pub(crate) owner: Option<String>,
+}
+
+#[derive(Default)]
+pub(crate) struct OutputBaseWaitStatus {
+    inner: StdMutex<OutputBaseWaitTiming>,
+}
+
+#[derive(Default)]
+struct OutputBaseWaitTiming {
+    active_since: Option<Instant>,
+    accumulated: Duration,
+    owner: Option<String>,
+}
+
+impl OutputBaseWaitStatus {
+    pub(crate) fn begin(&self, owner: Option<String>) {
+        let mut timing = self.inner.lock().unwrap_or_else(|error| error.into_inner());
+        if timing.active_since.is_none() {
+            timing.active_since = Some(Instant::now());
+            timing.owner = owner;
+        } else if timing.owner.is_none() {
+            timing.owner = owner;
+        }
+    }
+
+    pub(crate) fn end(&self) {
+        let mut timing = self.inner.lock().unwrap_or_else(|error| error.into_inner());
+        if let Some(started) = timing.active_since.take() {
+            timing.accumulated = timing.accumulated.saturating_add(started.elapsed());
+        }
+        timing.owner = None;
+    }
+
+    pub(crate) fn snapshot(&self) -> OutputBaseWaitSnapshot {
+        let timing = self.inner.lock().unwrap_or_else(|error| error.into_inner());
+        let elapsed = timing.accumulated.saturating_add(
+            timing
+                .active_since
+                .map_or(Duration::ZERO, |started| started.elapsed()),
+        );
+        OutputBaseWaitSnapshot {
+            active: timing.active_since.is_some(),
+            elapsed_ms: duration_millis(elapsed),
+            owner: timing.owner.clone(),
+        }
+    }
+}
+
+pub(crate) enum OutputBaseLockAcquisition {
+    Acquired(OutputBaseLockGuard),
+    Cancelled,
+}
+
+pub(crate) struct OutputBaseLockGuard {
+    file: File,
+}
+
+impl Drop for OutputBaseLockGuard {
+    fn drop(&mut self) {
+        let _ = self.file.unlock();
+    }
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+struct LockOwner {
+    pid: u32,
+    invocation_id: InvocationId,
+    acquired_at_ms: i64,
+}
+
+enum LockAttempt {
+    Acquired(OutputBaseLockGuard),
+    Busy(Option<LockOwner>),
+}
+
+pub(crate) fn default_output_base_lock_root() -> PathBuf {
+    #[cfg(unix)]
+    {
+        // Use a process-environment-independent root so MCP instances launched
+        // by different hosts still share one advisory-lock namespace.
+        // SAFETY: geteuid has no preconditions and does not mutate memory.
+        let identity = unsafe { libc::geteuid() };
+        PathBuf::from("/tmp").join(format!("bazel-mcp-output-base-locks-{identity}"))
+    }
+    #[cfg(not(unix))]
+    {
+        let user = std::env::var_os("USERNAME")
+            .or_else(|| std::env::var_os("USER"))
+            .unwrap_or_default();
+        let identity = blake3::hash(user.to_string_lossy().as_bytes()).to_hex()[..16].to_owned();
+        std::env::temp_dir().join(format!("bazel-mcp-output-base-locks-{identity}"))
+    }
+}
+
+pub(crate) async fn acquire(
+    root: &Path,
+    key: &Path,
+    invocation_id: InvocationId,
+    cancellation: CancellationToken,
+    wait_status: Arc<OutputBaseWaitStatus>,
+) -> Result<OutputBaseLockAcquisition, io::Error> {
+    tokio::fs::create_dir_all(root).await?;
+    set_private_directory(root).await?;
+    let digest = output_base_key_digest(key);
+    let path = root.join(format!("{digest}.lock"));
+    let owner = LockOwner {
+        pid: std::process::id(),
+        invocation_id,
+        acquired_at_ms: unix_timestamp_ms(),
+    };
+    let mut waiting = false;
+
+    loop {
+        if cancellation.is_cancelled() {
+            if waiting {
+                wait_status.end();
+            }
+            return Ok(OutputBaseLockAcquisition::Cancelled);
+        }
+        let attempt_path = path.clone();
+        let attempt_owner = owner.clone();
+        let attempt = task::spawn_blocking(move || try_lock(&attempt_path, &attempt_owner))
+            .await
+            .map_err(io::Error::other)??;
+        match attempt {
+            LockAttempt::Acquired(guard) => {
+                if waiting {
+                    wait_status.end();
+                }
+                return Ok(OutputBaseLockAcquisition::Acquired(guard));
+            }
+            LockAttempt::Busy(current_owner) => {
+                if !waiting {
+                    let owner = current_owner.map(|owner| format!("bazel_mcp:pid={}", owner.pid));
+                    wait_status.begin(owner);
+                    waiting = true;
+                }
+                tokio::select! {
+                    () = cancellation.cancelled() => {
+                        wait_status.end();
+                        return Ok(OutputBaseLockAcquisition::Cancelled);
+                    }
+                    () = tokio::time::sleep(LOCK_POLL_INTERVAL) => {}
+                }
+            }
+        }
+    }
+}
+
+fn output_base_key_digest(key: &Path) -> blake3::Hash {
+    #[cfg(unix)]
+    {
+        use std::os::unix::ffi::OsStrExt;
+        blake3::hash(key.as_os_str().as_bytes())
+    }
+    #[cfg(not(unix))]
+    {
+        blake3::hash(key.to_string_lossy().as_bytes())
+    }
+}
+
+fn try_lock(path: &Path, owner: &LockOwner) -> io::Result<LockAttempt> {
+    let mut options = OpenOptions::new();
+    options.create(true).read(true).write(true).truncate(false);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        options.mode(0o600);
+    }
+    let mut file = options.open(path)?;
+    set_private_file(&file)?;
+    match file.try_lock() {
+        Ok(()) => {
+            file.set_len(0)?;
+            file.seek(SeekFrom::Start(0))?;
+            serde_json::to_writer(&mut file, owner).map_err(io::Error::other)?;
+            file.write_all(b"\n")?;
+            file.flush()?;
+            Ok(LockAttempt::Acquired(OutputBaseLockGuard { file }))
+        }
+        Err(std::fs::TryLockError::WouldBlock) => {
+            file.seek(SeekFrom::Start(0))?;
+            let mut bytes = Vec::new();
+            file.take(OWNER_BYTES_LIMIT).read_to_end(&mut bytes)?;
+            let owner = serde_json::from_slice(&bytes).ok();
+            Ok(LockAttempt::Busy(owner))
+        }
+        Err(std::fs::TryLockError::Error(error)) => Err(error),
+    }
+}
+
+pub(crate) struct NativeOutputBaseWaitObserver {
+    cancellation: CancellationToken,
+    task: Option<JoinHandle<()>>,
+    wait_status: Arc<OutputBaseWaitStatus>,
+}
+
+impl NativeOutputBaseWaitObserver {
+    pub(crate) fn start(
+        stdout: PathBuf,
+        stderr: PathBuf,
+        bep: PathBuf,
+        wait_status: Arc<OutputBaseWaitStatus>,
+    ) -> Self {
+        let cancellation = CancellationToken::new();
+        let task_cancellation = cancellation.clone();
+        let task_status = wait_status.clone();
+        let task = tokio::spawn(async move {
+            observe_native_wait(stdout, stderr, bep, task_status, task_cancellation).await;
+        });
+        Self {
+            cancellation,
+            task: Some(task),
+            wait_status,
+        }
+    }
+
+    pub(crate) async fn finish(mut self) {
+        self.cancellation.cancel();
+        if let Some(task) = self.task.take() {
+            let _ = task.await;
+        }
+        self.wait_status.end();
+    }
+}
+
+impl Drop for NativeOutputBaseWaitObserver {
+    fn drop(&mut self) {
+        self.cancellation.cancel();
+        if let Some(task) = self.task.take() {
+            task.abort();
+        }
+        self.wait_status.end();
+    }
+}
+
+async fn observe_native_wait(
+    stdout: PathBuf,
+    stderr: PathBuf,
+    bep: PathBuf,
+    wait_status: Arc<OutputBaseWaitStatus>,
+    cancellation: CancellationToken,
+) {
+    let detection_started = Instant::now();
+    let mut waiting = false;
+    let mut waiting_marker_end = None;
+    let mut baseline_stdout = 0;
+    let mut baseline_bep = 0;
+    let mut baseline_stderr_len = 0;
+
+    loop {
+        let stderr_tail = read_bounded_tail(&stderr, NATIVE_WAIT_TAIL_BYTES)
+            .await
+            .unwrap_or_default();
+        if !waiting {
+            if contains(&stderr_tail, NATIVE_LOCK_MARKER)
+                || contains(&stderr_tail, NATIVE_WAIT_MARKER)
+            {
+                wait_status.begin(Some("bazel_client".to_owned()));
+                waiting = true;
+                baseline_stdout = file_size(&stdout).await;
+                baseline_bep = file_size(&bep).await;
+            } else if detection_started.elapsed() >= NATIVE_WAIT_DETECTION_WINDOW
+                || file_size(&stdout).await > 0
+                || file_size(&bep).await > 0
+            {
+                return;
+            }
+        }
+
+        if waiting {
+            if let Some(position) = find(&stderr_tail, NATIVE_WAIT_MARKER) {
+                let marker_end = position.saturating_add(NATIVE_WAIT_MARKER.len());
+                waiting_marker_end.get_or_insert(marker_end);
+                baseline_stderr_len = baseline_stderr_len.max(stderr_tail.len());
+                if stderr_tail[marker_end..]
+                    .iter()
+                    .any(|byte| !byte.is_ascii_whitespace())
+                {
+                    wait_status.end();
+                    return;
+                }
+            }
+            if waiting_marker_end.is_some()
+                && (file_size(&stdout).await > baseline_stdout
+                    || file_size(&bep).await > baseline_bep
+                    || stderr_tail.len() > baseline_stderr_len)
+            {
+                wait_status.end();
+                return;
+            }
+        }
+
+        tokio::select! {
+            () = cancellation.cancelled() => {
+                if waiting {
+                    wait_status.end();
+                }
+                return;
+            }
+            () = tokio::time::sleep(NATIVE_WAIT_POLL_INTERVAL) => {}
+        }
+    }
+}
+
+async fn read_bounded_tail(path: &Path, maximum_bytes: usize) -> io::Result<Vec<u8>> {
+    use tokio::io::{AsyncReadExt, AsyncSeekExt};
+
+    let mut file = tokio::fs::File::open(path).await?;
+    let length = file.metadata().await?.len();
+    let tail_length = length.min(u64::try_from(maximum_bytes).unwrap_or(u64::MAX));
+    file.seek(SeekFrom::Start(length.saturating_sub(tail_length)))
+        .await?;
+    let mut data = Vec::with_capacity(usize::try_from(tail_length).unwrap_or(maximum_bytes));
+    file.read_to_end(&mut data).await?;
+    Ok(data)
+}
+
+async fn file_size(path: &Path) -> u64 {
+    tokio::fs::metadata(path)
+        .await
+        .map_or(0, |metadata| metadata.len())
+}
+
+fn contains(haystack: &[u8], needle: &[u8]) -> bool {
+    find(haystack, needle).is_some()
+}
+
+fn find(haystack: &[u8], needle: &[u8]) -> Option<usize> {
+    (!needle.is_empty())
+        .then(|| {
+            haystack
+                .windows(needle.len())
+                .position(|window| window == needle)
+        })
+        .flatten()
+}
+
+async fn set_private_directory(path: &Path) -> io::Result<()> {
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        tokio::fs::set_permissions(path, std::fs::Permissions::from_mode(0o700)).await?;
+    }
+    Ok(())
+}
+
+fn set_private_file(file: &File) -> io::Result<()> {
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        file.set_permissions(std::fs::Permissions::from_mode(0o600))?;
+    }
+    Ok(())
+}
+
+fn duration_millis(duration: Duration) -> u64 {
+    u64::try_from(duration.as_millis()).unwrap_or(u64::MAX)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn wait_status_accumulates_multiple_segments() {
+        let status = OutputBaseWaitStatus::default();
+        status.begin(Some("first".to_owned()));
+        assert!(status.snapshot().active);
+        status.end();
+        status.begin(Some("second".to_owned()));
+        let snapshot = status.snapshot();
+        assert!(snapshot.active);
+        assert_eq!(snapshot.owner.as_deref(), Some("second"));
+        status.end();
+        assert!(!status.snapshot().active);
+    }
+
+    #[tokio::test]
+    async fn file_lock_wait_is_cancellable_and_released_by_drop() {
+        let root = tempfile::tempdir().unwrap();
+        let key = root.path().join("shared-output-base");
+        let first_status = Arc::new(OutputBaseWaitStatus::default());
+        let first = acquire(
+            root.path(),
+            &key,
+            InvocationId::new(),
+            CancellationToken::new(),
+            first_status,
+        )
+        .await
+        .unwrap();
+        let OutputBaseLockAcquisition::Acquired(first) = first else {
+            panic!("first lock acquisition was cancelled");
+        };
+
+        let cancellation = CancellationToken::new();
+        let second_status = Arc::new(OutputBaseWaitStatus::default());
+        let second = tokio::spawn({
+            let root = root.path().to_owned();
+            let key = key.clone();
+            let cancellation = cancellation.clone();
+            let status = second_status.clone();
+            async move {
+                acquire(&root, &key, InvocationId::new(), cancellation, status)
+                    .await
+                    .unwrap()
+            }
+        });
+        while !second_status.snapshot().active {
+            tokio::task::yield_now().await;
+        }
+        cancellation.cancel();
+        assert!(matches!(
+            second.await.unwrap(),
+            OutputBaseLockAcquisition::Cancelled
+        ));
+
+        drop(first);
+        let third = acquire(
+            root.path(),
+            &key,
+            InvocationId::new(),
+            CancellationToken::new(),
+            Arc::new(OutputBaseWaitStatus::default()),
+        )
+        .await
+        .unwrap();
+        assert!(matches!(third, OutputBaseLockAcquisition::Acquired(_)));
+    }
+}

--- a/crates/bazel-mcp-runner/src/service.rs
+++ b/crates/bazel-mcp-runner/src/service.rs
@@ -43,6 +43,10 @@ use tokio_util::sync::CancellationToken;
 use crate::{
     cancel::{ProcessGroupGuard, terminate_child},
     capture,
+    output_base_lock::{
+        NativeOutputBaseWaitObserver, OutputBaseLockAcquisition, OutputBaseWaitStatus,
+        acquire as acquire_output_base_lock, default_output_base_lock_root,
+    },
     version::detect_bazel_version,
 };
 
@@ -75,6 +79,7 @@ pub struct RunnerConfig {
     pub allow_unsupported_bazel_versions: bool,
     pub version_check_timeout: Duration,
     pub maximum_pending_invocations: usize,
+    pub output_base_lock_root: PathBuf,
     pub bep_transport: BepTransport,
     pub starlark_reducers: StarlarkReducerConfig,
 }
@@ -94,6 +99,7 @@ impl Default for RunnerConfig {
             allow_unsupported_bazel_versions: false,
             version_check_timeout: Duration::from_secs(30),
             maximum_pending_invocations: 256,
+            output_base_lock_root: default_output_base_lock_root(),
             bep_transport: BepTransport::Tail,
             starlark_reducers: StarlarkReducerConfig::default(),
         }
@@ -152,6 +158,7 @@ pub struct InvocationService {
     global: Arc<Semaphore>,
     pending: Arc<Semaphore>,
     workspace_locks: Arc<Mutex<HashMap<PathBuf, Weak<Mutex<()>>>>>,
+    output_base_waits: Arc<Mutex<HashMap<InvocationId, Arc<OutputBaseWaitStatus>>>>,
     live: Arc<Mutex<HashMap<InvocationId, CancellationToken>>>,
     version_cache: Arc<Mutex<HashMap<VersionCacheKey, u32>>>,
     bes: Option<BesServer>,
@@ -169,10 +176,19 @@ struct PreparedSubmission {
     queued: InvocationRecord,
     paths: InvocationPaths,
     lock_key: PathBuf,
+    output_base_wait: Arc<OutputBaseWaitStatus>,
     executable: PathBuf,
     cancellation: CancellationToken,
     _pending_permit: OwnedSemaphorePermit,
     deferred: bool,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct InvocationProgress {
+    pub state: InvocationState,
+    pub phase: Option<&'static str>,
+    pub output_base_lock_wait_ms: u64,
+    pub output_base_lock_owner: Option<String>,
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]
@@ -320,6 +336,11 @@ impl InvocationService {
                 "isolated Bazel server idle timeout must be greater than zero",
             ));
         }
+        if config.output_base_lock_root.as_os_str().is_empty() {
+            return Err(RunnerError::InvalidConfiguration(
+                "output-base lock root must not be empty",
+            ));
+        }
         if !config.allow_unsupported_bazel_versions
             && config.supported_bazel_major_versions.is_empty()
         {
@@ -338,6 +359,7 @@ impl InvocationService {
             config,
             redactor,
             workspace_locks: Arc::new(Mutex::new(HashMap::new())),
+            output_base_waits: Arc::new(Mutex::new(HashMap::new())),
             live: Arc::new(Mutex::new(HashMap::new())),
             version_cache: Arc::new(Mutex::new(HashMap::new())),
             bes,
@@ -366,6 +388,7 @@ impl InvocationService {
         let id = prepared.queued.request.id;
         let result = self.run_prepared(prepared).await;
         self.live.lock().await.remove(&id);
+        self.output_base_waits.lock().await.remove(&id);
         result
     }
 
@@ -416,6 +439,7 @@ impl InvocationService {
                 }
             }
             supervisor.live.lock().await.remove(&id);
+            supervisor.output_base_waits.lock().await.remove(&id);
         });
         Ok(id)
     }
@@ -558,12 +582,18 @@ impl InvocationService {
             .store
             .create_invocation_with_deferred(&stored, deferred.as_ref())
             .await?;
+        let output_base_wait = Arc::new(OutputBaseWaitStatus::default());
         self.live.lock().await.insert(id, cancellation.clone());
+        self.output_base_waits
+            .lock()
+            .await
+            .insert(id, output_base_wait.clone());
 
         Ok(PreparedSubmission {
             queued,
             paths,
             lock_key,
+            output_base_wait,
             executable,
             cancellation,
             _pending_permit: pending_permit,
@@ -579,6 +609,7 @@ impl InvocationService {
             queued,
             paths,
             lock_key,
+            output_base_wait,
             executable,
             cancellation,
             _pending_permit,
@@ -591,6 +622,28 @@ impl InvocationService {
                 guard = workspace_lock.lock() => guard,
                 () = cancellation.cancelled() => {
                     return self.finish_cancelled(id).await;
+                }
+            };
+            let output_base_guard = match acquire_output_base_lock(
+                &self.config.output_base_lock_root,
+                &lock_key,
+                id,
+                cancellation.clone(),
+                output_base_wait.clone(),
+            )
+            .await
+            {
+                Ok(OutputBaseLockAcquisition::Acquired(guard)) => guard,
+                Ok(OutputBaseLockAcquisition::Cancelled) => {
+                    return self.finish_cancelled(id).await;
+                }
+                Err(error) => {
+                    return self
+                        .finish_start_failure(
+                            id,
+                            &format!("could not acquire output-base coordination lock: {error}"),
+                        )
+                        .await;
                 }
             };
             let permit = tokio::select! {
@@ -647,13 +700,61 @@ impl InvocationService {
                 return Err(error.into());
             }
             let result = self
-                .execute(&queued, &paths, &executable, cancellation.clone())
+                .execute(
+                    &queued,
+                    &paths,
+                    &executable,
+                    cancellation.clone(),
+                    output_base_wait,
+                )
                 .await;
             drop(workspace_guard);
+            drop(output_base_guard);
             drop(permit);
             result
         }
         .await
+    }
+
+    async fn finish_start_failure(
+        &self,
+        id: InvocationId,
+        message: &str,
+    ) -> Result<InvocationRecord, RunnerError> {
+        let message = self.redactor.redact_bounded(message, 1_000);
+        let current = self.store.get_invocation(id).await?;
+        if current.state.is_terminal() {
+            return Ok(current);
+        }
+        if current.state == InvocationState::Queued
+            && let Err(error) = self
+                .store
+                .transition(id, InvocationState::Starting, None, None)
+                .await
+            && !matches!(error, StoreError::State(_))
+        {
+            return Err(error.into());
+        }
+        let current = self.store.get_invocation(id).await?;
+        if current.state.is_terminal() {
+            return Ok(current);
+        }
+        self.store
+            .transition(
+                id,
+                InvocationState::Failed,
+                Some(Termination::SpawnFailure {
+                    message: message.clone(),
+                }),
+                Some(bazel_mcp_types::InvocationSummary {
+                    success: false,
+                    headline: format!("Could not start Bazel: {message}"),
+                    truncated: true,
+                    ..Default::default()
+                }),
+            )
+            .await
+            .map_err(Into::into)
     }
 
     async fn materialize_worker_failure(
@@ -854,6 +955,27 @@ impl InvocationService {
 
     pub async fn invocation_state(&self, id: InvocationId) -> Result<InvocationState, RunnerError> {
         Ok(self.store.get_invocation(id).await?.state)
+    }
+
+    pub async fn invocation_progress(
+        &self,
+        id: InvocationId,
+    ) -> Result<InvocationProgress, RunnerError> {
+        let state = self.store.get_invocation(id).await?.state;
+        let wait = self.output_base_waits.lock().await.get(&id).cloned();
+        let wait = wait.map(|status| status.snapshot()).unwrap_or_else(|| {
+            crate::output_base_lock::OutputBaseWaitSnapshot {
+                active: false,
+                elapsed_ms: 0,
+                owner: None,
+            }
+        });
+        Ok(InvocationProgress {
+            state,
+            phase: wait.active.then_some("output_base_lock_wait"),
+            output_base_lock_wait_ms: wait.elapsed_ms,
+            output_base_lock_owner: wait.owner,
+        })
     }
 
     pub async fn inspect(&self, request: InspectRequest) -> Result<InspectResult, RunnerError> {
@@ -1102,6 +1224,7 @@ impl InvocationService {
         paths: &InvocationPaths,
         executable: &Path,
         cancellation: CancellationToken,
+        output_base_wait: Arc<OutputBaseWaitStatus>,
     ) -> Result<InvocationRecord, RunnerError> {
         if cancellation.is_cancelled() {
             return self.finish_cancelled(queued.request.id).await;
@@ -1379,6 +1502,12 @@ impl InvocationService {
                     ))
                 })
         });
+        let native_output_base_wait = NativeOutputBaseWaitObserver::start(
+            paths.stdout.clone(),
+            paths.stderr.clone(),
+            paths.bep.clone(),
+            output_base_wait.clone(),
+        );
         let started = Instant::now();
         let timeout = queued
             .request
@@ -1409,6 +1538,8 @@ impl InvocationService {
             }
         };
         process_group.disarm();
+        native_output_base_wait.finish().await;
+        let output_base_wait_snapshot = output_base_wait.snapshot();
         let bazel_wall_ms = duration_millis(started.elapsed());
         let postprocess: Result<InvocationRecord, RunnerError> = async {
             let reduction_started = Instant::now();
@@ -1620,6 +1751,7 @@ impl InvocationService {
                 bep_bytes: capture::file_size(&paths.bep).await,
                 bep_events: u64::try_from(bep_outcome.event_count).unwrap_or(u64::MAX),
                 queue_ms,
+                output_base_lock_wait_ms: output_base_wait_snapshot.elapsed_ms,
                 bazel_wall_ms,
                 reduction_ms: duration_millis(reduction_started.elapsed()),
                 ..Default::default()

--- a/crates/bazel-mcp-runner/tests/process.rs
+++ b/crates/bazel-mcp-runner/tests/process.rs
@@ -13,7 +13,7 @@ use bazel_mcp_bep::proto::{
 use bazel_mcp_bep::{encode_event_id, encode_frame};
 use bazel_mcp_policy::PolicyConfig;
 use bazel_mcp_runner::{
-    BepTransport, InspectRequest, InspectView, InvocationService, RunnerConfig,
+    BepTransport, InspectRequest, InspectView, InvocationProgress, InvocationService, RunnerConfig,
     StarlarkReducerConfig,
 };
 use bazel_mcp_store::Store;
@@ -92,6 +92,22 @@ async fn wait_for_invocation(service: &InvocationService, id: bazel_mcp_types::I
     panic!("timed out waiting for invocation {id}");
 }
 
+async fn wait_for_output_base_wait(
+    service: &InvocationService,
+    id: bazel_mcp_types::InvocationId,
+) -> InvocationProgress {
+    for _ in 0..500 {
+        if let Ok(progress) = service.invocation_progress(id).await
+            && progress.phase == Some("output_base_lock_wait")
+            && progress.output_base_lock_wait_ms > 0
+        {
+            return progress;
+        }
+        tokio::time::sleep(Duration::from_millis(10)).await;
+    }
+    panic!("timed out waiting for output-base lock progress for {id}");
+}
+
 async fn service(root: &TempDir, workspace: &Path, script: &str) -> InvocationService {
     service_with_redaction(root, workspace, script, Vec::new()).await
 }
@@ -166,6 +182,34 @@ async fn configured_service(
         config,
     )
     .await
+    .unwrap()
+}
+
+async fn shared_executable_service(
+    root: &TempDir,
+    workspace: &Path,
+    executable: &Path,
+    store_name: &str,
+    output_base_lock_root: &Path,
+) -> InvocationService {
+    tokio::fs::write(workspace.join("MODULE.bazel"), "module(name='test')\n")
+        .await
+        .unwrap();
+    let policy = PolicyConfig {
+        allowed_roots: vec![root.path().to_owned()],
+        bazel_executable: Some(executable.to_owned()),
+        ..PolicyConfig::default()
+    };
+    InvocationService::new(
+        Store::open(root.path().join(store_name)).await.unwrap(),
+        RunnerConfig {
+            policy,
+            cancellation_interrupt_grace: Duration::from_millis(100),
+            cancellation_terminate_grace: Duration::from_millis(100),
+            output_base_lock_root: output_base_lock_root.to_owned(),
+            ..RunnerConfig::default()
+        },
+    )
     .unwrap()
 }
 
@@ -1621,6 +1665,240 @@ exit 0\n",
     for run in same_workspace {
         run.await.unwrap();
     }
+}
+
+#[tokio::test]
+async fn independent_services_serialize_each_request_by_explicit_output_base() {
+    let root = tempfile::tempdir().unwrap();
+    let first_workspace = root.path().join("first-workspace");
+    let second_workspace = root.path().join("second-workspace");
+    let first_started = root.path().join("first-started");
+    let first_release = root.path().join("first-release");
+    let second_started = root.path().join("second-started");
+    tokio::fs::create_dir(&first_workspace).await.unwrap();
+    tokio::fs::create_dir(&second_workspace).await.unwrap();
+    let executable = root.path().join("shared-fake-bazel");
+    let script = format!(
+        "#!/bin/sh\n\
+if [ \"${{1:-}}\" = --version ]; then echo 'bazel 9.1.0'; exit 0; fi\n\
+for arg in \"$@\"; do\n\
+  case \"$arg\" in\n\
+    //:first)\n\
+      touch '{}'\n\
+      while [ ! -f '{}' ]; do sleep 0.01; done\n\
+      exit 0\n\
+      ;;\n\
+    //:second) touch '{}'; exit 0 ;;\n\
+  esac\n\
+done\n\
+exit 0\n",
+        first_started.display(),
+        first_release.display(),
+        second_started.display(),
+    );
+    tokio::fs::write(&executable, script).await.unwrap();
+    tokio::fs::set_permissions(&executable, std::fs::Permissions::from_mode(0o700))
+        .await
+        .unwrap();
+    let lock_root = root.path().join("shared-output-base-locks");
+    let first_service = shared_executable_service(
+        &root,
+        &first_workspace,
+        &executable,
+        "first-store",
+        &lock_root,
+    )
+    .await;
+    let second_service = shared_executable_service(
+        &root,
+        &second_workspace,
+        &executable,
+        "second-store",
+        &lock_root,
+    )
+    .await;
+    let output_base = root.path().join("shared-output-base");
+    let startup_argument = format!("--output_base={}", output_base.display());
+    let mut first_request = InvocationRequest::new(
+        first_workspace,
+        BazelCommand::Build,
+        vec!["//:first".to_owned()],
+    );
+    first_request.startup_arguments = vec![startup_argument.clone()];
+    let first_run = tokio::spawn({
+        let service = first_service.clone();
+        async move { service.run(first_request).await.unwrap() }
+    });
+    wait_for_path(&first_started).await;
+
+    let mut second_request = InvocationRequest::new(
+        second_workspace,
+        BazelCommand::Build,
+        vec!["//:second".to_owned()],
+    );
+    second_request.startup_arguments = vec![startup_argument];
+    let second_id = second_request.id;
+    let second_run = tokio::spawn({
+        let service = second_service.clone();
+        async move { service.run(second_request).await.unwrap() }
+    });
+    wait_for_invocation(&second_service, second_id).await;
+    let progress = wait_for_output_base_wait(&second_service, second_id).await;
+
+    assert!(
+        progress
+            .output_base_lock_owner
+            .as_deref()
+            .is_some_and(|owner| owner.starts_with("bazel_mcp:pid="))
+    );
+    assert!(
+        !second_started.exists(),
+        "the second Bazel client started before the first released the shared output base"
+    );
+    tokio::fs::write(&first_release, b"release").await.unwrap();
+    let first_record = first_run.await.unwrap();
+    let second_record = second_run.await.unwrap();
+
+    assert_eq!(first_record.state, InvocationState::Succeeded);
+    assert_eq!(second_record.state, InvocationState::Succeeded);
+    assert!(second_started.exists());
+    assert!(second_record.metrics.output_base_lock_wait_ms > 0);
+}
+
+#[tokio::test]
+async fn cancellation_while_waiting_for_cross_process_output_base_lock_never_spawns_bazel() {
+    let root = tempfile::tempdir().unwrap();
+    let first_workspace = root.path().join("first-workspace");
+    let second_workspace = root.path().join("second-workspace");
+    let first_started = root.path().join("first-started");
+    let first_release = root.path().join("first-release");
+    let second_started = root.path().join("second-started");
+    tokio::fs::create_dir(&first_workspace).await.unwrap();
+    tokio::fs::create_dir(&second_workspace).await.unwrap();
+    let executable = root.path().join("cancellable-fake-bazel");
+    let script = format!(
+        "#!/bin/sh\n\
+if [ \"${{1:-}}\" = --version ]; then echo 'bazel 9.1.0'; exit 0; fi\n\
+for arg in \"$@\"; do\n\
+  case \"$arg\" in\n\
+    //:first)\n\
+      touch '{}'\n\
+      while [ ! -f '{}' ]; do sleep 0.01; done\n\
+      exit 0\n\
+      ;;\n\
+    //:second) touch '{}'; exit 0 ;;\n\
+  esac\n\
+done\n\
+exit 0\n",
+        first_started.display(),
+        first_release.display(),
+        second_started.display(),
+    );
+    tokio::fs::write(&executable, script).await.unwrap();
+    tokio::fs::set_permissions(&executable, std::fs::Permissions::from_mode(0o700))
+        .await
+        .unwrap();
+    let lock_root = root.path().join("shared-output-base-locks");
+    let first_service = shared_executable_service(
+        &root,
+        &first_workspace,
+        &executable,
+        "first-store",
+        &lock_root,
+    )
+    .await;
+    let second_service = shared_executable_service(
+        &root,
+        &second_workspace,
+        &executable,
+        "second-store",
+        &lock_root,
+    )
+    .await;
+    let output_base = root.path().join("shared-output-base");
+    let startup_argument = format!("--output_base={}", output_base.display());
+    let mut first_request = InvocationRequest::new(
+        first_workspace,
+        BazelCommand::Build,
+        vec!["//:first".to_owned()],
+    );
+    first_request.startup_arguments = vec![startup_argument.clone()];
+    let first_run = tokio::spawn({
+        let service = first_service.clone();
+        async move { service.run(first_request).await.unwrap() }
+    });
+    wait_for_path(&first_started).await;
+
+    let mut second_request = InvocationRequest::new(
+        second_workspace,
+        BazelCommand::Build,
+        vec!["//:second".to_owned()],
+    );
+    second_request.startup_arguments = vec![startup_argument];
+    let second_id = second_request.id;
+    let cancellation = CancellationToken::new();
+    let run_cancellation = cancellation.clone();
+    let second_run = tokio::spawn({
+        let service = second_service.clone();
+        async move {
+            service
+                .run_with_cancellation(second_request, run_cancellation)
+                .await
+                .unwrap()
+        }
+    });
+    wait_for_invocation(&second_service, second_id).await;
+    wait_for_output_base_wait(&second_service, second_id).await;
+    cancellation.cancel();
+    let second_record = second_run.await.unwrap();
+
+    assert_eq!(second_record.state, InvocationState::Cancelled);
+    assert!(!second_started.exists());
+    tokio::fs::write(&first_release, b"release").await.unwrap();
+    assert_eq!(first_run.await.unwrap().state, InvocationState::Succeeded);
+}
+
+#[tokio::test]
+async fn native_bazel_output_base_wait_is_reported_and_included_in_metrics() {
+    let root = tempfile::tempdir().unwrap();
+    let workspace = root.path().join("workspace");
+    let wait_started = root.path().join("native-wait-started");
+    let release = root.path().join("native-wait-release");
+    tokio::fs::create_dir(&workspace).await.unwrap();
+    let script = format!(
+        "#!/bin/sh\n\
+if [ \"${{1:-}}\" = --version ]; then echo 'bazel 9.1.0'; exit 0; fi\n\
+echo 'WARNING: Running Bazel server needs to be killed, because startup options are different:' >&2\n\
+echo 'Another command holds the output base lock:' >&2\n\
+echo 'owner=client' >&2\n\
+echo 'Waiting for it to complete...' >&2\n\
+touch '{}'\n\
+while [ ! -f '{}' ]; do sleep 0.01; done\n\
+echo 'Starting local Bazel server and connecting to it...' >&2\n\
+exit 0\n",
+        wait_started.display(),
+        release.display(),
+    );
+    let service = configured_service(&root, &workspace, &script, |_| {}).await;
+    let request =
+        InvocationRequest::new(workspace, BazelCommand::Build, vec!["//:target".to_owned()]);
+    let id = request.id;
+    let run = tokio::spawn({
+        let service = service.clone();
+        async move { service.run(request).await.unwrap() }
+    });
+    wait_for_path(&wait_started).await;
+    let progress = wait_for_output_base_wait(&service, id).await;
+
+    assert_eq!(
+        progress.output_base_lock_owner.as_deref(),
+        Some("bazel_client")
+    );
+    tokio::fs::write(&release, b"release").await.unwrap();
+    let record = run.await.unwrap();
+
+    assert_eq!(record.state, InvocationState::Succeeded);
+    assert!(record.metrics.output_base_lock_wait_ms > 0);
 }
 
 #[tokio::test]

--- a/crates/bazel-mcp-server/src/handler.rs
+++ b/crates/bazel-mcp-server/src/handler.rs
@@ -189,13 +189,22 @@ impl BazelMcpServer {
                 }
                 () = &mut progress_delay, if progress_token.is_some() => {
                     if let Some(token) = &progress_token
-                        && let Ok(state) = self.runner.invocation_state(id).await
+                        && let Ok(progress) = self.runner.invocation_progress(id).await
                     {
                         let elapsed_ms = progress_started.elapsed().as_millis() as u64;
-                        let message = format!(
+                        let mut message = format!(
                             "state={} elapsed_ms={elapsed_ms}",
-                            format!("{state:?}").to_ascii_lowercase(),
+                            format!("{:?}", progress.state).to_ascii_lowercase(),
                         );
+                        if let Some(phase) = progress.phase {
+                            message.push_str(&format!(
+                                " phase={phase} output_base_lock_wait_ms={}",
+                                progress.output_base_lock_wait_ms,
+                            ));
+                            if let Some(owner) = progress.output_base_lock_owner {
+                                message.push_str(&format!(" owner={owner}"));
+                            }
+                        }
                         if client
                             .notify_progress(
                                 ProgressNotificationParam::new(token.clone(), elapsed_ms as f64)

--- a/crates/bazel-mcp-server/src/lib.rs
+++ b/crates/bazel-mcp-server/src/lib.rs
@@ -55,6 +55,7 @@ pub async fn serve(config: ServerConfig) -> anyhow::Result<()> {
                 config.version_check_timeout_seconds,
             ),
             maximum_pending_invocations: config.maximum_pending_invocations,
+            output_base_lock_root: RunnerConfig::default().output_base_lock_root,
             bep_transport: config.bep_transport,
             starlark_reducers: config.starlark.runner_config(),
         },

--- a/crates/bazel-mcp-types/src/invocation.rs
+++ b/crates/bazel-mcp-types/src/invocation.rs
@@ -173,6 +173,8 @@ pub struct InvocationMetrics {
     pub progress_notifications: u64,
     pub inspect_calls: u64,
     pub queue_ms: u64,
+    #[serde(default)]
+    pub output_base_lock_wait_ms: u64,
     pub bazel_wall_ms: u64,
     pub reduction_ms: u64,
 }

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -227,6 +227,22 @@ the native result and add a bounded note. See the
 | `starlark.max_callstack_size` | `100` | Maximum Starlark call-stack depth. |
 | `starlark.timeout_ms` | `100` | Best-effort wall-clock evaluation limit per reducer. |
 
+## Shared output bases
+
+Every Bazel request participates in user-scoped, cross-process coordination
+using the known effective output-base key. An explicit `--output_base` is keyed
+by its canonical path; otherwise the canonical workspace is the conservative
+key. The lock is request-scoped, so separate bazel-mcp processes that share an
+explicit output base wait before spawning their Bazel clients.
+
+This coordination does not change Bazel startup arguments and does not reject a
+shared output base across workspaces. Direct Bazel clients, editor integrations,
+and output-base choices hidden in bazelrc still use Bazel's native blocking lock
+and normal server takeover/restart behavior. While either wait is active,
+synchronous MCP progress reports `phase=output_base_lock_wait`; completed
+invocations expose the combined duration as `output_base_lock_wait_ms` in the
+metrics view. Owner labels are deliberately bounded and omit workspace paths.
+
 ## CLI options
 
 Run `bazel-mcp --help` for the authoritative command-line reference:

--- a/specs/001-product-requirements.md
+++ b/specs/001-product-requirements.md
@@ -520,15 +520,28 @@ State transitions are durable and monotonic. Terminal states do not change.
 
 ### 12.2 Concurrency
 
-- Commands using the same effective Bazel output base MUST execute serially.
+- Commands using the same known effective Bazel output base MUST execute
+  serially across runner instances owned by the same operating-system user.
 - When no explicit output base is supplied, the canonical workspace is the lock
   key.
 - When an explicit output base is supplied, its canonical path is the lock key,
   including across different workspaces.
+- The cross-process advisory lock is acquired for every invocation and held
+  until that Bazel client exits. It supplements Bazel's own output-base lock;
+  it does not replace or disable Bazel's native wait-and-takeover behavior.
+- Shared output bases across workspaces are supported. The runner MUST NOT
+  reject them or silently isolate them merely because a different workspace or
+  Bazel server startup configuration may trigger a server restart after lock
+  handoff.
+- A direct Bazel client, editor integration, or output-base setting hidden in
+  bazelrc may still contend outside the advisory-lock namespace. In that case,
+  the spawned Bazel client MUST retain its normal blocking lock behavior.
 - Commands for independent lock keys MAY execute concurrently subject to a
   configurable global limit.
 - The default global running limit is four invocations.
-- Queue position and elapsed queue time may be reported as progress.
+- Output-base lock-wait phase, elapsed wait, and a bounded owner label may be
+  reported as progress. Owner details MUST exclude workspace paths and pass
+  through the normal redaction boundary.
 - The server MUST NOT create alternate output bases merely to increase
   concurrency.
 
@@ -540,7 +553,9 @@ State transitions are durable and monotonic. Terminal states do not change.
 - A progress update is sent earlier only for a meaningful state transition such
   as leaving the queue or beginning execution.
 - Progress messages contain only state, elapsed time, and concise structured BEP
-  counts or phases when available.
+  counts or phases when available. Output-base waits use the
+  `output_base_lock_wait` phase with elapsed wait milliseconds and a bounded,
+  redacted owner label when available.
 - Identical progress updates are suppressed.
 - Progress notification failures do not fail the Bazel invocation.
 
@@ -895,7 +910,7 @@ For every invocation, record:
 - Model-visible result bytes
 - Number of progress notifications
 - Number of inspect calls
-- Queue time, Bazel wall time, and reduction time
+- Queue time, output-base lock wait time, Bazel wall time, and reduction time
 - Counts of diagnostics returned, suppressed, and deduplicated
 - Parser fallback reasons
 - Bazel and reducer versions
@@ -967,6 +982,10 @@ The corpus MUST include:
 
 - Two commands for the same workspace execute serially without relying on
   Bazel's invisible output-base lock wait.
+- Independent runner instances using one explicit output base serialize before
+  spawning Bazel, and a cancelled waiter never spawns a child.
+- Native Bazel lock waits caused by direct or otherwise uncoordinated clients
+  are observable as progress and contribute to the recorded lock-wait metric.
 - Independent workspaces can run concurrently.
 - Two worktrees cannot read each other's "last" result because no such API
   exists.
@@ -1146,7 +1165,7 @@ blocking BEP and filesystem work uses bounded blocking tasks.
 | BEP schema changes across Bazel versions | Parse or semantic drift | Pin protos, ignore unknown fields, maintain cross-version golden fixtures. |
 | Remote-minimal builds reference unavailable artifacts | Test or coverage detail is missing | Report availability explicitly; add authenticated CAS/BuildBuddy adapters later. |
 | Tool results duplicate text and structured content | Token savings regress | Default to one text representation and benchmark host-specific encoding. |
-| Concurrent commands wait on the same output-base lock | Hidden latency and apparent stalls | Schedule by canonical effective output base before spawning Bazel. |
+| Concurrent commands wait on the same output-base lock | Hidden latency and apparent stalls | Acquire a per-user cross-process advisory lock for every known output-base key, preserve Bazel's native wait-and-takeover path for uncoordinated clients, and report bounded wait progress. |
 | Logs contain secrets | Sensitive data reaches model or disk | Private storage, retention, configured redaction before summaries and inspection. |
 | Retained logs consume large amounts of disk | Builds fail or machine degrades | Quotas, oldest-first eviction, and preflight storage checks. |
 | Filesystem records are interrupted during commit or deletion | Missing metadata or leaked evidence | Use atomic rename commit points, two-phase trash deletion, exclusive locking, and crash/restart tests. |

--- a/specs/002-project-architecture.md
+++ b/specs/002-project-architecture.md
@@ -422,7 +422,9 @@ processes.
 Responsibilities:
 
 - Expose `InvocationService` with `run`, `inspect`, and `cancel` operations.
-- Queue work by known effective output-base key and enforce the global limit.
+- Queue work by known effective output-base key, acquire a per-user
+  cross-process advisory lock for every invocation, and enforce the global
+  limit.
 - Generate UUIDv7 invocation IDs.
 - Assemble validated Bazel argv without a shell.
 - Spawn the wrapper/Bazel client in a process group.
@@ -431,7 +433,8 @@ Responsibilities:
 - Enforce timeout and graceful cancellation escalation.
 - Await async store operations directly; run CPU-heavy BEP/reducer work and
   blocking filesystem work via bounded `spawn_blocking` tasks.
-- Produce concise progress snapshots.
+- Observe both advisory and native Bazel output-base waits and include their
+  combined duration in concise progress snapshots and invocation metrics.
 - Recover stored state during application startup.
 
 Suggested layout:
@@ -631,6 +634,7 @@ bazel-mcp-server
       ▼
 bazel-mcp-runner
   - scheduler and live invocation registry
+  - per-request cross-process output-base locks
   - Tokio process tasks
   - cancellation tokens
       ├────────────► bazel-mcp-policy


### PR DESCRIPTION
## Summary

- acquire a user-scoped advisory lock for every request using the known effective Bazel output base
- preserve Bazel's native blocking lock, server takeover, and restart behavior for direct clients and bazelrc-derived contention
- report advisory and native lock waits through MCP progress and `output_base_lock_wait_ms`
- make queued lock waits cancellable without spawning a Bazel child
- document shared-output-base behavior and add process coverage for serialization, cancellation, and native waits

## Root cause

The existing scheduler serialized output bases only inside one `InvocationService`. Separate bazel-mcp processes could therefore launch clients for the same output base concurrently, while contention with direct Bazel clients remained hidden inside Bazel wall time.

## User impact

Sharing one output base across workspaces remains supported. bazel-mcp now coordinates known output bases across local MCP processes on every invocation, and uncoordinated clients still wait and take over through Bazel normally instead of being rejected or silently isolated.

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p bazel-mcp-types -p bazel-mcp-runner -p bazel-mcp-server`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo shear`
- `bazel.run build //:bazel-mcp` through the MCP server

A broader Bazel test request still encounters the pre-existing missing `test-outcomes.bep` compile-data declaration in `//crates/bazel-mcp-runner:unit_test`; the corresponding Cargo unit and process suites pass.

Closes #72
