### PR TITLE
perf: reduce query and reducer allocations

### DIFF
--- a/LEARNINGS.md
+++ b/LEARNINGS.md
@@ -121,6 +121,13 @@ unrelated to MCP efficiency. Do not include secrets or raw sensitive output.
   beside the actionable failure, consuming model-visible item budget; discard
   empty reducer messages before ranking and serialization. Thread:
   `019f6b89-e945-78a0-9264-a6ad416905a1`.
+- A successful 1,000-row `bazel.run query` still normalized, deduplicated,
+  redacted, and serialized the bounded capture as failure-evidence log data;
+  DHAT measured about 736 KB in 5,222 allocations per call across ten
+  end-to-end MCP requests even though agents consume `query_results`. Defer log
+  materialization until reduction selects the `log` view, and skip it for
+  ordinary successful queries. Thread:
+  `019f6db7-4010-7191-8796-1c83ff2a7f42`.
 - Recorded BEP strings used fixed-length uppercase workspace markers while
   service locations used lowercase markers, complicating live/replay parity and
   leaking padding into visible messages; normalize both marker forms before

--- a/crates/bazel-mcp-reducer/src/build.rs
+++ b/crates/bazel-mcp-reducer/src/build.rs
@@ -649,27 +649,45 @@ fn diagnostic_priority(diagnostic: &Diagnostic) -> (Severity, u8, u8) {
         DiagnosticCategory::Unknown => 4,
         DiagnosticCategory::Action => 5,
     };
-    let lower = diagnostic.message.to_ascii_lowercase();
-    let rust_failure =
-        lower.contains("panicked at") || (lower.contains("assertion") && lower.contains(" failed"));
+    let message = diagnostic.message.as_str();
+    let rust_failure = contains_ignore_ascii_case(message, "panicked at")
+        || (contains_ignore_ascii_case(message, "assertion")
+            && contains_ignore_ascii_case(message, " failed"));
     let evidence_quality = if diagnostic.location.is_some()
-        || (lower.contains("root_cause") && !lower.contains("error executing"))
+        || (contains_ignore_ascii_case(message, "root_cause")
+            && !contains_ignore_ascii_case(message, "error executing"))
     {
         0
     } else if diagnostic.category == DiagnosticCategory::Test && rust_failure {
         1
-    } else if lower.starts_with("test failed:")
-        || lower.starts_with("test timed out:")
-        || lower.starts_with("test was incomplete:")
-        || lower.starts_with("test result was unavailable:")
+    } else if starts_with_ignore_ascii_case(message, "test failed:")
+        || starts_with_ignore_ascii_case(message, "test timed out:")
+        || starts_with_ignore_ascii_case(message, "test was incomplete:")
+        || starts_with_ignore_ascii_case(message, "test result was unavailable:")
     {
         3
-    } else if lower.contains("error executing") {
+    } else if contains_ignore_ascii_case(message, "error executing") {
         2
     } else {
         1
     };
     (diagnostic.severity, category, evidence_quality)
+}
+
+fn contains_ignore_ascii_case(value: &str, needle: &str) -> bool {
+    let needle = needle.as_bytes();
+    needle.is_empty()
+        || value
+            .as_bytes()
+            .windows(needle.len())
+            .any(|window| window.eq_ignore_ascii_case(needle))
+}
+
+fn starts_with_ignore_ascii_case(value: &str, prefix: &str) -> bool {
+    value
+        .as_bytes()
+        .get(..prefix.len())
+        .is_some_and(|start| start.eq_ignore_ascii_case(prefix.as_bytes()))
 }
 
 fn test_outcome_diagnostic(label: &str, status: TestStatus) -> Option<Diagnostic> {
@@ -1057,8 +1075,10 @@ fn cpp_path_end(line: &str, delimiter: char) -> Option<usize> {
     EXTENSIONS
         .iter()
         .filter_map(|extension| {
-            let marker = format!("{extension}{delimiter}");
-            line.rfind(&marker).map(|index| index + extension.len())
+            line.rmatch_indices(extension).find_map(|(index, _)| {
+                let path_end = index + extension.len();
+                line[path_end..].starts_with(delimiter).then_some(path_end)
+            })
         })
         .max()
 }
@@ -2665,6 +2685,36 @@ ERROR: Build did NOT complete successfully
                 column: Some(7),
             })
         );
+    }
+
+    #[test]
+    fn allocation_free_ascii_matching_preserves_case_insensitive_ranking() {
+        assert!(contains_ignore_ascii_case(
+            "FANOUT_ROOT_CAUSE",
+            "root_cause"
+        ));
+        assert!(contains_ignore_ascii_case(
+            "ERROR EXECUTING CppCompile",
+            "error executing"
+        ));
+        assert!(starts_with_ignore_ascii_case(
+            "TEST FAILED: //pkg:test",
+            "test failed:"
+        ));
+        assert!(!starts_with_ignore_ascii_case(
+            "xTEST FAILED: //pkg:test",
+            "test failed:"
+        ));
+    }
+
+    #[test]
+    fn finds_cpp_path_extensions_without_formatted_markers() {
+        assert_eq!(cpp_path_end("generated.cc.tmp.cc:9: error", ':'), Some(19));
+        assert_eq!(
+            cpp_path_end(r"C:\workspace\source.cpp(12,7): error", '('),
+            Some(23)
+        );
+        assert_eq!(cpp_path_end("source.cc.tmp:9: error", ':'), None);
     }
 
     #[test]

--- a/crates/bazel-mcp-reducer/src/text.rs
+++ b/crates/bazel-mcp-reducer/src/text.rs
@@ -53,22 +53,21 @@ pub fn normalize_terminal_text(input: &[u8]) -> String {
 
 #[must_use]
 pub fn deduplicate_lines(input: &str) -> Vec<(String, u32)> {
-    let mut counts = BTreeMap::<String, u32>::new();
+    let mut counts = BTreeMap::<&str, u32>::new();
     let mut order = Vec::new();
     for line in input.lines().map(str::trim).filter(|line| !line.is_empty()) {
-        if !counts.contains_key(line) {
-            order.push(line.to_owned());
+        if let Some(count) = counts.get_mut(line) {
+            *count = count.saturating_add(1);
+        } else {
+            order.push(line);
+            counts.insert(line, 1);
         }
-        counts
-            .entry(line.to_owned())
-            .and_modify(|count| *count = count.saturating_add(1))
-            .or_insert(1);
     }
     order
         .into_iter()
         .map(|line| {
-            let count = counts.get(&line).copied().unwrap_or(1);
-            (line, count)
+            let count = counts.get(line).copied().unwrap_or(1);
+            (line.to_owned(), count)
         })
         .collect()
 }
@@ -88,8 +87,8 @@ mod tests {
     #[test]
     fn exact_deduplication_preserves_first_order() {
         assert_eq!(
-            deduplicate_lines("warning\nerror\nwarning"),
-            vec![("warning".into(), 2), ("error".into(), 1)]
+            deduplicate_lines(" warning \nerror\nwarning\n\n error "),
+            vec![("warning".into(), 2), ("error".into(), 2)]
         );
     }
 }

--- a/crates/bazel-mcp-runner/src/service.rs
+++ b/crates/bazel-mcp-runner/src/service.rs
@@ -1464,15 +1464,18 @@ impl InvocationService {
             let stdout = capture::read_bounded_tail(&paths.stdout, log_limit).await?;
             let stderr = capture::read_bounded_tail(&paths.stderr, log_limit).await?;
             let exit_code = status.as_ref().and_then(ExitStatus::code);
-            self.persist_failure_evidence(
-                paths,
-                &queued.request.workspace,
-                &queued.request.command,
-                exit_code != Some(0),
-                &stdout,
-                &stderr,
-            )
-            .await?;
+            let failed = exit_code != Some(0);
+            if should_persist_failure_evidence(&queued.request.command, failed) {
+                self.persist_failure_evidence(
+                    paths,
+                    &queued.request.workspace,
+                    &queued.request.command,
+                    failed,
+                    &stdout,
+                    &stderr,
+                )
+                .await?;
+            }
             let reduced = catch_unwind(AssertUnwindSafe(|| {
                 bep.finish(
                     &stdout,
@@ -2513,6 +2516,10 @@ fn page_evidence_records(
     Ok((items, truncated, next_cursor))
 }
 
+fn should_persist_failure_evidence(command: &BazelCommand, failed: bool) -> bool {
+    failed || command.class() != CommandClass::Query
+}
+
 fn failure_evidence_records(
     command: &BazelCommand,
     failed: bool,
@@ -3035,6 +3042,23 @@ mod tests {
     use tempfile::tempdir;
 
     use super::*;
+
+    #[test]
+    fn skips_eager_failure_evidence_only_for_successful_queries() {
+        for command in [
+            BazelCommand::Query,
+            BazelCommand::Cquery,
+            BazelCommand::Aquery,
+        ] {
+            assert!(!should_persist_failure_evidence(&command, false));
+            assert!(should_persist_failure_evidence(&command, true));
+        }
+        assert!(should_persist_failure_evidence(&BazelCommand::Build, false));
+        assert!(should_persist_failure_evidence(
+            &BazelCommand::Version,
+            false
+        ));
+    }
 
     #[tokio::test]
     async fn workspace_lock_registry_discards_inactive_output_bases() {


### PR DESCRIPTION
## Summary

- skip eager failure-evidence serialization for successful `query`, `cquery`, and `aquery` invocations while retaining on-demand log inspection
- borrow input lines while deduplicating and allocate only the unique output rows
- replace temporary C++ extension markers and lowercased diagnostic copies with allocation-free scans
- record the MCP workflow symptom and follow-up in `LEARNINGS.md`

## Why

DHAT profiling showed successful 1,000-row queries were still normalizing, deduplicating, redacting, and serializing a failure-evidence log that normal clients do not consume. The reducer also allocated per input line, per C++ extension probe, and per diagnostic ranking comparison.

## Impact

Measured with the same DHAT workloads before and after:

- line deduplication: 3.11 MB / 100,123 allocations to 14.3 KB / 123 allocations
- terminal reduction: 21.95 MB / 383,166 allocations to 18.66 MB / 163,168 allocations
- ten successful query requests: 20.82 MB / 73,406 allocations to 13.40 MB / 21,139 allocations

This reduces allocation bytes by 35.6% and allocation count by 71.2% in the profiled end-to-end query workload.

## Validation

- `cargo test -p bazel-mcp-reducer -p bazel-mcp-runner` (114 tests including goldens and process tests)
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo shear`
- `git diff --check`
