### PR TITLE
perf: reduce filtered query allocations

### DIFF
--- a/LEARNINGS.md
+++ b/LEARNINGS.md
@@ -134,6 +134,12 @@ unrelated to MCP efficiency. Do not include secrets or raw sensitive output.
   materialization until reduction selects the `log` view, and skip it for
   ordinary successful queries. Thread:
   `019f6db7-4010-7191-8796-1c83ff2a7f42`.
+- A filtered `bazel.inspect query_results` scan over 100,000 rows allocated a
+  fresh line, transformed value, lowercase match string, and serialized clone
+  per row: 14.88 MB across 401,020 allocations. Reuse decoding,
+  transformation, and serialization buffers, compare ASCII case in place, and
+  transfer ownership only for selected rows. Thread:
+  `019f6db7-4010-7191-8796-1c83ff2a7f42`.
 - Recorded BEP strings used fixed-length uppercase workspace markers while
   service locations used lowercase markers, complicating live/replay parity and
   leaking padding into visible messages; normalize both marker forms before

--- a/crates/bazel-mcp-policy/src/redaction.rs
+++ b/crates/bazel-mcp-policy/src/redaction.rs
@@ -30,38 +30,46 @@ impl Redactor {
     /// beyond `maximum_bytes`.
     #[must_use]
     pub fn redact_bounded(&self, value: &str, maximum_bytes: usize) -> String {
+        let mut output = String::new();
+        self.redact_bounded_into(value, maximum_bytes, &mut output);
+        output
+    }
+
+    /// Redacts matches into a caller-owned buffer so repeated operations can
+    /// reuse its allocation.
+    pub fn redact_bounded_into(&self, value: &str, maximum_bytes: usize, output: &mut String) {
         let mut patterns = self.patterns.iter();
         let Some(first) = patterns.next() else {
-            return bounded_prefix(value, maximum_bytes);
+            output.clear();
+            push_bounded(output, value, maximum_bytes);
+            return;
         };
-        patterns.fold(
-            replace_all_bounded(first, value, maximum_bytes),
-            |current, pattern| replace_all_bounded(pattern, &current, maximum_bytes),
-        )
+        replace_all_bounded(first, value, maximum_bytes, output);
+        let mut scratch = String::new();
+        for pattern in patterns {
+            replace_all_bounded(pattern, output, maximum_bytes, &mut scratch);
+            std::mem::swap(output, &mut scratch);
+        }
     }
 }
 
-fn replace_all_bounded(pattern: &Regex, value: &str, maximum_bytes: usize) -> String {
+fn replace_all_bounded(pattern: &Regex, value: &str, maximum_bytes: usize, output: &mut String) {
     const REPLACEMENT: &str = "[REDACTED]";
 
-    let mut output = String::with_capacity(value.len().min(maximum_bytes));
+    output.clear();
+    output.reserve(value.len().min(maximum_bytes));
     let mut previous_end = 0;
     for matched in pattern.find_iter(value) {
-        if !push_bounded(
-            &mut output,
-            &value[previous_end..matched.start()],
-            maximum_bytes,
-        ) {
-            return output;
+        if !push_bounded(output, &value[previous_end..matched.start()], maximum_bytes) {
+            return;
         }
         if output.len().saturating_add(REPLACEMENT.len()) > maximum_bytes {
-            return output;
+            return;
         }
         output.push_str(REPLACEMENT);
         previous_end = matched.end();
     }
-    push_bounded(&mut output, &value[previous_end..], maximum_bytes);
-    output
+    push_bounded(output, &value[previous_end..], maximum_bytes);
 }
 
 fn push_bounded(output: &mut String, value: &str, maximum_bytes: usize) -> bool {
@@ -76,12 +84,6 @@ fn push_bounded(output: &mut String, value: &str, maximum_bytes: usize) -> bool 
     }
     output.push_str(&value[..boundary]);
     false
-}
-
-fn bounded_prefix(value: &str, maximum_bytes: usize) -> String {
-    let mut output = String::new();
-    push_bounded(&mut output, value, maximum_bytes);
-    output
 }
 
 #[cfg(test)]
@@ -106,5 +108,17 @@ mod tests {
     fn never_exposes_a_secret_cut_by_the_output_boundary() {
         let redactor = Redactor::new(&[r"token=[^\s]+".to_owned()]).unwrap();
         assert_eq!(redactor.redact_bounded("token=secret", 5), "");
+    }
+
+    #[test]
+    fn reusable_output_matches_owned_redaction_for_multiple_patterns() {
+        let redactor =
+            Redactor::new(&[r"token=[^\s]+".to_owned(), r"password=[^\s]+".to_owned()]).unwrap();
+        let mut output = String::with_capacity(128);
+        redactor.redact_bounded_into("token=secret password=hunter2 visible", 128, &mut output);
+        assert_eq!(output, "[REDACTED] [REDACTED] visible");
+
+        redactor.redact_bounded_into("short", 128, &mut output);
+        assert_eq!(output, "short");
     }
 }

--- a/crates/bazel-mcp-runner/src/service.rs
+++ b/crates/bazel-mcp-runner/src/service.rs
@@ -1107,11 +1107,13 @@ impl InvocationService {
                 let redactor = self.redactor.clone();
                 let (page, total, filtered) = self
                     .store
-                    .page_query_rows_mapped(
+                    .page_query_rows_mapped_into(
                         id,
                         request.filter.as_deref(),
                         page_request,
-                        move |value| redactor.redact_bounded(value, 4 * 1024),
+                        move |value, output| {
+                            redactor.redact_bounded_into(value, 4 * 1024, output);
+                        },
                     )
                     .await?;
                 (
@@ -1563,7 +1565,7 @@ impl InvocationService {
                     let redactor = self.redactor.clone();
                     let (page, total, _) = self
                         .store
-                        .page_query_rows_mapped(
+                        .page_query_rows_mapped_into(
                             queued.request.id,
                             None,
                             PageRequest {
@@ -1571,7 +1573,9 @@ impl InvocationService {
                                 limit: 3,
                                 max_bytes: None,
                             },
-                            move |value| redactor.redact_bounded(value, 4 * 1024),
+                            move |value, output| {
+                                redactor.redact_bounded_into(value, 4 * 1024, output);
+                            },
                         )
                         .await?;
                     (total, page.items)

--- a/crates/bazel-mcp-store/src/storage.rs
+++ b/crates/bazel-mcp-store/src/storage.rs
@@ -1,4 +1,5 @@
 use std::{
+    borrow::Cow,
     collections::{BTreeMap, BTreeSet},
     fs::{File, OpenOptions},
     io::{BufRead, BufReader},
@@ -1128,8 +1129,11 @@ impl Store {
         filter: Option<&str>,
         page: PageRequest,
     ) -> Result<(Page<QueryRow>, u64, u64), StoreError> {
-        self.page_query_rows_mapped(id, filter, page, str::to_owned)
-            .await
+        self.page_query_rows_mapped_into(id, filter, page, |value, output| {
+            output.clear();
+            output.push_str(value);
+        })
+        .await
     }
 
     /// Page raw query output after applying a caller-supplied text transform.
@@ -1144,6 +1148,24 @@ impl Store {
     ) -> Result<(Page<QueryRow>, u64, u64), StoreError>
     where
         F: Fn(&str) -> String + Send + 'static,
+    {
+        self.page_query_rows_mapped_into(id, filter, page, move |value, output| {
+            *output = transform(value);
+        })
+        .await
+    }
+
+    /// Page raw query output while reusing a caller-populated transformation
+    /// buffer across scanned rows.
+    pub async fn page_query_rows_mapped_into<F>(
+        &self,
+        id: InvocationId,
+        filter: Option<&str>,
+        page: PageRequest,
+        transform: F,
+    ) -> Result<(Page<QueryRow>, u64, u64), StoreError>
+    where
+        F: Fn(&str, &mut String) + Send + 'static,
     {
         let mutation_lock = self.mutation_lock(id).await;
         let _guard = mutation_lock.lock().await;
@@ -1811,7 +1833,7 @@ fn page_query_file<F>(
     transform: F,
 ) -> Result<(Page<QueryRow>, u64, u64), StoreError>
 where
-    F: Fn(&str) -> String,
+    F: Fn(&str, &mut String),
 {
     let file = match File::open(path) {
         Ok(file) => file,
@@ -1839,38 +1861,41 @@ where
     let mut reader = BoundedLineReader::new(BufReader::new(file), QUERY_LINE_LIMIT);
     let mut total = 0_u64;
     let mut filtered = 0_u64;
-    let normalized_filter = filter.map(str::to_ascii_lowercase);
     let mut selected = Vec::with_capacity(request.limit);
     let mut used_bytes = 2_usize;
     let mut truncated = false;
-    while let Some(mut line) = reader.next_line()? {
+    let mut transformed = String::new();
+    let mut serialized = Vec::new();
+    while let Some(line) = reader.next_line()? {
         total = total.saturating_add(1);
-        line.value = transform(&line.value);
-        let matches = normalized_filter
-            .as_ref()
-            .is_none_or(|filter| line.value.to_ascii_lowercase().contains(filter));
+        transform(line.value.as_ref(), &mut transformed);
+        let matches = filter.is_none_or(|filter| contains_ignore_ascii_case(&transformed, filter));
         if matches {
             filtered = filtered.saturating_add(1);
             if line.start_offset >= request.start_offset && !truncated {
-                let item_bytes = serde_json::to_vec(&QueryRow {
-                    ordinal: line.ordinal,
-                    value: line.value.clone(),
-                })?
-                .len();
-                let separator = usize::from(!selected.is_empty());
-                if selected.len() == request.limit
-                    || (!selected.is_empty()
+                if selected.len() == request.limit {
+                    truncated = true;
+                } else {
+                    let item_bytes =
+                        serialized_query_row_len(line.ordinal, &transformed, &mut serialized)?;
+                    let separator = usize::from(!selected.is_empty());
+                    if !selected.is_empty()
                         && used_bytes
                             .saturating_add(separator)
                             .saturating_add(item_bytes)
-                            > request.maximum_bytes)
-                {
-                    truncated = true;
-                } else {
-                    used_bytes = used_bytes
-                        .saturating_add(separator)
-                        .saturating_add(item_bytes);
-                    selected.push(line);
+                            > request.maximum_bytes
+                    {
+                        truncated = true;
+                    } else {
+                        used_bytes = used_bytes
+                            .saturating_add(separator)
+                            .saturating_add(item_bytes);
+                        selected.push(SelectedQueryLine {
+                            end_offset: line.end_offset,
+                            ordinal: line.ordinal,
+                            value: std::mem::take(&mut transformed),
+                        });
+                    }
                 }
             }
         }
@@ -1942,7 +1967,7 @@ fn page_unfiltered_query_file<F>(
     transform: F,
 ) -> Result<(Page<QueryRow>, u64, u64), StoreError>
 where
-    F: Fn(&str) -> String,
+    F: Fn(&str, &mut String),
 {
     use std::io::{Seek, SeekFrom};
 
@@ -1956,20 +1981,21 @@ where
     let mut selected = Vec::with_capacity(request.limit);
     let mut used_bytes = 2_usize;
     let mut truncated = false;
-    while let Some(mut line) = reader.next_line()? {
-        line.value = transform(&line.value);
-        let item_bytes = serde_json::to_vec(&QueryRow {
-            ordinal: line.ordinal,
-            value: line.value.clone(),
-        })?
-        .len();
+    let mut transformed = String::new();
+    let mut serialized = Vec::new();
+    while let Some(line) = reader.next_line()? {
+        if selected.len() == request.limit {
+            truncated = true;
+            break;
+        }
+        transform(line.value.as_ref(), &mut transformed);
+        let item_bytes = serialized_query_row_len(line.ordinal, &transformed, &mut serialized)?;
         let separator = usize::from(!selected.is_empty());
-        if selected.len() == request.limit
-            || (!selected.is_empty()
-                && used_bytes
-                    .saturating_add(separator)
-                    .saturating_add(item_bytes)
-                    > request.maximum_bytes)
+        if !selected.is_empty()
+            && used_bytes
+                .saturating_add(separator)
+                .saturating_add(item_bytes)
+                > request.maximum_bytes
         {
             truncated = true;
             break;
@@ -1977,7 +2003,11 @@ where
         used_bytes = used_bytes
             .saturating_add(separator)
             .saturating_add(item_bytes);
-        selected.push(line);
+        selected.push(SelectedQueryLine {
+            end_offset: line.end_offset,
+            ordinal: line.ordinal,
+            value: std::mem::take(&mut transformed),
+        });
     }
     let next_cursor = if truncated {
         selected
@@ -2013,15 +2043,47 @@ where
     ))
 }
 
+#[derive(Serialize)]
+struct BorrowedQueryRow<'a> {
+    ordinal: u64,
+    value: &'a str,
+}
+
+fn serialized_query_row_len(
+    ordinal: u64,
+    value: &str,
+    buffer: &mut Vec<u8>,
+) -> Result<usize, StoreError> {
+    buffer.clear();
+    serde_json::to_writer(&mut *buffer, &BorrowedQueryRow { ordinal, value })?;
+    Ok(buffer.len())
+}
+
+fn contains_ignore_ascii_case(value: &str, needle: &str) -> bool {
+    let needle = needle.as_bytes();
+    needle.is_empty()
+        || value
+            .as_bytes()
+            .windows(needle.len())
+            .any(|window| window.eq_ignore_ascii_case(needle))
+}
+
 struct BoundedLineReader<R> {
     reader: R,
     offset: u64,
     ordinal: u64,
     limit: usize,
+    value: Vec<u8>,
 }
 
-struct BoundedLine {
+struct BoundedLine<'a> {
     start_offset: u64,
+    end_offset: u64,
+    ordinal: u64,
+    value: Cow<'a, str>,
+}
+
+struct SelectedQueryLine {
     end_offset: u64,
     ordinal: u64,
     value: String,
@@ -2038,13 +2100,14 @@ impl<R: BufRead> BoundedLineReader<R> {
             offset,
             ordinal,
             limit,
+            value: Vec::new(),
         }
     }
 
-    fn next_line(&mut self) -> std::io::Result<Option<BoundedLine>> {
+    fn next_line(&mut self) -> std::io::Result<Option<BoundedLine<'_>>> {
         let start_offset = self.offset;
         let ordinal = self.ordinal;
-        let mut value = Vec::new();
+        self.value.clear();
         let mut saw_bytes = false;
         loop {
             let (consumed, newline, reached_eof) = {
@@ -2053,13 +2116,13 @@ impl<R: BufRead> BoundedLineReader<R> {
                     (0, false, true)
                 } else if let Some(position) = available.iter().position(|byte| *byte == b'\n') {
                     let consumed = position + 1;
-                    let copy = position.min(self.limit.saturating_sub(value.len()));
-                    value.extend_from_slice(&available[..copy]);
+                    let copy = position.min(self.limit.saturating_sub(self.value.len()));
+                    self.value.extend_from_slice(&available[..copy]);
                     (consumed, true, false)
                 } else {
                     let consumed = available.len();
-                    let copy = consumed.min(self.limit.saturating_sub(value.len()));
-                    value.extend_from_slice(&available[..copy]);
+                    let copy = consumed.min(self.limit.saturating_sub(self.value.len()));
+                    self.value.extend_from_slice(&available[..copy]);
                     (consumed, false, false)
                 }
             };
@@ -2078,15 +2141,15 @@ impl<R: BufRead> BoundedLineReader<R> {
                 break;
             }
         }
-        if value.last() == Some(&b'\r') {
-            value.pop();
+        if self.value.last() == Some(&b'\r') {
+            self.value.pop();
         }
         self.ordinal = self.ordinal.saturating_add(1);
         Ok(Some(BoundedLine {
             start_offset,
             end_offset: self.offset,
             ordinal,
-            value: String::from_utf8_lossy(&value).into_owned(),
+            value: String::from_utf8_lossy(&self.value),
         }))
     }
 }
@@ -2377,6 +2440,37 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn buffered_query_transform_precedes_ascii_insensitive_filtering() {
+        let root = TempDir::new().unwrap();
+        let store = Store::open(root.path()).await.unwrap();
+        let record = record(root.path());
+        let id = record.request.id;
+        let paths = store.create_invocation(&record).await.unwrap();
+        tokio::fs::write(&paths.stdout, b"first\nMiXeD needle\nthird\n")
+            .await
+            .unwrap();
+        let transformed = Arc::new(AtomicUsize::new(0));
+        let observed = transformed.clone();
+        let (page, total, filtered) = store
+            .page_query_rows_mapped_into(
+                id,
+                Some("mixed NEEDLE"),
+                PageRequest::default(),
+                move |value, output| {
+                    observed.fetch_add(1, AtomicOrdering::Relaxed);
+                    output.clear();
+                    output.push_str(value);
+                },
+            )
+            .await
+            .unwrap();
+
+        assert_eq!((total, filtered), (3, 1));
+        assert_eq!(page.items[0].value, "MiXeD needle");
+        assert_eq!(transformed.load(AtomicOrdering::Relaxed), 3);
+    }
+
+    #[tokio::test]
     async fn serialized_byte_packing_preserves_limit_filter_and_cursor_continuity() {
         let root = TempDir::new().unwrap();
         let store = Store::open(root.path()).await.unwrap();
@@ -2474,7 +2568,7 @@ mod tests {
             .unwrap();
         assert_eq!((total, filtered), (100, 100));
         assert_eq!(page.items.len(), 3);
-        assert_eq!(transformed.load(AtomicOrdering::Relaxed), 4);
+        assert_eq!(transformed.load(AtomicOrdering::Relaxed), 3);
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

- reuse line-reading, query-transformation, redaction, and JSON-serialization buffers during filtered scans
- match filters ASCII-case-insensitively without allocating lowercase copies
- preserve the existing owned transformation API while wiring the runner to a reusable-output path
- record the allocation symptom and follow-up in `LEARNINGS.md`

## Why

A filtered scan over 100,000 query-result rows allocated a fresh line buffer, transformed string, lowercase search string, and serialized row for each candidate. Those temporary objects dominated allocation volume even though only a small page of rows was returned.

The new path keeps reusable scratch storage across candidates, preserves redaction-before-filter behavior, and transfers string ownership only for rows selected for the page.

## Impact

Measured with the same 100,000-row filtered-query fixture:

- DHAT allocated bytes: **14,876,112 → 37,844** (**99.75% reduction**)
- DHAT allocations: **401,020 → 185** (**99.95% reduction**)
- Hyperfine, 20 scans per sample over 10 samples: **326.1 ms → 131.4 ms** (**2.48× faster**)

Cursor behavior, exact byte-budget packing, CRLF handling, invalid UTF-8 handling, and redaction-before-filter semantics remain covered by tests.

## Validation

- `make test`
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo shear`
- `git diff --check`
