### PR TITLE
fix(runner): measure silent native lock waits

### DIFF
--- a/LEARNINGS.md
+++ b/LEARNINGS.md
@@ -25,6 +25,13 @@ unrelated to MCP efficiency. Do not include secrets or raw sensitive output.
   lock, preserve Bazel's native wait-and-takeover behavior, and expose only a
   bounded owner label plus the combined wait duration. Thread:
   `019f6db5-c3bf-77c1-9524-4fed404237c0`.
+- A live Bazel 9.2 contention run waited behind an uncoordinated client and
+  successfully restarted for the next workspace, but emitted no lock-wait text
+  before takeover; the stderr observer therefore sent no wait phase and
+  recorded zero wait milliseconds, leaving the delay opaque to the agent.
+  Observe sanitized owner changes in the known explicit output-base lock file
+  instead of relying only on Bazel stderr markers. Thread:
+  `019f6db5-c3bf-77c1-9524-4fed404237c0`.
 - Listing full durable invocation records exhausted 8 KiB and destructive byte
   shrinking erased IDs and states; keep ledger rows compact and direct users to
   per-invocation views for canonical arguments and detailed diagnostics.

--- a/crates/bazel-mcp-runner/src/output_base_lock.rs
+++ b/crates/bazel-mcp-runner/src/output_base_lock.rs
@@ -222,17 +222,33 @@ pub(crate) struct NativeOutputBaseWaitObserver {
 }
 
 impl NativeOutputBaseWaitObserver {
-    pub(crate) fn start(
+    pub(crate) async fn start(
         stdout: PathBuf,
         stderr: PathBuf,
         bep: PathBuf,
+        output_base: Option<PathBuf>,
         wait_status: Arc<OutputBaseWaitStatus>,
     ) -> Self {
+        let initial_bazel_lock_pid = match output_base.as_deref() {
+            Some(output_base) => active_bazel_lock_owner(output_base).await,
+            None => None,
+        };
+        if let Some(pid) = initial_bazel_lock_pid {
+            wait_status.begin(Some(format!("bazel_client:pid={pid}")));
+        }
         let cancellation = CancellationToken::new();
         let task_cancellation = cancellation.clone();
         let task_status = wait_status.clone();
         let task = tokio::spawn(async move {
-            observe_native_wait(stdout, stderr, bep, task_status, task_cancellation).await;
+            observe_native_wait(
+                stdout,
+                stderr,
+                bep,
+                initial_bazel_lock_pid,
+                task_status,
+                task_cancellation,
+            )
+            .await;
         });
         Self {
             cancellation,
@@ -264,17 +280,24 @@ async fn observe_native_wait(
     stdout: PathBuf,
     stderr: PathBuf,
     bep: PathBuf,
+    initial_bazel_lock_pid: Option<u32>,
     wait_status: Arc<OutputBaseWaitStatus>,
     cancellation: CancellationToken,
 ) {
     let detection_started = Instant::now();
-    let mut waiting = false;
+    let mut waiting = initial_bazel_lock_pid.is_some();
     let mut waiting_marker_end = None;
     let mut baseline_stdout = 0;
     let mut baseline_bep = 0;
     let mut baseline_stderr_len = 0;
 
     loop {
+        if let Some(initial_pid) = initial_bazel_lock_pid
+            && !process_exists(initial_pid)
+        {
+            wait_status.end();
+            return;
+        }
         let stderr_tail = read_bounded_tail(&stderr, NATIVE_WAIT_TAIL_BYTES)
             .await
             .unwrap_or_default();
@@ -327,6 +350,55 @@ async fn observe_native_wait(
             () = tokio::time::sleep(NATIVE_WAIT_POLL_INTERVAL) => {}
         }
     }
+}
+
+async fn active_bazel_lock_owner(output_base: &Path) -> Option<u32> {
+    let pid = read_bazel_lock_owner(output_base).await?;
+    process_exists(pid).then_some(pid)
+}
+
+async fn read_bazel_lock_owner(output_base: &Path) -> Option<u32> {
+    let bytes = read_bounded_prefix(&output_base.join("lock"), OWNER_BYTES_LIMIT)
+        .await
+        .ok()?;
+    parse_bazel_lock_pid(&bytes)
+}
+
+fn parse_bazel_lock_pid(bytes: &[u8]) -> Option<u32> {
+    let text = std::str::from_utf8(bytes).ok()?;
+    text.lines()
+        .find_map(|line| line.strip_prefix("pid="))?
+        .trim()
+        .parse()
+        .ok()
+}
+
+#[cfg(unix)]
+fn process_exists(pid: u32) -> bool {
+    let Ok(pid) = i32::try_from(pid) else {
+        return false;
+    };
+    // SAFETY: signal 0 performs process-existence and permission checks only.
+    if unsafe { libc::kill(pid, 0) } == 0 {
+        return true;
+    }
+    io::Error::last_os_error().raw_os_error() != Some(libc::ESRCH)
+}
+
+#[cfg(not(unix))]
+fn process_exists(_pid: u32) -> bool {
+    // Avoid treating stale Bazel lock metadata as a live wait on platforms
+    // where the runner cannot safely check process liveness.
+    false
+}
+
+async fn read_bounded_prefix(path: &Path, maximum_bytes: u64) -> io::Result<Vec<u8>> {
+    use tokio::io::AsyncReadExt;
+
+    let file = tokio::fs::File::open(path).await?;
+    let mut data = Vec::with_capacity(usize::try_from(maximum_bytes).unwrap_or(4 * 1024));
+    file.take(maximum_bytes).read_to_end(&mut data).await?;
+    Ok(data)
 }
 
 async fn read_bounded_tail(path: &Path, maximum_bytes: usize) -> io::Result<Vec<u8>> {
@@ -400,6 +472,63 @@ mod tests {
         assert_eq!(snapshot.owner.as_deref(), Some("second"));
         status.end();
         assert!(!status.snapshot().active);
+    }
+
+    #[test]
+    fn parses_only_the_bounded_bazel_lock_pid_field() {
+        assert_eq!(
+            parse_bazel_lock_pid(b"pid=12345\nowner=client\ncwd=/private/workspace\n"),
+            Some(12_345)
+        );
+        assert_eq!(parse_bazel_lock_pid(b"owner=client\n"), None);
+        assert_eq!(parse_bazel_lock_pid(b"pid=not-a-pid\n"), None);
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn native_observer_tracks_a_live_explicit_output_base_owner() {
+        let root = tempfile::tempdir().unwrap();
+        let stdout = root.path().join("stdout.log");
+        let stderr = root.path().join("stderr.log");
+        let bep = root.path().join("events.bep");
+        for path in [&stdout, &stderr, &bep] {
+            tokio::fs::write(path, b"").await.unwrap();
+        }
+        let mut holder = tokio::process::Command::new("sleep")
+            .arg("30")
+            .spawn()
+            .unwrap();
+        let holder_pid = holder.id().unwrap();
+        tokio::fs::write(
+            root.path().join("lock"),
+            format!("pid={holder_pid}\nowner=client\ncwd=/redacted\n"),
+        )
+        .await
+        .unwrap();
+        let status = Arc::new(OutputBaseWaitStatus::default());
+        let observer = NativeOutputBaseWaitObserver::start(
+            stdout,
+            stderr,
+            bep,
+            Some(root.path().to_owned()),
+            status.clone(),
+        )
+        .await;
+
+        let snapshot = status.snapshot();
+        assert!(snapshot.active);
+        let expected_owner = format!("bazel_client:pid={holder_pid}");
+        assert_eq!(snapshot.owner.as_deref(), Some(expected_owner.as_str()));
+        holder.kill().await.unwrap();
+        let _ = holder.wait().await;
+        for _ in 0..100 {
+            if !status.snapshot().active {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+        assert!(!status.snapshot().active);
+        observer.finish().await;
     }
 
     #[tokio::test]

--- a/crates/bazel-mcp-runner/src/service.rs
+++ b/crates/bazel-mcp-runner/src/service.rs
@@ -176,6 +176,7 @@ struct PreparedSubmission {
     queued: InvocationRecord,
     paths: InvocationPaths,
     lock_key: PathBuf,
+    explicit_output_base: Option<PathBuf>,
     output_base_wait: Arc<OutputBaseWaitStatus>,
     executable: PathBuf,
     cancellation: CancellationToken,
@@ -552,7 +553,9 @@ impl InvocationService {
             .try_acquire_owned()
             .map_err(|_| RunnerError::QueueFull(self.config.maximum_pending_invocations))?;
         let workspace = validate_workspace(&request.workspace, &self.config.policy.allowed_roots)?;
-        let lock_key = effective_output_base(&workspace, &request.startup_arguments)?
+        let explicit_output_base = effective_output_base(&workspace, &request.startup_arguments)?;
+        let lock_key = explicit_output_base
+            .clone()
             .unwrap_or_else(|| workspace.clone());
         let executable = resolve_bazel_executable(&workspace, &self.config.policy)?;
         self.validate_bazel_version(&executable, &workspace).await?;
@@ -593,6 +596,7 @@ impl InvocationService {
             queued,
             paths,
             lock_key,
+            explicit_output_base,
             output_base_wait,
             executable,
             cancellation,
@@ -609,6 +613,7 @@ impl InvocationService {
             queued,
             paths,
             lock_key,
+            explicit_output_base,
             output_base_wait,
             executable,
             cancellation,
@@ -705,6 +710,7 @@ impl InvocationService {
                     &paths,
                     &executable,
                     cancellation.clone(),
+                    explicit_output_base.as_deref(),
                     output_base_wait,
                 )
                 .await;
@@ -1224,6 +1230,7 @@ impl InvocationService {
         paths: &InvocationPaths,
         executable: &Path,
         cancellation: CancellationToken,
+        explicit_output_base: Option<&Path>,
         output_base_wait: Arc<OutputBaseWaitStatus>,
     ) -> Result<InvocationRecord, RunnerError> {
         if cancellation.is_cancelled() {
@@ -1260,6 +1267,14 @@ impl InvocationService {
                     .map_err(Into::into);
             }
         };
+        let native_output_base_wait = NativeOutputBaseWaitObserver::start(
+            paths.stdout.clone(),
+            paths.stderr.clone(),
+            paths.bep.clone(),
+            explicit_output_base.map(Path::to_owned),
+            output_base_wait.clone(),
+        )
+        .await;
         #[cfg(unix)]
         let mut prepared_fifo = if queued.request.command.class() == CommandClass::BuildLike
             && self.config.bep_transport == BepTransport::Fifo
@@ -1502,12 +1517,6 @@ impl InvocationService {
                     ))
                 })
         });
-        let native_output_base_wait = NativeOutputBaseWaitObserver::start(
-            paths.stdout.clone(),
-            paths.stderr.clone(),
-            paths.bep.clone(),
-            output_base_wait.clone(),
-        );
         let started = Instant::now();
         let timeout = queued
             .request

--- a/crates/bazel-mcp-runner/tests/process.rs
+++ b/crates/bazel-mcp-runner/tests/process.rs
@@ -1902,6 +1902,60 @@ exit 0\n",
 }
 
 #[tokio::test]
+async fn explicit_output_base_owner_is_reported_without_bazel_stderr_markers() {
+    let root = tempfile::tempdir().unwrap();
+    let workspace = root.path().join("workspace");
+    let output_base = root.path().join("shared-output-base");
+    let bazel_started = root.path().join("bazel-started");
+    let release = root.path().join("release");
+    tokio::fs::create_dir(&workspace).await.unwrap();
+    tokio::fs::create_dir(&output_base).await.unwrap();
+    let script = format!(
+        "#!/bin/sh\n\
+if [ \"${{1:-}}\" = --version ]; then echo 'bazel 9.1.0'; exit 0; fi\n\
+touch '{}'\n\
+while [ ! -f '{}' ]; do sleep 0.01; done\n\
+exit 0\n",
+        bazel_started.display(),
+        release.display(),
+    );
+    let service = configured_service(&root, &workspace, &script, |_| {}).await;
+    let mut holder_command = tokio::process::Command::new("sleep");
+    holder_command.arg("30").kill_on_drop(true);
+    let mut holder = holder_command.spawn().unwrap();
+    let holder_pid = holder.id().unwrap();
+    tokio::fs::write(
+        output_base.join("lock"),
+        format!("pid={holder_pid}\nowner=client\ncwd=/private/workspace\n"),
+    )
+    .await
+    .unwrap();
+    let mut request =
+        InvocationRequest::new(workspace, BazelCommand::Build, vec!["//:target".to_owned()]);
+    request.startup_arguments = vec![format!("--output_base={}", output_base.display())];
+    let id = request.id;
+    let run = tokio::spawn({
+        let service = service.clone();
+        async move { service.run(request).await.unwrap() }
+    });
+    wait_for_path(&bazel_started).await;
+    let progress = wait_for_output_base_wait(&service, id).await;
+
+    let expected_owner = format!("bazel_client:pid={holder_pid}");
+    assert_eq!(
+        progress.output_base_lock_owner.as_deref(),
+        Some(expected_owner.as_str())
+    );
+    holder.kill().await.unwrap();
+    let _ = holder.wait().await;
+    tokio::fs::write(&release, b"release").await.unwrap();
+    let record = run.await.unwrap();
+
+    assert_eq!(record.state, InvocationState::Succeeded);
+    assert!(record.metrics.output_base_lock_wait_ms > 0);
+}
+
+#[tokio::test]
 async fn server_owned_flags_precede_the_target_argument_delimiter() {
     let root = tempfile::tempdir().unwrap();
     let workspace = root.path().join("workspace");


### PR DESCRIPTION
## Summary

- detect native Bazel contention for known explicit output bases before starting the waiting Bazel client
- read only the bounded `pid=` owner field and report a sanitized `bazel_client:pid=...` label
- follow the original live holder until it exits, while retaining stderr-marker detection as a fallback
- add unit and process coverage for silent waits and record the MCP observability learning

This is a follow-up to #72 and #74. Bazel 9.2 can wait successfully for an output-base lock without emitting the stderr markers used by the original observer, leaving `output_base_lock_wait_ms` at zero.

## Validation

- `make test`
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo shear`
- `cargo test -p bazel-mcp-runner` after rebasing onto current `main`
- `bazel.run build //:bazel-mcp` through the MCP server
- real Bazel 9.2 integration with two workspaces sharing one output base: both commands succeeded, takeover/restart was observed, and the silent native wait reported `8074 ms` plus progress owner `bazel_client:pid=...`

`make check` reached the local `nix develop` wrapper after formatting and clippy passed; because Nix is unavailable on this host, its underlying `cargo shear` command was run directly and passed.
