### PR TITLE
refactor: separate runner orchestration concerns

### DIFF
--- a/crates/bazel-mcp-reducer/src/lib.rs
+++ b/crates/bazel-mcp-reducer/src/lib.rs
@@ -7,6 +7,7 @@ mod extension;
 mod query;
 mod starlark;
 mod test;
+mod test_evidence;
 mod text;
 
 pub use budget::{Budget, Budgeted};
@@ -25,4 +26,5 @@ pub use starlark::{
     REDUCER_API_VERSION, StarlarkLimits, StarlarkReducerConfig, load_starlark_reducers,
 };
 pub use test::{TestFailureAccumulator, TestFailureEvidence, TestXmlError, parse_test_xml};
+pub use test_evidence::{TestEvidenceInput, TestEvidenceReducer, TestEvidenceResult};
 pub use text::{deduplicate_lines, normalize_terminal_text};

--- a/crates/bazel-mcp-reducer/src/test_evidence.rs
+++ b/crates/bazel-mcp-reducer/src/test_evidence.rs
@@ -1,0 +1,260 @@
+//! Streaming, deterministic reduction of normalized failed-test evidence.
+
+use bazel_mcp_types::{Diagnostic, DiagnosticCategory, Severity, TestCase, TestStatus};
+
+use crate::{
+    JavaScriptTestDiagnosticParser, JavaTestDiagnosticParser, PythonDiagnosticParser,
+    TestFailureAccumulator, TestFailureEvidence, parse_go_diagnostic,
+};
+
+const MAX_FAILURES: usize = 20;
+const MAX_MESSAGE_BYTES: usize = 1_000;
+
+/// Stable context for one failed Bazel test target's evidence stream.
+pub struct TestEvidenceInput<'a> {
+    pub label: &'a str,
+}
+
+/// Deterministically reduced evidence for one failed Bazel test target.
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub struct TestEvidenceResult {
+    pub cases: Vec<TestCase>,
+    pub diagnostics: Vec<Diagnostic>,
+}
+
+/// Streaming reducer for language-specific and framework-specific test output.
+///
+/// Acquisition stays in the runner so raw logs can be durably retained before
+/// this reducer sees normalized, redacted lines.
+pub struct TestEvidenceReducer {
+    label: String,
+    javascript: JavaScriptTestDiagnosticParser,
+    java: JavaTestDiagnosticParser,
+    python: PythonDiagnosticParser,
+    failures: TestFailureAccumulator,
+    extracted_failures: Vec<TestFailureEvidence>,
+    fallback: Option<(u8, Diagnostic)>,
+}
+
+impl TestEvidenceReducer {
+    #[must_use]
+    pub fn new(input: TestEvidenceInput<'_>) -> Self {
+        Self {
+            label: input.label.to_owned(),
+            javascript: JavaScriptTestDiagnosticParser::default(),
+            java: JavaTestDiagnosticParser::default(),
+            python: PythonDiagnosticParser::default(),
+            failures: TestFailureAccumulator::default(),
+            extracted_failures: Vec::new(),
+            fallback: None,
+        }
+    }
+
+    pub fn observe_line(&mut self, line: &str) {
+        let label = &self.label;
+        self.failures.observe_line(line);
+        let javascript_diagnostic = self.javascript.observe_line(line);
+        let java_diagnostic = self.java.observe_line(line);
+        let candidate = if let Some(mut diagnostic) = parse_go_diagnostic(line) {
+            diagnostic.category = DiagnosticCategory::Test;
+            diagnostic.target = Some(label.to_owned());
+            diagnostic.message = bounded_text(&diagnostic.message, MAX_MESSAGE_BYTES);
+            Some((0, diagnostic))
+        } else if let Some(mut diagnostic) = javascript_diagnostic {
+            diagnostic.target = Some(label.to_owned());
+            diagnostic.message = bounded_text(&diagnostic.message, MAX_MESSAGE_BYTES);
+            Some((0, diagnostic))
+        } else if let Some(mut diagnostic) = java_diagnostic {
+            diagnostic.target = Some(label.to_owned());
+            diagnostic.message = bounded_text(&diagnostic.message, MAX_MESSAGE_BYTES);
+            Some((0, diagnostic))
+        } else if let Some(mut diagnostic) = self.python.observe_line(line) {
+            diagnostic.category = DiagnosticCategory::Test;
+            diagnostic.target = Some(label.to_owned());
+            diagnostic.message = bounded_text(&diagnostic.message, MAX_MESSAGE_BYTES);
+            Some((0, diagnostic))
+        } else {
+            failure_evidence_priority(line).map(|priority| {
+                (
+                    priority,
+                    Diagnostic {
+                        severity: Severity::Error,
+                        category: DiagnosticCategory::Test,
+                        message: bounded_text(line, MAX_MESSAGE_BYTES),
+                        location: None,
+                        target: Some(label.to_owned()),
+                        action: None,
+                        repetition_count: 1,
+                    },
+                )
+            })
+        };
+        if let Some((priority, diagnostic)) = candidate
+            && self
+                .fallback
+                .as_ref()
+                .is_none_or(|(current, current_diagnostic)| {
+                    priority < *current
+                        || (priority == *current
+                            && diagnostic.location.is_some()
+                            && current_diagnostic.location.is_none())
+                })
+        {
+            self.fallback = Some((priority, diagnostic));
+        }
+    }
+
+    /// Completes the current log. Incomplete logs do not contribute structured
+    /// failures, matching the runner's durable snapshot semantics.
+    pub fn finish_log(&mut self, complete: bool) {
+        if complete {
+            for mut diagnostic in [self.javascript.finish(), self.java.finish()]
+                .into_iter()
+                .flatten()
+            {
+                diagnostic.target = Some(self.label.clone());
+                diagnostic.message = bounded_text(&diagnostic.message, MAX_MESSAGE_BYTES);
+                if self.fallback.as_ref().is_none_or(|(priority, current)| {
+                    *priority > 0
+                        || (*priority == 0
+                            && diagnostic.location.is_some()
+                            && current.location.is_none())
+                }) {
+                    self.fallback = Some((0, diagnostic));
+                }
+            }
+            for failure in std::mem::take(&mut self.failures).finish() {
+                if self.extracted_failures.len() >= MAX_FAILURES {
+                    break;
+                }
+                if !self.extracted_failures.iter().any(|current| {
+                    current.name == failure.name && current.message == failure.message
+                }) {
+                    self.extracted_failures.push(failure);
+                }
+            }
+        } else {
+            self.failures = TestFailureAccumulator::default();
+        }
+        self.javascript = JavaScriptTestDiagnosticParser::default();
+        self.java = JavaTestDiagnosticParser::default();
+        self.python = PythonDiagnosticParser::default();
+    }
+
+    #[must_use]
+    pub fn finish(self) -> TestEvidenceResult {
+        if self.extracted_failures.is_empty() {
+            return TestEvidenceResult {
+                diagnostics: self
+                    .fallback
+                    .map(|(_, diagnostic)| diagnostic)
+                    .into_iter()
+                    .collect(),
+                ..TestEvidenceResult::default()
+            };
+        }
+
+        let cases = self
+            .extracted_failures
+            .iter()
+            .take(MAX_FAILURES)
+            .map(|failure| TestCase {
+                name: failure.name.clone(),
+                status: TestStatus::Failed,
+                duration_ms: None,
+                message: Some(failure.message.clone()),
+            })
+            .collect();
+        let diagnostics = self
+            .extracted_failures
+            .into_iter()
+            .take(MAX_FAILURES)
+            .map(|failure| Diagnostic {
+                severity: Severity::Error,
+                category: DiagnosticCategory::Test,
+                message: failure.message,
+                location: failure.location,
+                target: Some(self.label.clone()),
+                action: None,
+                repetition_count: 1,
+            })
+            .collect();
+        TestEvidenceResult { cases, diagnostics }
+    }
+}
+
+pub(crate) fn failure_evidence_priority(line: &str) -> Option<u8> {
+    let line = line.trim();
+    let lower = line.to_ascii_lowercase();
+    let base = lower
+        .split_once(" [repeated ")
+        .map_or(lower.as_str(), |(base, _)| base);
+    if matches!(base, "failure:" | "failures:")
+        || (line.starts_with("test ") && base.ends_with(" ... ok"))
+    {
+        return None;
+    }
+    if lower.contains("root_cause")
+        || lower.contains("panicked at")
+        || (lower.contains("assertion") && lower.contains(" failed"))
+    {
+        Some(0)
+    } else if lower.contains("error:")
+        || lower.starts_with("error ")
+        || lower.contains("fatal:")
+        || lower.contains("no such target")
+        || lower.contains("no such package")
+        || lower.contains("undefined reference")
+        || lower.contains("missing strict dependencies")
+        || (lower.contains(".go: import of \"") && lower.ends_with('"'))
+    {
+        Some(1)
+    } else if lower.contains("failed:")
+        || lower.contains("failure")
+        || lower.starts_with("test result: failed")
+        || (line.starts_with("test ") && line.ends_with(" ... FAILED"))
+    {
+        Some(2)
+    } else {
+        None
+    }
+}
+
+fn bounded_text(value: &str, maximum_bytes: usize) -> String {
+    if value.len() <= maximum_bytes {
+        return value.to_owned();
+    }
+    let mut boundary = maximum_bytes;
+    while !value.is_char_boundary(boundary) {
+        boundary -= 1;
+    }
+    format!("{}…", &value[..boundary])
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{TestEvidenceInput, TestEvidenceReducer};
+
+    #[test]
+    fn reducer_prefers_structured_failures_to_fallback_excerpts() {
+        let mut reducer = TestEvidenceReducer::new(TestEvidenceInput {
+            label: "//example:test",
+        });
+        for line in [
+            "error: generic failure",
+            "test example::fails ... FAILED",
+            "---- example::fails stdout ----",
+            "thread 'example::fails' panicked at src/lib.rs:7:3:",
+            "assertion `left == right` failed",
+        ] {
+            reducer.observe_line(line);
+        }
+        reducer.finish_log(true);
+        let result = reducer.finish();
+
+        assert_eq!(result.cases.len(), 1);
+        assert_eq!(result.cases[0].name, "example::fails");
+        assert_eq!(result.diagnostics.len(), 1);
+        assert!(result.diagnostics[0].message.contains("assertion"));
+    }
+}

--- a/crates/bazel-mcp-runner/src/artifacts.rs
+++ b/crates/bazel-mcp-runner/src/artifacts.rs
@@ -1,0 +1,104 @@
+//! Contained local-artifact resolution and coverage loading.
+
+use std::{
+    io,
+    path::{Path, PathBuf},
+};
+
+use bazel_mcp_reducer::parse_lcov_reader;
+use bazel_mcp_types::ArtifactKind;
+
+use crate::service::InvocationService;
+
+impl InvocationService {
+    pub(crate) async fn load_coverage(
+        &self,
+        workspace: &Path,
+        artifacts: &[bazel_mcp_types::Artifact],
+    ) -> Option<bazel_mcp_types::CoverageSummary> {
+        for artifact in artifacts
+            .iter()
+            .filter(|artifact| artifact.kind == ArtifactKind::Coverage)
+        {
+            let Some(canonical) = self.validated_artifact_path(workspace, artifact).await else {
+                continue;
+            };
+            let parsed = tokio::task::spawn_blocking(move || {
+                let file = std::fs::File::open(canonical)?;
+                parse_lcov_reader(std::io::BufReader::new(file))
+                    .map_err(|error| io::Error::new(io::ErrorKind::InvalidData, error))
+            })
+            .await;
+            if let Ok(Ok(coverage)) = parsed {
+                return Some(coverage);
+            }
+        }
+        None
+    }
+
+    pub(crate) async fn validated_artifact_path(
+        &self,
+        workspace: &Path,
+        artifact: &bazel_mcp_types::Artifact,
+    ) -> Option<PathBuf> {
+        let path = local_artifact_path(artifact)?;
+        let canonical = tokio::fs::canonicalize(&path).await.ok()?;
+        let in_workspace = canonical.starts_with(workspace);
+        let in_output_root = if let Some(root) = &self.config.output_user_root {
+            tokio::fs::canonicalize(root)
+                .await
+                .is_ok_and(|root| canonical.starts_with(root))
+        } else {
+            false
+        };
+        let in_bazel_testlogs = if artifact.kind == ArtifactKind::TestLog {
+            match bazel_test_log_output_base(&path).zip(bazel_test_log_output_base(&canonical)) {
+                Some((lexical_root, canonical_root)) => tokio::fs::canonicalize(lexical_root)
+                    .await
+                    .is_ok_and(|lexical_root| {
+                        lexical_root == canonical_root && canonical.starts_with(&lexical_root)
+                    }),
+                None => false,
+            }
+        } else {
+            false
+        };
+        (in_workspace || in_output_root || in_bazel_testlogs).then_some(canonical)
+    }
+}
+
+pub(crate) fn local_artifact_path(artifact: &bazel_mcp_types::Artifact) -> Option<PathBuf> {
+    if !artifact.locally_available {
+        return None;
+    }
+    if let Some(path) = artifact.uri.strip_prefix("file://") {
+        return Some(PathBuf::from(path));
+    }
+    let path = PathBuf::from(&artifact.uri);
+    path.is_absolute().then_some(path)
+}
+
+pub(crate) fn bazel_test_log_output_base(path: &Path) -> Option<PathBuf> {
+    let components = path.components().collect::<Vec<_>>();
+    let execroot = components
+        .iter()
+        .position(|component| component.as_os_str() == "execroot")?;
+    let bazel_out = components
+        .iter()
+        .enumerate()
+        .skip(execroot + 1)
+        .find(|(_, component)| component.as_os_str() == "bazel-out")?
+        .0;
+    components
+        .iter()
+        .enumerate()
+        .skip(bazel_out + 1)
+        .find(|(_, component)| component.as_os_str() == "testlogs")?;
+    if !matches!(
+        path.extension().and_then(|value| value.to_str()),
+        Some("log" | "xml")
+    ) {
+        return None;
+    }
+    Some(components[..execroot].iter().collect())
+}

--- a/crates/bazel-mcp-runner/src/cancel.rs
+++ b/crates/bazel-mcp-runner/src/cancel.rs
@@ -13,6 +13,8 @@ pub(crate) struct ProcessGroupGuard {
 
 impl ProcessGroupGuard {
     pub(crate) fn for_child(child: &Child) -> Self {
+        #[cfg(not(unix))]
+        let _ = child;
         Self {
             #[cfg(unix)]
             process_group: child.id().and_then(|id| i32::try_from(id).ok()),

--- a/crates/bazel-mcp-runner/src/evidence.rs
+++ b/crates/bazel-mcp-runner/src/evidence.rs
@@ -21,6 +21,6 @@ pub(crate) async fn set_private_file(path: &Path) -> Result<(), io::Error> {
 }
 
 #[cfg(not(unix))]
-async fn set_private_file(_path: &Path) -> Result<(), io::Error> {
+pub(crate) async fn set_private_file(_path: &Path) -> Result<(), io::Error> {
     Ok(())
 }

--- a/crates/bazel-mcp-runner/src/evidence.rs
+++ b/crates/bazel-mcp-runner/src/evidence.rs
@@ -1,0 +1,26 @@
+//! Private, atomic persistence for derived invocation evidence.
+
+use std::{io, path::Path};
+
+use tokio::io::AsyncWriteExt;
+
+pub(crate) async fn write_private_atomic(path: &Path, bytes: &[u8]) -> Result<(), io::Error> {
+    let temporary = path.with_extension("tmp");
+    let mut file = tokio::fs::File::create(&temporary).await?;
+    file.write_all(bytes).await?;
+    file.flush().await?;
+    drop(file);
+    set_private_file(&temporary).await?;
+    tokio::fs::rename(temporary, path).await
+}
+
+#[cfg(unix)]
+pub(crate) async fn set_private_file(path: &Path) -> Result<(), io::Error> {
+    use std::os::unix::fs::PermissionsExt;
+    tokio::fs::set_permissions(path, std::fs::Permissions::from_mode(0o600)).await
+}
+
+#[cfg(not(unix))]
+async fn set_private_file(_path: &Path) -> Result<(), io::Error> {
+    Ok(())
+}

--- a/crates/bazel-mcp-runner/src/execution.rs
+++ b/crates/bazel-mcp-runner/src/execution.rs
@@ -1,0 +1,1029 @@
+//! Bazel process execution and terminal summary finalization.
+
+use std::{
+    io,
+    panic::{AssertUnwindSafe, catch_unwind},
+    path::Path,
+    process::ExitStatus,
+    sync::Arc,
+    time::{Duration, Instant},
+};
+
+use bazel_mcp_policy::filtered_environment;
+use bazel_mcp_reducer::{
+    Budget, REDUCER_API_VERSION, ReducerContext, StreamReductionOutput, finalize_diagnostics,
+    normalize_terminal_text,
+};
+use bazel_mcp_store::{InvocationCompletion, InvocationPaths, StoreError};
+use bazel_mcp_types::{
+    BazelCommand, CommandClass, Diagnostic, DiagnosticCategory, InvocationId, InvocationMetrics,
+    InvocationRecord, InvocationRequest, InvocationState, PageRequest, Severity, Termination,
+    TestStatus,
+};
+use tokio::{process::Command, task};
+use tokio_util::sync::CancellationToken;
+
+use crate::{
+    cancel::{ProcessGroupGuard, terminate_child},
+    capture,
+    inspection::should_persist_failure_evidence,
+    output_base_lock::{NativeOutputBaseWaitObserver, OutputBaseWaitStatus},
+    service::{
+        BES_COMPLETION_GRACE, BepTransport, COMPLETE_BEP_LOG_LIMIT, FALLBACK_LOG_LIMIT,
+        InvocationService, RunnerConfig, RunnerError, bounded_text,
+    },
+};
+
+impl InvocationService {
+    pub(crate) async fn execute(
+        &self,
+        queued: &InvocationRecord,
+        paths: &InvocationPaths,
+        executable: &Path,
+        cancellation: CancellationToken,
+        explicit_output_base: Option<&Path>,
+        output_base_wait: Arc<OutputBaseWaitStatus>,
+    ) -> Result<InvocationRecord, RunnerError> {
+        if cancellation.is_cancelled() {
+            return self.finish_cancelled(queued.request.id).await;
+        }
+        let queue_ms = u64::try_from(
+            bazel_mcp_types::unix_timestamp_ms().saturating_sub(queued.request.requested_at_ms),
+        )
+        .unwrap_or_default();
+        let (stdout, stderr) = match capture::open_stdio(paths).await {
+            Ok(streams) => streams,
+            Err(error) => {
+                let message = self.redactor.redact_bounded(
+                    &format!("could not create Bazel evidence files: {error}"),
+                    1_000,
+                );
+                let summary = bazel_mcp_types::InvocationSummary {
+                    success: false,
+                    headline: format!("Could not prepare Bazel invocation: {message}"),
+                    truncated: true,
+                    ..Default::default()
+                };
+                return self
+                    .store
+                    .transition(
+                        queued.request.id,
+                        InvocationState::Failed,
+                        Some(Termination::SpawnFailure {
+                            message: message.clone(),
+                        }),
+                        Some(summary),
+                    )
+                    .await
+                    .map_err(Into::into);
+            }
+        };
+        let native_output_base_wait = NativeOutputBaseWaitObserver::start(
+            paths.stdout.clone(),
+            paths.stderr.clone(),
+            paths.bep.clone(),
+            explicit_output_base.map(Path::to_owned),
+            output_base_wait.clone(),
+        )
+        .await;
+        #[cfg(unix)]
+        let mut prepared_fifo = if queued.request.command.class() == CommandClass::BuildLike
+            && self.config.bep_transport == BepTransport::Fifo
+        {
+            match capture::PreparedFifoBepCapture::prepare(&paths.bep) {
+                Ok(prepared) => match probe_bazel_server_pid(
+                    executable,
+                    &queued.request.workspace,
+                    &queued.request.startup_arguments,
+                    &self.config,
+                    cancellation.clone(),
+                )
+                .await
+                {
+                    Ok(server_pid) => Some((prepared, server_pid)),
+                    Err(error) => {
+                        tracing::warn!(
+                            invocation_id = %queued.request.id,
+                            %error,
+                            "could not discover Bazel server PID; falling back to BEP file tail"
+                        );
+                        None
+                    }
+                },
+                Err(error) => {
+                    tracing::warn!(
+                        invocation_id = %queued.request.id,
+                        %error,
+                        "could not prepare BEP FIFO; falling back to BEP file tail"
+                    );
+                    None
+                }
+            }
+        } else {
+            None
+        };
+        #[cfg(not(unix))]
+        if queued.request.command.class() == CommandClass::BuildLike
+            && self.config.bep_transport == BepTransport::Fifo
+        {
+            tracing::debug!(
+                invocation_id = %queued.request.id,
+                "BEP FIFO transport is unavailable on this platform; using file tail"
+            );
+        }
+        if cancellation.is_cancelled() {
+            return self.finish_cancelled(queued.request.id).await;
+        }
+        let extension_limits = (!self.reducers.is_empty()).then_some({
+            (
+                self.config.starlark_reducers.limits.max_events,
+                self.config.starlark_reducers.limits.max_input_bytes,
+            )
+        });
+        let bes_bep = if queued.request.command.class() == CommandClass::BuildLike {
+            match &self.bes {
+                Some(server) => Some(capture::LiveBepCapture::Bes(capture::BesBepCapture::start(
+                    server.register(queued.request.id.to_string())?,
+                    paths.bep.clone(),
+                    extension_limits,
+                )?)),
+                None => None,
+            }
+        } else {
+            None
+        };
+        let mut command = Command::new(executable);
+        command
+            .current_dir(&queued.request.workspace)
+            .env_clear()
+            .envs(filtered_environment(&self.config.policy));
+        if let Some(output_user_root) = &self.config.output_user_root {
+            command
+                .arg(format!("--output_user_root={}", output_user_root.display()))
+                .arg(format!(
+                    "--max_idle_secs={}",
+                    self.config.isolated_bazel_server_idle_timeout.as_secs()
+                ));
+        }
+        command
+            .args(&queued.request.startup_arguments)
+            .arg(queued.request.command.as_str());
+        if queued.request.command.class() == CommandClass::BuildLike {
+            command.arg(format!("--invocation_id={}", queued.request.id));
+            match self.config.bep_transport {
+                BepTransport::Tail => {
+                    command
+                        .arg(format!("--build_event_binary_file={}", paths.bep.display()))
+                        .arg("--build_event_binary_file_path_conversion=false");
+                }
+                BepTransport::Fifo => {
+                    #[cfg(unix)]
+                    let output = prepared_fifo
+                        .as_ref()
+                        .map_or(paths.bep.as_path(), |(prepared, _)| prepared.path());
+                    #[cfg(not(unix))]
+                    let output = paths.bep.as_path();
+                    command
+                        .arg(format!("--build_event_binary_file={}", output.display()))
+                        .arg("--build_event_binary_file_path_conversion=false");
+                }
+                BepTransport::Bes => {
+                    let endpoint = self
+                        .bes
+                        .as_ref()
+                        .ok_or(RunnerError::InvalidConfiguration(
+                            "BES transport was not initialized",
+                        ))?
+                        .endpoint();
+                    command
+                        .arg(format!("--bes_backend={endpoint}"))
+                        .arg("--bes_upload_mode=wait_for_upload_complete");
+                }
+            }
+            command.args([
+                "--tool_tag=bazel-mcp",
+                "--color=no",
+                "--curses=no",
+                "--show_progress=false",
+                "--show_result=0",
+            ]);
+            if matches!(
+                queued.request.command,
+                BazelCommand::Test | BazelCommand::Coverage
+            ) {
+                command.args(["--test_output=errors", "--test_summary=none"]);
+            }
+        }
+        command.args(&queued.request.arguments);
+        command.stdout(stdout).stderr(stderr).kill_on_drop(true);
+        #[cfg(unix)]
+        {
+            use std::os::unix::process::CommandExt;
+            command.as_std_mut().process_group(0);
+        }
+
+        let mut child = match command.spawn() {
+            Ok(child) => child,
+            Err(error) => {
+                let message = self.redactor.redact_bounded(&error.to_string(), 1_000);
+                let summary = bazel_mcp_types::InvocationSummary {
+                    success: false,
+                    headline: format!("Could not start Bazel: {message}"),
+                    ..Default::default()
+                };
+                return self
+                    .store
+                    .transition(
+                        queued.request.id,
+                        InvocationState::Failed,
+                        Some(Termination::SpawnFailure { message }),
+                        Some(summary),
+                    )
+                    .await
+                    .map_err(Into::into);
+            }
+        };
+        #[cfg(unix)]
+        let fifo_bep = prepared_fifo.take().map(|(prepared, server_pid)| {
+            let client_pid = child.id().unwrap_or_default();
+            capture::LiveBepCapture::Fifo(prepared.start(
+                paths.bep.clone(),
+                server_pid,
+                client_pid,
+                extension_limits,
+            ))
+        });
+        let mut process_group = ProcessGroupGuard::for_child(&child);
+        if let Err(error) = self
+            .store
+            .transition(queued.request.id, InvocationState::Running, None, None)
+            .await
+        {
+            let _ = terminate_child(
+                &mut child,
+                self.config.cancellation_interrupt_grace,
+                self.config.cancellation_terminate_grace,
+            )
+            .await;
+            let workspace = queued.request.workspace.to_string_lossy();
+            let message = self.redactor.redact_bounded(
+                &error.to_string().replace(workspace.as_ref(), "<workspace>"),
+                1_000,
+            );
+            tracing::warn!(
+                invocation_id = %queued.request.id,
+                error = %message,
+                "could not record running Bazel invocation"
+            );
+            if self
+                .store
+                .get_invocation(queued.request.id)
+                .await
+                .is_ok_and(|record| !record.state.is_terminal())
+            {
+                let summary = bazel_mcp_types::InvocationSummary {
+                    success: false,
+                    headline: format!("Could not record Bazel execution state: {message}"),
+                    truncated: true,
+                    inspect_hint: Some("log".to_owned()),
+                    ..Default::default()
+                };
+                let _ = self
+                    .store
+                    .transition(
+                        queued.request.id,
+                        InvocationState::Failed,
+                        Some(Termination::Interrupted),
+                        Some(summary),
+                    )
+                    .await;
+            }
+            if let Ok(record) = self.store.get_invocation(queued.request.id).await
+                && record.state.is_terminal()
+                && record.summary.is_some()
+            {
+                return Ok(record);
+            }
+            return Err(error.into());
+        }
+        #[cfg(unix)]
+        let incremental_bep = fifo_bep.or(bes_bep).or_else(|| {
+            (queued.request.command.class() == CommandClass::BuildLike
+                && self.config.bep_transport != BepTransport::Bes)
+                .then(|| {
+                    capture::LiveBepCapture::Tail(capture::IncrementalBepCapture::start(
+                        paths.bep.clone(),
+                        extension_limits,
+                    ))
+                })
+        });
+        #[cfg(not(unix))]
+        let incremental_bep = bes_bep.or_else(|| {
+            (queued.request.command.class() == CommandClass::BuildLike
+                && self.config.bep_transport != BepTransport::Bes)
+                .then(|| {
+                    capture::LiveBepCapture::Tail(capture::IncrementalBepCapture::start(
+                        paths.bep.clone(),
+                        extension_limits,
+                    ))
+                })
+        });
+        let started = Instant::now();
+        let timeout = queued
+            .request
+            .timeout_ms
+            .map(Duration::from_millis)
+            .unwrap_or(self.config.default_timeout)
+            .max(Duration::from_secs(1))
+            .min(self.config.maximum_timeout);
+        let timeout_sleep = tokio::time::sleep(timeout);
+        tokio::pin!(timeout_sleep);
+        let (status, termination, state) = tokio::select! {
+            result = child.wait() => finish_from_status(result?),
+            () = cancellation.cancelled() => {
+                let status = terminate_child(
+                    &mut child,
+                    self.config.cancellation_interrupt_grace,
+                    self.config.cancellation_terminate_grace,
+                ).await?;
+                (Some(status), Termination::Cancelled, InvocationState::Cancelled)
+            }
+            () = &mut timeout_sleep => {
+                let status = terminate_child(
+                    &mut child,
+                    self.config.cancellation_interrupt_grace,
+                    self.config.cancellation_terminate_grace,
+                ).await?;
+                (Some(status), Termination::Timeout, InvocationState::TimedOut)
+            }
+        };
+        process_group.disarm();
+        native_output_base_wait.finish().await;
+        let output_base_wait_snapshot = output_base_wait.snapshot();
+        let bazel_wall_ms = duration_millis(started.elapsed());
+        let postprocess: Result<InvocationRecord, RunnerError> = async {
+            let reduction_started = Instant::now();
+            let incremental_reduction = match incremental_bep {
+                Some(capture) => {
+                    let reduction = capture.finish(BES_COMPLETION_GRACE).await?;
+                    tracing::debug!(
+                        invocation_id = %queued.request.id,
+                        source = ?reduction.source,
+                        finalize_ms = reduction.finalize_ms,
+                        events = reduction.outcome.event_count,
+                        bytes = reduction.outcome.decoded_bytes,
+                        "completed incremental BEP reduction"
+                    );
+                    Some(reduction)
+                }
+                None => None,
+            };
+            let (query_row_count, query_sample) =
+                if queued.request.command.class() == CommandClass::Query {
+                    let redactor = self.redactor.clone();
+                    let (page, total, _) = self
+                        .store
+                        .page_query_rows_mapped_into(
+                            queued.request.id,
+                            None,
+                            PageRequest {
+                                cursor: None,
+                                limit: 3,
+                                max_bytes: None,
+                            },
+                            move |value, output| {
+                                redactor.redact_bounded_into(value, 4 * 1024, output);
+                            },
+                        )
+                        .await?;
+                    (total, page.items)
+                } else {
+                    (0, Vec::new())
+                };
+            let (bep, bep_outcome) = match incremental_reduction {
+                Some(reduction) => (reduction.accumulator, reduction.outcome),
+                None => capture::reduce_bep(paths.bep.clone(), extension_limits).await?,
+            };
+            if let Some(error) = &bep_outcome.terminal_error {
+                tracing::warn!(invocation_id = %queued.request.id, %error, "partially decoded BEP");
+            }
+            // Complete structured evidence needs only a small diagnostic tail;
+            // partial or missing BEP retains a larger bounded fallback.
+            let log_limit = if bep_outcome.event_count > 0 && bep_outcome.terminal_error.is_none() {
+                COMPLETE_BEP_LOG_LIMIT
+            } else {
+                FALLBACK_LOG_LIMIT
+            };
+            let stdout = capture::read_bounded_tail(&paths.stdout, log_limit).await?;
+            let stderr = capture::read_bounded_tail(&paths.stderr, log_limit).await?;
+            let exit_code = status.as_ref().and_then(ExitStatus::code);
+            let failed = exit_code != Some(0);
+            if should_persist_failure_evidence(&queued.request.command, failed) {
+                self.persist_failure_evidence(
+                    paths,
+                    &queued.request.workspace,
+                    &queued.request.command,
+                    failed,
+                    &stdout,
+                    &stderr,
+                )
+                .await?;
+            }
+            let reduced = catch_unwind(AssertUnwindSafe(|| {
+                bep.finish(
+                    &stdout,
+                    &stderr,
+                    exit_code,
+                    bazel_wall_ms,
+                    // Enrichment can add higher-value failed-test evidence.
+                    // Apply the public result budget only after that evidence
+                    // is present so ranking and aggregation precede limits.
+                    Budget {
+                        max_bytes: usize::MAX,
+                        max_items: usize::MAX,
+                    },
+                )
+            }));
+            let StreamReductionOutput {
+                mut summary,
+                mut artifacts,
+                canonical_arguments,
+                reducer_events,
+                reducer_input_truncated,
+            } = reduced.unwrap_or_else(|_| {
+                tracing::warn!(
+                    invocation_id = %queued.request.id,
+                    "streaming BEP reducer panicked; using bounded fallback summary"
+                );
+                StreamReductionOutput {
+                    summary: fallback_summary(exit_code, bazel_wall_ms, &stderr, &stdout),
+                    artifacts: Vec::new(),
+                    canonical_arguments: None,
+                    reducer_events: Vec::new(),
+                    reducer_input_truncated: false,
+                }
+            });
+            let canonical_arguments = canonical_arguments.map(|mut arguments| {
+                let workspace = queued.request.workspace.to_string_lossy();
+                for argument in &mut arguments {
+                    *argument = self.redactor.redact_bounded(
+                        &argument.replace(workspace.as_ref(), "<workspace>"),
+                        64 * 1024,
+                    );
+                }
+                arguments
+            });
+            for artifact in &mut artifacts {
+                artifact.name = self.redactor.redact_bounded(&artifact.name, 1_000);
+                artifact.uri = self.redactor.redact_bounded(&artifact.uri, 1_000);
+            }
+            if queued.request.command.class() == CommandClass::Query && exit_code == Some(0) {
+                summary.headline = format!("Bazel query returned {query_row_count} rows");
+                summary.inspect_hint = (query_row_count > 0).then(|| "query_results".to_owned());
+                summary.query_result_count = Some(query_row_count);
+                summary.query_sample = query_sample;
+            } else if matches!(
+                queued.request.command.class(),
+                CommandClass::Informational | CommandClass::Unknown
+            ) && exit_code == Some(0)
+            {
+                let text = if stdout.is_empty() { &stderr } else { &stdout };
+                let excerpt = normalize_terminal_text(text);
+                if !excerpt.is_empty() {
+                    summary.headline = bounded_text(&excerpt, 1_000);
+                    if excerpt.len() > 1_000 {
+                        summary.truncated = true;
+                        summary.inspect_hint = Some("log".to_owned());
+                    }
+                }
+            }
+            self.enrich_tests(paths, &queued.request.workspace, &mut summary, &artifacts)
+                .await;
+            if queued.request.command == BazelCommand::Coverage {
+                summary.coverage = self
+                    .load_coverage(&queued.request.workspace, &artifacts)
+                    .await;
+            }
+            let mut custom_headline = None;
+            let mut custom_notices = Vec::new();
+            if !self.reducers.is_empty() {
+                let context = self.reducer_context(
+                    &queued.request,
+                    exit_code,
+                    bazel_wall_ms,
+                    &stdout,
+                    &stderr,
+                    reducer_events,
+                    reducer_input_truncated,
+                    &summary,
+                );
+                let reducers = self.reducers.clone();
+                let (next_summary, report) = task::spawn_blocking(move || {
+                    let mut next_summary = summary;
+                    let report = reducers.apply(&context, &mut next_summary);
+                    (next_summary, report)
+                })
+                .await?;
+                summary = next_summary;
+                if report.headline_applied {
+                    custom_headline = Some(summary.headline.clone());
+                }
+                for name in report.applied {
+                    let name = self.redactor.redact_bounded(&name, 128);
+                    tracing::debug!(invocation_id = %queued.request.id, reducer = %name, "applied custom reducer");
+                }
+                for failure in report.failures {
+                    let name = self.redactor.redact_bounded(&failure.name, 128);
+                    let error = self.redactor.redact_bounded(&failure.error, 2 * 1024);
+                    tracing::warn!(
+                        invocation_id = %queued.request.id,
+                        reducer = %name,
+                        %error,
+                        "custom reducer failed; native result retained"
+                    );
+                    custom_notices.push(custom_reducer_notice(format!(
+                        "Custom reducer {:?} failed; native reducer output was retained",
+                        name
+                    )));
+                }
+                for collision in report.override_collisions {
+                    let collision = self.redactor.redact_bounded(&collision, 512);
+                    tracing::warn!(invocation_id = %queued.request.id, %collision, "custom reducer override collision");
+                    custom_notices.push(custom_reducer_notice(collision));
+                }
+            }
+            finalize_with_custom_notices(&mut summary, custom_notices);
+            if let Some(headline) = custom_headline {
+                summary.headline = headline;
+            }
+            if !summary.success && summary.inspect_hint.is_none() {
+                let view = if summary
+                    .tests
+                    .iter()
+                    .any(|test| test.status != TestStatus::Passed && test.test_log_available)
+                {
+                    "test_log"
+                } else {
+                    "log"
+                };
+                summary.inspect_hint = Some(view.to_owned());
+            }
+            self.sanitize_summary(queued.request.id, &queued.request.workspace, &mut summary);
+            let metrics = InvocationMetrics {
+                raw_output_bytes: capture::file_size(&paths.stdout)
+                    .await
+                    .saturating_add(capture::file_size(&paths.stderr).await),
+                bep_bytes: capture::file_size(&paths.bep).await,
+                bep_events: u64::try_from(bep_outcome.event_count).unwrap_or(u64::MAX),
+                queue_ms,
+                output_base_lock_wait_ms: output_base_wait_snapshot.elapsed_ms,
+                bazel_wall_ms,
+                reduction_ms: duration_millis(reduction_started.elapsed()),
+                ..Default::default()
+            };
+            self.store
+                .finish_invocation(
+                    queued.request.id,
+                    InvocationCompletion {
+                        state,
+                        termination: termination.clone(),
+                        summary,
+                        metrics,
+                        canonical_arguments,
+                        artifacts,
+                    },
+                )
+                .await
+                .map_err(Into::into)
+        }
+        .await;
+
+        if let Err(error) = &postprocess {
+            let workspace = queued.request.workspace.to_string_lossy();
+            let message = self.redactor.redact_bounded(
+                &error.to_string().replace(workspace.as_ref(), "<workspace>"),
+                1_000,
+            );
+            tracing::warn!(
+                invocation_id = %queued.request.id,
+                error = %message,
+                "Bazel result post-processing failed"
+            );
+            if self
+                .store
+                .get_invocation(queued.request.id)
+                .await
+                .is_ok_and(|record| !record.state.is_terminal())
+            {
+                let terminal_state = if state == InvocationState::Succeeded {
+                    InvocationState::Failed
+                } else {
+                    state
+                };
+                let summary = bazel_mcp_types::InvocationSummary {
+                    success: false,
+                    headline: format!("Could not finish processing Bazel results: {message}"),
+                    elapsed_ms: bazel_wall_ms,
+                    truncated: true,
+                    inspect_hint: Some("log".to_owned()),
+                    ..Default::default()
+                };
+                let _ = self
+                    .store
+                    .transition(
+                        queued.request.id,
+                        terminal_state,
+                        Some(termination),
+                        Some(summary),
+                    )
+                    .await;
+            }
+            if let Ok(record) = self.store.get_invocation(queued.request.id).await
+                && record.state.is_terminal()
+                && record.summary.is_some()
+            {
+                return Ok(record);
+            }
+        }
+        postprocess
+    }
+
+    fn sanitize_summary(
+        &self,
+        _id: InvocationId,
+        workspace: &Path,
+        summary: &mut bazel_mcp_types::InvocationSummary,
+    ) {
+        let workspace = workspace.to_string_lossy();
+        let sanitize = |value: &str, maximum_bytes| {
+            self.redactor.redact_bounded(
+                &value.replace(workspace.as_ref(), "<workspace>"),
+                maximum_bytes,
+            )
+        };
+        summary.headline = sanitize(&summary.headline, 1_000);
+        for target in &mut summary.targets {
+            target.label = sanitize(&target.label, 1_000);
+        }
+        for diagnostic in &mut summary.diagnostics {
+            diagnostic.message = sanitize(&diagnostic.message, 1_000);
+            if let Some(location) = &mut diagnostic.location {
+                let path = location.path.replace(workspace.as_ref(), "<workspace>");
+                let path = path
+                    .strip_prefix("<workspace>/")
+                    .or_else(|| path.strip_prefix("<workspace>\\"))
+                    .or_else(|| path.strip_prefix("<WORKSPACE>/"))
+                    .or_else(|| path.strip_prefix("<WORKSPACE>\\"))
+                    .unwrap_or(&path);
+                location.path = self.redactor.redact_bounded(path, 1_000);
+            }
+            diagnostic.target = diagnostic
+                .target
+                .as_deref()
+                .map(|target| sanitize(target, 1_000));
+            diagnostic.action = diagnostic
+                .action
+                .as_deref()
+                .map(|action| sanitize(action, 1_000));
+        }
+        for test in &mut summary.tests {
+            test.label = sanitize(&test.label, 1_000);
+            for case in &mut test.cases {
+                case.name = sanitize(&case.name, 512);
+                case.message = case
+                    .message
+                    .as_deref()
+                    .map(|message| sanitize(message, 1_000));
+            }
+        }
+        if let Some(coverage) = &mut summary.coverage {
+            for file in &mut coverage.files {
+                file.path = sanitize(&file.path, 1_000);
+            }
+        }
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn reducer_context(
+        &self,
+        request: &InvocationRequest,
+        exit_code: Option<i32>,
+        elapsed_ms: u64,
+        stdout: &[u8],
+        stderr: &[u8],
+        mut events: Vec<bazel_mcp_reducer::ReducerEvent>,
+        mut input_truncated: bool,
+        summary: &bazel_mcp_types::InvocationSummary,
+    ) -> ReducerContext {
+        let maximum_input = self.config.starlark_reducers.limits.max_input_bytes;
+        let workspace = request.workspace.to_string_lossy();
+        let sanitize = |value: &str, maximum_bytes| {
+            self.redactor.redact_bounded(
+                &value.replace(workspace.as_ref(), "<workspace>"),
+                maximum_bytes,
+            )
+        };
+        let stdout = normalize_terminal_text(stdout);
+        let stderr = normalize_terminal_text(stderr);
+        let (stdout_limit, stderr_limit) = match (stdout.is_empty(), stderr.is_empty()) {
+            (false, true) => (maximum_input, 0),
+            (true, false) => (0, maximum_input),
+            _ => (
+                maximum_input / 2,
+                maximum_input.saturating_sub(maximum_input / 2),
+            ),
+        };
+        input_truncated |= stdout.len() > stdout_limit || stderr.len() > stderr_limit;
+        let stdout = sanitize(&stdout, stdout_limit);
+        let stderr = sanitize(&stderr, stderr_limit);
+        for event in &mut events {
+            event.label = event
+                .label
+                .as_deref()
+                .map(|value| sanitize(value, 4 * 1024));
+            event.target_kind = event
+                .target_kind
+                .as_deref()
+                .map(|value| sanitize(value, 4 * 1024));
+            event.action_type = event
+                .action_type
+                .as_deref()
+                .map(|value| sanitize(value, 4 * 1024));
+            event.message = event
+                .message
+                .as_deref()
+                .map(|value| sanitize(value, 64 * 1024));
+        }
+        const MAX_ARGUMENTS: usize = 1_024;
+        let raw_arguments = request
+            .startup_arguments
+            .iter()
+            .chain(request.arguments.iter());
+        let arguments = raw_arguments
+            .take(MAX_ARGUMENTS)
+            .map(|value| sanitize(value, 4 * 1024))
+            .collect::<Vec<_>>();
+        input_truncated |= request
+            .startup_arguments
+            .len()
+            .saturating_add(request.arguments.len())
+            > MAX_ARGUMENTS;
+        let mut baseline = summary.clone();
+        finalize_diagnostics(
+            &mut baseline,
+            Budget {
+                max_bytes: maximum_input / 4,
+                max_items: self.config.starlark_reducers.limits.max_output_items,
+            },
+        );
+        self.sanitize_summary(request.id, &request.workspace, &mut baseline);
+        ReducerContext {
+            api_version: REDUCER_API_VERSION,
+            command: request.command.as_str().to_owned(),
+            arguments,
+            exit_code,
+            elapsed_ms,
+            stdout,
+            stderr,
+            events,
+            input_truncated,
+            baseline,
+        }
+    }
+
+    pub(crate) async fn finish_cancelled(
+        &self,
+        id: InvocationId,
+    ) -> Result<InvocationRecord, RunnerError> {
+        let current = self.store.get_invocation(id).await?;
+        if current.state.is_terminal() {
+            return Ok(current);
+        }
+        match self
+            .store
+            .transition(
+                id,
+                InvocationState::Cancelled,
+                Some(Termination::Cancelled),
+                Some(cancelled_summary()),
+            )
+            .await
+        {
+            Ok(record) => Ok(record),
+            Err(StoreError::State(_)) => {
+                let record = self.store.get_invocation(id).await?;
+                if record.state.is_terminal() {
+                    Ok(record)
+                } else {
+                    Err(RunnerError::Store(StoreError::State(
+                        bazel_mcp_types::StateTransitionError {
+                            current: record.state,
+                            next: InvocationState::Cancelled,
+                        },
+                    )))
+                }
+            }
+            Err(error) => Err(error.into()),
+        }
+    }
+}
+
+#[cfg(unix)]
+pub(crate) async fn probe_bazel_server_pid(
+    executable: &Path,
+    workspace: &Path,
+    startup_arguments: &[String],
+    config: &RunnerConfig,
+    cancellation: CancellationToken,
+) -> io::Result<u32> {
+    let mut command = Command::new(executable);
+    command
+        .current_dir(workspace)
+        .env_clear()
+        .envs(filtered_environment(&config.policy));
+    if let Some(output_user_root) = &config.output_user_root {
+        command
+            .arg(format!("--output_user_root={}", output_user_root.display()))
+            .arg(format!(
+                "--max_idle_secs={}",
+                config.isolated_bazel_server_idle_timeout.as_secs()
+            ));
+    }
+    command
+        .args(startup_arguments)
+        .arg("info")
+        .arg("server_pid")
+        .stdin(std::process::Stdio::null())
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::null())
+        .kill_on_drop(true);
+
+    let output = tokio::select! {
+        result = tokio::time::timeout(config.version_check_timeout, command.output()) => {
+            result.map_err(|_| io::Error::new(io::ErrorKind::TimedOut, "Bazel server PID probe timed out"))??
+        }
+        () = cancellation.cancelled() => {
+            return Err(io::Error::new(io::ErrorKind::Interrupted, "Bazel server PID probe cancelled"));
+        }
+    };
+    if !output.status.success() {
+        return Err(io::Error::other(format!(
+            "Bazel server PID probe exited with {:?}",
+            output.status.code()
+        )));
+    }
+    let stdout = String::from_utf8(output.stdout).map_err(|_| {
+        io::Error::new(io::ErrorKind::InvalidData, "Bazel server PID was not UTF-8")
+    })?;
+    stdout
+        .lines()
+        .find_map(|line| {
+            let value = line
+                .trim()
+                .strip_prefix("server_pid:")
+                .map_or_else(|| line.trim(), str::trim);
+            value.parse::<u32>().ok()
+        })
+        .filter(|pid| *pid > 0 && *pid <= i32::MAX as u32)
+        .ok_or_else(|| {
+            io::Error::new(
+                io::ErrorKind::InvalidData,
+                "Bazel server PID probe returned no valid PID",
+            )
+        })
+}
+
+pub(crate) fn custom_reducer_notice(message: String) -> Diagnostic {
+    Diagnostic {
+        severity: Severity::Note,
+        category: DiagnosticCategory::Bazel,
+        message,
+        location: None,
+        target: None,
+        action: None,
+        repetition_count: 1,
+    }
+}
+
+pub(crate) fn finalize_with_custom_notices(
+    summary: &mut bazel_mcp_types::InvocationSummary,
+    notices: Vec<Diagnostic>,
+) {
+    if notices.is_empty() {
+        finalize_diagnostics(summary, Budget::result_default());
+        return;
+    }
+    let mut notice_summary = bazel_mcp_types::InvocationSummary {
+        success: true,
+        diagnostics: notices,
+        ..Default::default()
+    };
+    finalize_diagnostics(
+        &mut notice_summary,
+        Budget {
+            max_bytes: 1024,
+            max_items: 4,
+        },
+    );
+    let notices = notice_summary.diagnostics;
+    let notice_bytes = notices
+        .iter()
+        .map(|notice| notice.message.len())
+        .sum::<usize>();
+    let budget = Budget::result_default();
+    finalize_diagnostics(
+        summary,
+        Budget {
+            max_bytes: budget.max_bytes.saturating_sub(notice_bytes),
+            max_items: budget.max_items.saturating_sub(notices.len()),
+        },
+    );
+    summary.diagnostics.extend(notices);
+    if notice_summary.truncated {
+        summary.truncated = true;
+        summary.inspect_hint = Some("diagnostics".to_owned());
+    }
+}
+
+pub(crate) fn finish_from_status(
+    status: ExitStatus,
+) -> (Option<ExitStatus>, Termination, InvocationState) {
+    let state = if status.success() {
+        InvocationState::Succeeded
+    } else {
+        InvocationState::Failed
+    };
+    if let Some(code) = status.code() {
+        (Some(status), Termination::Exit { code }, state)
+    } else {
+        #[cfg(unix)]
+        {
+            use std::os::unix::process::ExitStatusExt;
+            let signal = status.signal().unwrap_or_default();
+            (Some(status), Termination::Signal { signal }, state)
+        }
+        #[cfg(not(unix))]
+        {
+            (Some(status), Termination::Exit { code: -1 }, state)
+        }
+    }
+}
+
+pub(crate) fn duration_millis(duration: Duration) -> u64 {
+    u64::try_from(duration.as_millis()).unwrap_or(u64::MAX)
+}
+
+pub(crate) fn cancelled_summary() -> bazel_mcp_types::InvocationSummary {
+    bazel_mcp_types::InvocationSummary {
+        success: false,
+        headline: "Bazel invocation was cancelled before starting".to_owned(),
+        ..Default::default()
+    }
+}
+
+pub(crate) fn fallback_summary(
+    exit_code: Option<i32>,
+    elapsed_ms: u64,
+    stderr: &[u8],
+    stdout: &[u8],
+) -> bazel_mcp_types::InvocationSummary {
+    let success = exit_code == Some(0);
+    let text = if stderr.is_empty() { stdout } else { stderr };
+    let message = normalize_terminal_text(text)
+        .lines()
+        .rev()
+        .find(|line| !line.trim().is_empty())
+        .map(|line| bounded_text(line, 1_000));
+    let diagnostics = if success {
+        Vec::new()
+    } else {
+        message
+            .as_ref()
+            .map(|message| Diagnostic {
+                severity: Severity::Error,
+                category: DiagnosticCategory::Unknown,
+                message: message.clone(),
+                location: None,
+                target: None,
+                action: None,
+                repetition_count: 1,
+            })
+            .into_iter()
+            .collect()
+    };
+    bazel_mcp_types::InvocationSummary {
+        success,
+        headline: if success {
+            format!("Bazel completed successfully in {elapsed_ms} ms")
+        } else if let Some(message) = message {
+            format!("Bazel failed: {message}")
+        } else {
+            format!("Bazel failed with exit code {exit_code:?}")
+        },
+        diagnostics,
+        elapsed_ms,
+        truncated: true,
+        inspect_hint: Some("log".to_owned()),
+        ..Default::default()
+    }
+}

--- a/crates/bazel-mcp-runner/src/execution.rs
+++ b/crates/bazel-mcp-runner/src/execution.rs
@@ -1,13 +1,15 @@
 //! Bazel process execution and terminal summary finalization.
 
 use std::{
-    io,
     panic::{AssertUnwindSafe, catch_unwind},
     path::Path,
     process::ExitStatus,
     sync::Arc,
     time::{Duration, Instant},
 };
+
+#[cfg(unix)]
+use std::io;
 
 use bazel_mcp_policy::filtered_environment;
 use bazel_mcp_reducer::{
@@ -30,9 +32,12 @@ use crate::{
     output_base_lock::{NativeOutputBaseWaitObserver, OutputBaseWaitStatus},
     service::{
         BES_COMPLETION_GRACE, BepTransport, COMPLETE_BEP_LOG_LIMIT, FALLBACK_LOG_LIMIT,
-        InvocationService, RunnerConfig, RunnerError, bounded_text,
+        InvocationService, RunnerError, bounded_text,
     },
 };
+
+#[cfg(unix)]
+use crate::service::RunnerConfig;
 
 impl InvocationService {
     pub(crate) async fn execute(

--- a/crates/bazel-mcp-runner/src/inspection.rs
+++ b/crates/bazel-mcp-runner/src/inspection.rs
@@ -1,0 +1,788 @@
+//! Bounded inspection requests, pagination, and response shaping.
+
+use std::{
+    collections::BTreeMap,
+    io,
+    path::{Path, PathBuf},
+};
+
+use base64::{Engine, engine::general_purpose::URL_SAFE_NO_PAD};
+use bazel_mcp_reducer::normalize_terminal_text;
+use bazel_mcp_store::{InvocationPaths, StoreError};
+use bazel_mcp_types::{
+    ArtifactKind, BazelCommand, CommandClass, InvocationId, InvocationRecord, InvocationState,
+    PageRequest, Termination,
+};
+use serde::{Deserialize, Serialize};
+use tokio::io::{AsyncBufReadExt, BufReader};
+
+use crate::{
+    capture,
+    evidence::write_private_atomic,
+    service::{InvocationService, RunnerError, bounded_text},
+};
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum InspectView {
+    Summary,
+    Metrics,
+    Diagnostics,
+    Tests,
+    TestLog,
+    Coverage,
+    Artifacts,
+    QueryResults,
+    Log,
+    Invocations,
+}
+
+#[derive(Clone, Debug)]
+pub struct InspectRequest {
+    pub invocation_id: Option<InvocationId>,
+    pub workspace: Option<PathBuf>,
+    pub state: Option<InvocationState>,
+    pub command: Option<BazelCommand>,
+    pub view: InspectView,
+    pub cursor: Option<String>,
+    pub filter: Option<String>,
+    pub limit: u32,
+    pub max_bytes: usize,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub(crate) struct LogCursor {
+    invocation_id: InvocationId,
+    view: InspectView,
+    pub(crate) next_record: u64,
+    filter: Option<String>,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub(crate) struct EvidenceRecord {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) label: Option<String>,
+    pub(crate) text: String,
+}
+
+impl LogCursor {
+    pub(crate) fn encode(&self) -> Result<String, RunnerError> {
+        Ok(URL_SAFE_NO_PAD.encode(serde_json::to_vec(self)?))
+    }
+
+    fn decode(value: &str) -> Result<Self, RunnerError> {
+        let raw = URL_SAFE_NO_PAD
+            .decode(value)
+            .map_err(|_| RunnerError::InvalidOffset)?;
+        serde_json::from_slice(&raw).map_err(|_| RunnerError::InvalidOffset)
+    }
+
+    pub(crate) fn decode_for(
+        value: &str,
+        invocation_id: InvocationId,
+        view: InspectView,
+        filter: Option<&str>,
+    ) -> Result<Self, RunnerError> {
+        let cursor = Self::decode(value)?;
+        if cursor.invocation_id != invocation_id
+            || cursor.view != view
+            || cursor.filter.as_deref() != filter
+        {
+            return Err(RunnerError::InvalidOffset);
+        }
+        Ok(cursor)
+    }
+}
+
+#[derive(Clone, Debug, Serialize)]
+pub struct InspectResult {
+    pub invocation_id: Option<InvocationId>,
+    pub view: InspectView,
+    pub items: serde_json::Value,
+    pub total_count: Option<u64>,
+    pub filtered_count: Option<u64>,
+    pub next_cursor: Option<String>,
+    pub truncated: bool,
+}
+
+impl InvocationService {
+    pub async fn inspect(&self, request: InspectRequest) -> Result<InspectResult, RunnerError> {
+        if request.view == InspectView::Invocations {
+            let mut limit = request.limit.clamp(1, 100);
+            loop {
+                let page = self
+                    .store
+                    .list_invocations(
+                        request.workspace.as_deref(),
+                        request.state,
+                        request.command.as_ref(),
+                        PageRequest {
+                            cursor: request.cursor.clone(),
+                            limit,
+                            max_bytes: None,
+                        },
+                    )
+                    .await?;
+                let result = InspectResult {
+                    invocation_id: None,
+                    view: request.view,
+                    items: serde_json::Value::Array(
+                        page.items.iter().map(invocation_ledger_row).collect(),
+                    ),
+                    total_count: None,
+                    filtered_count: None,
+                    next_cursor: page.next_cursor,
+                    truncated: page.truncated,
+                };
+                if serialized_len(&result)? <= request.max_bytes || limit == 1 {
+                    return enforce_inspect_budget(result, request.max_bytes);
+                }
+                limit = (limit / 2).max(1);
+            }
+        }
+
+        let id = request.invocation_id.ok_or(StoreError::InvalidCursor)?;
+        let record = self.store.get_invocation(id).await?;
+        let page_request = PageRequest {
+            cursor: request.cursor.clone(),
+            limit: request.limit.clamp(1, 100),
+            max_bytes: Some(request.max_bytes.saturating_sub(512)),
+        };
+        let paths = self.store.paths_for(&record);
+        let (items, total_count, filtered_count, next_cursor, truncated) = match request.view {
+            InspectView::Summary => {
+                let items = record.summary.as_ref().map_or_else(Vec::new, |summary| {
+                    vec![serde_json::json!({
+                        "success": summary.success,
+                        "headline": summary.headline,
+                        "targets": summary.target_counts,
+                        "tests": summary.test_counts,
+                        "diagnostics": summary.diagnostics,
+                        "coverage": summary.coverage.as_ref().map(|coverage| serde_json::json!({
+                            "lines_found": coverage.lines_found,
+                            "lines_hit": coverage.lines_hit,
+                            "coverage_percent": coverage.coverage_percent,
+                        })),
+                        "query_result_count": summary.query_result_count,
+                        "query_sample": summary.query_sample,
+                        "elapsed_ms": summary.elapsed_ms,
+                        "truncated": summary.truncated,
+                        "inspect_hint": summary.inspect_hint,
+                    })]
+                });
+                (
+                    serde_json::to_value(items)?,
+                    Some(u64::from(record.summary.is_some())),
+                    Some(u64::from(record.summary.is_some())),
+                    None,
+                    record
+                        .summary
+                        .as_ref()
+                        .is_some_and(|summary| summary.truncated),
+                )
+            }
+            InspectView::Metrics => {
+                let items = vec![serde_json::json!({
+                    "state": record.state,
+                    "requested_at_ms": record.request.requested_at_ms,
+                    "started_at_ms": record.started_at_ms,
+                    "finished_at_ms": record.finished_at_ms,
+                    "termination": record.termination,
+                    "metrics": record.metrics,
+                })];
+                (serde_json::to_value(items)?, Some(1), Some(1), None, false)
+            }
+            InspectView::Diagnostics => {
+                let (page, total, filtered) = self
+                    .store
+                    .page_diagnostics(id, request.filter.as_deref(), page_request)
+                    .await?;
+                (
+                    serde_json::to_value(page.items)?,
+                    Some(total),
+                    Some(filtered),
+                    page.next_cursor,
+                    page.truncated,
+                )
+            }
+            InspectView::Tests => {
+                let (page, total, filtered) = self
+                    .store
+                    .page_tests(id, request.filter.as_deref(), page_request)
+                    .await?;
+                (
+                    serde_json::to_value(page.items)?,
+                    Some(total),
+                    Some(filtered),
+                    page.next_cursor,
+                    page.truncated,
+                )
+            }
+            InspectView::Artifacts => {
+                let (page, total, filtered) = self
+                    .store
+                    .page_artifacts(id, request.filter.as_deref(), page_request)
+                    .await?;
+                (
+                    serde_json::to_value(page.items)?,
+                    Some(total),
+                    Some(filtered),
+                    page.next_cursor,
+                    page.truncated,
+                )
+            }
+            InspectView::QueryResults => {
+                let redactor = self.redactor.clone();
+                let (page, total, filtered) = self
+                    .store
+                    .page_query_rows_mapped_into(
+                        id,
+                        request.filter.as_deref(),
+                        page_request,
+                        move |value, output| {
+                            redactor.redact_bounded_into(value, 4 * 1024, output);
+                        },
+                    )
+                    .await?;
+                (
+                    serde_json::to_value(page.items)?,
+                    Some(total),
+                    Some(filtered),
+                    page.next_cursor,
+                    page.truncated,
+                )
+            }
+            InspectView::Coverage => {
+                let (page, total, filtered) = self
+                    .store
+                    .page_coverage(id, request.filter.as_deref(), page_request)
+                    .await?;
+                let mut items = serde_json::to_value(page.items)?;
+                let mut total = total;
+                let mut filtered = filtered;
+                if items.as_array().is_some_and(Vec::is_empty) {
+                    let (artifacts, _, _) = self
+                        .store
+                        .page_artifacts(
+                            id,
+                            request.filter.as_deref(),
+                            PageRequest {
+                                cursor: None,
+                                limit: request.limit,
+                                max_bytes: Some(request.max_bytes.saturating_sub(512)),
+                            },
+                        )
+                        .await?;
+                    let unavailable = artifacts
+                        .items
+                        .into_iter()
+                        .filter(|artifact| {
+                            artifact.kind == ArtifactKind::Coverage && !artifact.locally_available
+                        })
+                        .map(|artifact| {
+                            serde_json::json!({
+                                "availability_reason": "remote_artifact_unavailable",
+                                "artifact": artifact,
+                            })
+                        })
+                        .collect::<Vec<_>>();
+                    let unavailable = if unavailable.is_empty() {
+                        vec![serde_json::json!({
+                            "availability_reason": "coverage_artifact_not_found",
+                        })]
+                    } else {
+                        unavailable
+                    };
+                    total = unavailable.len() as u64;
+                    filtered = total;
+                    items = serde_json::Value::Array(unavailable);
+                }
+                (
+                    items,
+                    Some(total),
+                    Some(filtered),
+                    page.next_cursor,
+                    page.truncated,
+                )
+            }
+            InspectView::Log => {
+                let (items, truncated, next_cursor) = self
+                    .read_evidence_page(&paths.evidence, &paths, &request)
+                    .await?;
+                (
+                    serde_json::to_value(items)?,
+                    None,
+                    None,
+                    next_cursor,
+                    truncated,
+                )
+            }
+            InspectView::TestLog => {
+                let (items, truncated, next_cursor) = if paths.test_log_evidence.exists() {
+                    self.read_evidence_page(&paths.test_log_evidence, &paths, &request)
+                        .await?
+                } else {
+                    self.read_test_log_unavailable_page(id, &request).await?
+                };
+                (
+                    serde_json::to_value(items)?,
+                    None,
+                    None,
+                    next_cursor,
+                    truncated,
+                )
+            }
+            InspectView::Invocations => unreachable!("handled above"),
+        };
+        enforce_inspect_budget(
+            InspectResult {
+                invocation_id: Some(id),
+                view: request.view,
+                items,
+                total_count,
+                filtered_count,
+                next_cursor,
+                truncated,
+            },
+            request.max_bytes,
+        )
+    }
+
+    pub(crate) async fn persist_failure_evidence(
+        &self,
+        paths: &InvocationPaths,
+        workspace: &Path,
+        command: &BazelCommand,
+        failed: bool,
+        stdout: &[u8],
+        stderr: &[u8],
+    ) -> Result<(), RunnerError> {
+        let records = failure_evidence_records(command, failed, stdout, stderr);
+        let workspace = workspace.to_string_lossy();
+        let mut bytes = Vec::new();
+        for mut record in records {
+            record.text = self.redactor.redact_bounded(
+                &record.text.replace(workspace.as_ref(), "<workspace>"),
+                4 * 1024,
+            );
+            serde_json::to_writer(&mut bytes, &record)?;
+            bytes.push(b'\n');
+        }
+        write_private_atomic(&paths.evidence, &bytes).await?;
+        Ok(())
+    }
+
+    async fn read_evidence_page(
+        &self,
+        path: &Path,
+        paths: &InvocationPaths,
+        request: &InspectRequest,
+    ) -> Result<(Vec<String>, bool, Option<String>), RunnerError> {
+        let invocation_id = request.invocation_id.ok_or(StoreError::InvalidCursor)?;
+        let start = request
+            .cursor
+            .as_deref()
+            .map(|value| {
+                LogCursor::decode_for(
+                    value,
+                    invocation_id,
+                    request.view,
+                    request.filter.as_deref(),
+                )
+            })
+            .transpose()?
+            .map_or(0, |cursor| cursor.next_record);
+        let file = match tokio::fs::File::open(path).await {
+            Ok(file) => file,
+            Err(error)
+                if error.kind() == io::ErrorKind::NotFound && request.view == InspectView::Log =>
+            {
+                let stdout = capture::read_bounded_tail(&paths.stdout, 1024 * 1024).await?;
+                let stderr = capture::read_bounded_tail(&paths.stderr, 1024 * 1024).await?;
+                let records = failure_evidence_records(
+                    &BazelCommand::Custom("retained".to_owned()),
+                    true,
+                    &stdout,
+                    &stderr,
+                );
+                return page_evidence_records(records.into_iter(), start, request, invocation_id);
+            }
+            Err(error) => return Err(error.into()),
+        };
+        let mut lines = BufReader::new(file).lines();
+        let mut records = Vec::new();
+        while let Some(line) = lines.next_line().await? {
+            records.push(serde_json::from_str::<EvidenceRecord>(&line)?);
+        }
+        page_evidence_records(records.into_iter(), start, request, invocation_id)
+    }
+
+    async fn read_test_log_unavailable_page(
+        &self,
+        invocation_id: InvocationId,
+        request: &InspectRequest,
+    ) -> Result<(Vec<String>, bool, Option<String>), RunnerError> {
+        let start = request
+            .cursor
+            .as_deref()
+            .map(|value| {
+                LogCursor::decode_for(
+                    value,
+                    invocation_id,
+                    request.view,
+                    request.filter.as_deref(),
+                )
+            })
+            .transpose()?
+            .map_or(0, |cursor| cursor.next_record);
+        let maximum_bytes = request.max_bytes.saturating_sub(512).max(1);
+        let maximum_items = usize::try_from(request.limit.clamp(1, 100)).unwrap_or(100);
+        let filter = request.filter.as_deref().map(str::to_ascii_lowercase);
+        let mut items = Vec::new();
+        let mut used_bytes = 2_usize;
+        let mut reason_index = 0_u64;
+        let mut storage_cursor = None;
+
+        loop {
+            let (page, _, _) = self
+                .store
+                .page_tests(
+                    invocation_id,
+                    None,
+                    PageRequest {
+                        cursor: storage_cursor,
+                        limit: 100,
+                        max_bytes: Some(128 * 1024),
+                    },
+                )
+                .await?;
+            for test in page.items {
+                let Some(reason) = test.test_log_unavailable_reason else {
+                    continue;
+                };
+                let index = reason_index;
+                reason_index = reason_index.saturating_add(1);
+                if index < start {
+                    continue;
+                }
+                let text = self
+                    .redactor
+                    .redact_bounded(&format!("{}: {reason}", test.label), 4 * 1024);
+                if !filter
+                    .as_ref()
+                    .is_none_or(|filter| text.to_ascii_lowercase().contains(filter))
+                {
+                    continue;
+                }
+                let item_bytes = serde_json::to_vec(&text)?.len();
+                let separator = usize::from(!items.is_empty());
+                if items.len() == maximum_items
+                    || (!items.is_empty()
+                        && used_bytes
+                            .saturating_add(separator)
+                            .saturating_add(item_bytes)
+                            > maximum_bytes)
+                {
+                    let next_cursor = LogCursor {
+                        invocation_id,
+                        view: request.view,
+                        next_record: index,
+                        filter: request.filter.clone(),
+                    }
+                    .encode()?;
+                    return Ok((items, true, Some(next_cursor)));
+                }
+                used_bytes = used_bytes
+                    .saturating_add(separator)
+                    .saturating_add(item_bytes);
+                items.push(text);
+            }
+            if !page.truncated {
+                return Ok((items, false, None));
+            }
+            storage_cursor = page.next_cursor;
+        }
+    }
+}
+
+pub(crate) fn page_evidence_records(
+    records: impl Iterator<Item = EvidenceRecord>,
+    start: u64,
+    request: &InspectRequest,
+    invocation_id: InvocationId,
+) -> Result<(Vec<String>, bool, Option<String>), RunnerError> {
+    let maximum_bytes = request.max_bytes.saturating_sub(512).max(1);
+    let maximum_items = usize::try_from(request.limit.clamp(1, 100)).unwrap_or(100);
+    let filter = request.filter.as_deref().map(str::to_ascii_lowercase);
+    let mut items = Vec::new();
+    let mut used_bytes = 2_usize;
+    let mut next_record = start;
+    let mut truncated = false;
+    for (index, record) in records.enumerate() {
+        let index = u64::try_from(index).unwrap_or(u64::MAX);
+        if index < start {
+            continue;
+        }
+        let matches = filter.as_ref().is_none_or(|filter| {
+            record.text.to_ascii_lowercase().contains(filter)
+                || record
+                    .label
+                    .as_deref()
+                    .is_some_and(|label| label.to_ascii_lowercase().contains(filter))
+        });
+        if !matches {
+            next_record = index.saturating_add(1);
+            continue;
+        }
+        let item_bytes = serde_json::to_vec(&record.text)?.len();
+        let separator = usize::from(!items.is_empty());
+        if items.len() == maximum_items
+            || (!items.is_empty()
+                && used_bytes
+                    .saturating_add(separator)
+                    .saturating_add(item_bytes)
+                    > maximum_bytes)
+        {
+            next_record = index;
+            truncated = true;
+            break;
+        }
+        used_bytes = used_bytes
+            .saturating_add(separator)
+            .saturating_add(item_bytes);
+        items.push(record.text);
+        next_record = index.saturating_add(1);
+    }
+    let next_cursor = truncated
+        .then_some(LogCursor {
+            invocation_id,
+            view: request.view,
+            next_record,
+            filter: request.filter.clone(),
+        })
+        .map(|cursor| cursor.encode())
+        .transpose()?;
+    Ok((items, truncated, next_cursor))
+}
+
+pub(crate) fn should_persist_failure_evidence(command: &BazelCommand, failed: bool) -> bool {
+    failed || command.class() != CommandClass::Query
+}
+
+pub(crate) fn failure_evidence_records(
+    command: &BazelCommand,
+    failed: bool,
+    stdout: &[u8],
+    stderr: &[u8],
+) -> Vec<EvidenceRecord> {
+    let test_like = matches!(command, BazelCommand::Test | BazelCommand::Coverage);
+    let streams = if (failed && test_like) || (!failed && !stdout.is_empty()) {
+        [stdout, stderr]
+    } else {
+        [stderr, stdout]
+    };
+    let mut positions = BTreeMap::<String, usize>::new();
+    let mut lines = Vec::<(String, u32)>::new();
+    for stream in streams {
+        for line in normalize_terminal_text(stream).lines() {
+            let line = line.trim();
+            if line.is_empty() {
+                continue;
+            }
+            let line = bounded_text(line, 4 * 1024);
+            if let Some(index) = positions.get(&line).copied() {
+                lines[index].1 = lines[index].1.saturating_add(1);
+            } else {
+                positions.insert(line.clone(), lines.len());
+                lines.push((line, 1));
+            }
+        }
+    }
+    let mut actionable = Vec::new();
+    let mut fallback = Vec::new();
+    for (line, count) in lines {
+        let record = EvidenceRecord {
+            label: None,
+            text: if count > 1 {
+                format!("{line} [repeated {count} times]")
+            } else {
+                line
+            },
+        };
+        if is_actionable_evidence(&record.text) {
+            actionable.push(record);
+        } else {
+            fallback.push(record);
+        }
+    }
+    let fallback_start = fallback.len().saturating_sub(2_000);
+    actionable.truncate(1_000);
+    actionable.extend(fallback.into_iter().skip(fallback_start));
+    actionable.truncate(3_000);
+    actionable
+}
+
+fn is_actionable_evidence(line: &str) -> bool {
+    failure_evidence_priority(line).is_some()
+}
+
+fn failure_evidence_priority(line: &str) -> Option<u8> {
+    let line = line.trim();
+    let lower = line.to_ascii_lowercase();
+    let base = lower
+        .split_once(" [repeated ")
+        .map_or(lower.as_str(), |(base, _)| base);
+    if matches!(base, "failure:" | "failures:")
+        || (line.starts_with("test ") && base.ends_with(" ... ok"))
+    {
+        return None;
+    }
+    if lower.contains("root_cause")
+        || lower.contains("panicked at")
+        || (lower.contains("assertion") && lower.contains(" failed"))
+    {
+        Some(0)
+    } else if lower.contains("error:")
+        || lower.starts_with("error ")
+        || lower.contains("fatal:")
+        || lower.contains("no such target")
+        || lower.contains("no such package")
+        || lower.contains("undefined reference")
+        || lower.contains("missing strict dependencies")
+        || (lower.contains(".go: import of \"") && lower.ends_with('"'))
+    {
+        Some(1)
+    } else if lower.contains("failed:")
+        || lower.contains("failure")
+        || lower.starts_with("test result: failed")
+        || (line.starts_with("test ") && line.ends_with(" ... FAILED"))
+    {
+        Some(2)
+    } else {
+        None
+    }
+}
+
+fn invocation_ledger_row(record: &InvocationRecord) -> serde_json::Value {
+    let arguments = record
+        .request
+        .arguments
+        .iter()
+        .take(3)
+        .map(|argument| bounded_text(argument, 128))
+        .collect::<Vec<_>>();
+    let exit_code = match record.termination {
+        Some(Termination::Exit { code }) => Some(code),
+        _ => None,
+    };
+    serde_json::json!({
+        "invocation_id": record.request.id,
+        "workspace": bounded_text(&record.request.workspace.to_string_lossy(), 256),
+        "state": record.state,
+        "command": record.request.command,
+        "arguments": arguments,
+        "arguments_truncated": record.request.arguments.len() > 3,
+        "requested_at_ms": record.request.requested_at_ms,
+        "finished_at_ms": record.finished_at_ms,
+        "exit_code": exit_code,
+        "duration_ms": record.metrics.bazel_wall_ms,
+        "headline": record
+            .summary
+            .as_ref()
+            .map(|summary| bounded_text(&summary.headline, 256)),
+        "targets": record.summary.as_ref().map(|summary| &summary.target_counts),
+        "tests": record.summary.as_ref().map(|summary| &summary.test_counts),
+        "raw_output_bytes": record.metrics.raw_output_bytes,
+        "model_visible_bytes": record.metrics.model_visible_bytes,
+        "inspect_calls": record.metrics.inspect_calls,
+    })
+}
+
+fn enforce_inspect_budget(
+    mut result: InspectResult,
+    requested_bytes: usize,
+) -> Result<InspectResult, RunnerError> {
+    let hard_limit = requested_bytes.min(32 * 1024);
+    if serialized_len(&result)? <= hard_limit {
+        return Ok(result);
+    }
+    result.truncated = true;
+
+    match result.view {
+        InspectView::Summary => {
+            while serialized_len(&result)? > hard_limit {
+                let Some(summary) = result
+                    .items
+                    .as_array_mut()
+                    .and_then(|items| items.first_mut())
+                else {
+                    break;
+                };
+                let Some(diagnostics) = summary
+                    .get_mut("diagnostics")
+                    .and_then(serde_json::Value::as_array_mut)
+                else {
+                    break;
+                };
+                if diagnostics.pop().is_none() {
+                    break;
+                }
+                summary["truncated"] = serde_json::Value::Bool(true);
+            }
+        }
+        InspectView::Tests => {
+            while serialized_len(&result)? > hard_limit {
+                let Some(tests) = result.items.as_array_mut() else {
+                    break;
+                };
+                let Some(cases) = tests.iter_mut().rev().find_map(|test| {
+                    test.get_mut("cases")
+                        .and_then(serde_json::Value::as_array_mut)
+                        .filter(|cases| !cases.is_empty())
+                }) else {
+                    break;
+                };
+                cases.pop();
+            }
+        }
+        _ => {}
+    }
+
+    for string_limit in [1_000, 512, 256, 64, 0] {
+        if serialized_len(&result)? <= hard_limit {
+            return Ok(result);
+        }
+        bound_json_strings(&mut result.items, string_limit);
+    }
+    if serialized_len(&result)? > hard_limit {
+        return Err(RunnerError::ResponseTooLarge(hard_limit));
+    }
+    Ok(result)
+}
+
+fn serialized_len(result: &InspectResult) -> Result<usize, RunnerError> {
+    Ok(serde_json::to_vec(result)?.len())
+}
+
+fn bound_json_strings(value: &mut serde_json::Value, maximum_bytes: usize) {
+    match value {
+        serde_json::Value::String(text) => {
+            if maximum_bytes == 0 {
+                text.clear();
+            } else if text.len() > maximum_bytes {
+                *text = bounded_text(text, maximum_bytes);
+            }
+        }
+        serde_json::Value::Array(items) => {
+            for item in items {
+                bound_json_strings(item, maximum_bytes);
+            }
+        }
+        serde_json::Value::Object(fields) => {
+            for value in fields.values_mut() {
+                bound_json_strings(value, maximum_bytes);
+            }
+        }
+        serde_json::Value::Null | serde_json::Value::Bool(_) | serde_json::Value::Number(_) => {}
+    }
+}

--- a/crates/bazel-mcp-runner/src/lib.rs
+++ b/crates/bazel-mcp-runner/src/lib.rs
@@ -1,13 +1,21 @@
 //! Asynchronous Bazel invocation lifecycle and application service.
 
+mod artifacts;
 mod cancel;
 mod capture;
+mod evidence;
+mod execution;
+mod inspection;
 mod output_base_lock;
+mod scheduler;
 mod service;
+mod test_evidence;
 mod version;
 
 pub use bazel_mcp_reducer::{StarlarkLimits, StarlarkReducerConfig};
+pub use inspection::{InspectRequest, InspectResult, InspectView};
+#[doc(hidden)]
+pub use service::RunnerTestSupport;
 pub use service::{
-    BepTransport, CancelResult, InspectRequest, InspectResult, InspectView, InvocationProgress,
-    InvocationService, RunnerConfig, RunnerError,
+    BepTransport, CancelResult, InvocationProgress, InvocationService, RunnerConfig, RunnerError,
 };

--- a/crates/bazel-mcp-runner/src/scheduler.rs
+++ b/crates/bazel-mcp-runner/src/scheduler.rs
@@ -1,0 +1,120 @@
+//! In-process invocation admission, serialization, and cancellation state.
+
+use std::{
+    collections::HashMap,
+    path::{Path, PathBuf},
+    sync::{Arc, Weak},
+};
+
+use bazel_mcp_types::InvocationId;
+use tokio::sync::{Mutex, OwnedSemaphorePermit, Semaphore};
+use tokio_util::sync::CancellationToken;
+
+use crate::output_base_lock::OutputBaseWaitStatus;
+
+/// Owns in-process admission, execution, workspace serialization, and
+/// cancellation/progress registration for Bazel invocations.
+#[derive(Clone)]
+pub(crate) struct InvocationScheduler {
+    global: Arc<Semaphore>,
+    pending: Arc<Semaphore>,
+    workspace_locks: Arc<Mutex<HashMap<PathBuf, Weak<Mutex<()>>>>>,
+    output_base_waits: Arc<Mutex<HashMap<InvocationId, Arc<OutputBaseWaitStatus>>>>,
+    live: Arc<Mutex<HashMap<InvocationId, CancellationToken>>>,
+}
+
+impl InvocationScheduler {
+    pub(crate) fn new(global_concurrency: usize, maximum_pending: usize) -> Self {
+        Self {
+            global: Arc::new(Semaphore::new(global_concurrency)),
+            pending: Arc::new(Semaphore::new(maximum_pending)),
+            workspace_locks: Arc::new(Mutex::new(HashMap::new())),
+            output_base_waits: Arc::new(Mutex::new(HashMap::new())),
+            live: Arc::new(Mutex::new(HashMap::new())),
+        }
+    }
+
+    pub(crate) fn try_acquire_pending(&self) -> Option<OwnedSemaphorePermit> {
+        self.pending.clone().try_acquire_owned().ok()
+    }
+
+    pub(crate) async fn acquire_execution(&self) -> Option<OwnedSemaphorePermit> {
+        self.global.clone().acquire_owned().await.ok()
+    }
+
+    pub(crate) async fn workspace_lock(&self, key: &Path) -> Arc<Mutex<()>> {
+        let mut locks = self.workspace_locks.lock().await;
+        locks.retain(|_, lock| lock.strong_count() > 0);
+        if let Some(lock) = locks.get(key).and_then(Weak::upgrade) {
+            return lock;
+        }
+        let lock = Arc::new(Mutex::new(()));
+        locks.insert(key.to_owned(), Arc::downgrade(&lock));
+        lock
+    }
+
+    pub(crate) async fn register(
+        &self,
+        id: InvocationId,
+        cancellation: CancellationToken,
+        output_base_wait: Arc<OutputBaseWaitStatus>,
+    ) {
+        self.live.lock().await.insert(id, cancellation);
+        self.output_base_waits
+            .lock()
+            .await
+            .insert(id, output_base_wait);
+    }
+
+    pub(crate) async fn remove(&self, id: InvocationId) {
+        self.live.lock().await.remove(&id);
+        self.output_base_waits.lock().await.remove(&id);
+    }
+
+    pub(crate) async fn cancellation(&self, id: InvocationId) -> Option<CancellationToken> {
+        self.live.lock().await.get(&id).cloned()
+    }
+
+    pub(crate) async fn output_base_wait(
+        &self,
+        id: InvocationId,
+    ) -> Option<Arc<OutputBaseWaitStatus>> {
+        self.output_base_waits.lock().await.get(&id).cloned()
+    }
+
+    pub(crate) async fn cancel_all(&self) -> usize {
+        let cancellations: Vec<_> = self.live.lock().await.values().cloned().collect();
+        let count = cancellations.len();
+        for cancellation in cancellations {
+            cancellation.cancel();
+        }
+        count
+    }
+
+    pub(crate) async fn active_count(&self) -> usize {
+        self.live.lock().await.len()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{path::Path, sync::Arc};
+
+    use super::InvocationScheduler;
+
+    #[tokio::test]
+    async fn workspace_lock_registry_discards_inactive_output_bases() {
+        let scheduler = InvocationScheduler::new(1, 1);
+
+        for index in 0..100 {
+            let lock = scheduler
+                .workspace_lock(Path::new(&format!("/tmp/output-base-{index}")))
+                .await;
+            drop(lock);
+        }
+        let retained = scheduler.workspace_lock(Path::new("/tmp/retained")).await;
+
+        assert_eq!(scheduler.workspace_locks.lock().await.len(), 1);
+        assert!(Arc::strong_count(&retained) >= 1);
+    }
+}

--- a/crates/bazel-mcp-runner/src/service.rs
+++ b/crates/bazel-mcp-runner/src/service.rs
@@ -1,58 +1,54 @@
 use std::{
-    collections::{BTreeMap, HashMap},
+    collections::HashMap,
     io,
-    panic::{AssertUnwindSafe, catch_unwind},
     path::{Path, PathBuf},
-    process::ExitStatus,
-    sync::{Arc, Weak},
-    time::{Duration, Instant},
+    sync::Arc,
+    time::Duration,
 };
 
-use base64::{Engine, engine::general_purpose::URL_SAFE_NO_PAD};
 use bazel_mcp_bes::{BesError, BesServer};
 use bazel_mcp_policy::{
     PolicyConfig, PolicyError, Redactor, effective_output_base, filtered_environment,
     resolve_bazel_executable, validate_arguments, validate_command, validate_query_arguments,
     validate_workspace,
 };
-use bazel_mcp_reducer::{
-    Budget, JavaScriptTestDiagnosticParser, JavaTestDiagnosticParser, PythonDiagnosticParser,
-    REDUCER_API_VERSION, ReducerContext, ReducerPipeline, StarlarkReducerConfig,
-    StreamReductionOutput, TestFailureAccumulator, TestFailureEvidence, finalize_diagnostics,
-    load_starlark_reducers, normalize_terminal_text, parse_go_diagnostic, parse_lcov_reader,
-    parse_test_xml,
-};
-use bazel_mcp_store::{InvocationCompletion, InvocationPaths, Store, StoreError};
+use bazel_mcp_reducer::{ReducerPipeline, StarlarkReducerConfig, load_starlark_reducers};
+use bazel_mcp_store::{InvocationPaths, Store, StoreError};
 use bazel_mcp_types::{
-    ArtifactKind, BazelCommand, CommandClass, DeferredFailure, DeferredFailureKind,
-    DeferredResultRecord, DeferredResultView, DeferredRetrieval, DeferredTerminalState, Diagnostic,
-    DiagnosticCategory, InvocationId, InvocationMetrics, InvocationRecord, InvocationRequest,
-    InvocationState, Page, PageRequest, ResultDisposition, Severity, Termination, TestCase,
-    TestStatus,
+    DeferredFailure, DeferredFailureKind, DeferredResultRecord, DeferredResultView,
+    DeferredRetrieval, DeferredTerminalState, InvocationId, InvocationRecord, InvocationRequest,
+    InvocationState, Page, PageRequest, ResultDisposition, Termination,
 };
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
-use tokio::{
-    io::{AsyncBufReadExt, AsyncWriteExt, BufReader},
-    process::Command,
-    sync::{Mutex, OwnedSemaphorePermit, Semaphore},
-    task,
-};
+use tokio::sync::{Mutex, OwnedSemaphorePermit};
 use tokio_util::sync::CancellationToken;
 
 use crate::{
-    cancel::{ProcessGroupGuard, terminate_child},
-    capture,
+    execution::cancelled_summary,
     output_base_lock::{
-        NativeOutputBaseWaitObserver, OutputBaseLockAcquisition, OutputBaseWaitStatus,
-        acquire as acquire_output_base_lock, default_output_base_lock_root,
+        OutputBaseLockAcquisition, OutputBaseWaitStatus, acquire as acquire_output_base_lock,
+        default_output_base_lock_root,
     },
+    scheduler::InvocationScheduler,
     version::detect_bazel_version,
 };
 
-const COMPLETE_BEP_LOG_LIMIT: usize = 2 * 1024 * 1024;
-const FALLBACK_LOG_LIMIT: usize = 8 * 1024 * 1024;
-const BES_COMPLETION_GRACE: Duration = Duration::from_secs(2);
+#[cfg(test)]
+use crate::inspection::{
+    EvidenceRecord, InspectRequest, InspectView, LogCursor, failure_evidence_records,
+    page_evidence_records, should_persist_failure_evidence,
+};
+
+#[cfg(test)]
+use crate::{artifacts::local_artifact_path, test_evidence::artifact_matches_test};
+
+#[cfg(test)]
+use bazel_mcp_types::{ArtifactKind, BazelCommand};
+
+pub(crate) const COMPLETE_BEP_LOG_LIMIT: usize = 2 * 1024 * 1024;
+pub(crate) const FALLBACK_LOG_LIMIT: usize = 8 * 1024 * 1024;
+pub(crate) const BES_COMPLETION_GRACE: Duration = Duration::from_secs(2);
 
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
@@ -152,17 +148,13 @@ pub enum RunnerError {
 
 #[derive(Clone)]
 pub struct InvocationService {
-    store: Store,
-    config: RunnerConfig,
-    redactor: Redactor,
-    global: Arc<Semaphore>,
-    pending: Arc<Semaphore>,
-    workspace_locks: Arc<Mutex<HashMap<PathBuf, Weak<Mutex<()>>>>>,
-    output_base_waits: Arc<Mutex<HashMap<InvocationId, Arc<OutputBaseWaitStatus>>>>,
-    live: Arc<Mutex<HashMap<InvocationId, CancellationToken>>>,
+    pub(crate) store: Store,
+    pub(crate) config: RunnerConfig,
+    pub(crate) redactor: Redactor,
+    scheduler: InvocationScheduler,
     version_cache: Arc<Mutex<HashMap<VersionCacheKey, u32>>>,
-    bes: Option<BesServer>,
-    reducers: ReducerPipeline,
+    pub(crate) bes: Option<BesServer>,
+    pub(crate) reducers: ReducerPipeline,
 }
 
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
@@ -184,95 +176,57 @@ struct PreparedSubmission {
     deferred: bool,
 }
 
+/// Narrow store access used by the runner's process-level integration tests.
+/// Production callers should use the invocation and inspection APIs instead.
+#[doc(hidden)]
+#[derive(Clone, Copy)]
+pub struct RunnerTestSupport<'a> {
+    store: &'a Store,
+}
+
+#[doc(hidden)]
+impl RunnerTestSupport<'_> {
+    pub async fn get_invocation(self, id: InvocationId) -> Result<InvocationRecord, StoreError> {
+        self.store.get_invocation(id).await
+    }
+
+    #[must_use]
+    pub fn paths_for(self, record: &InvocationRecord) -> InvocationPaths {
+        self.store.paths_for(record)
+    }
+
+    pub async fn replace_artifacts(
+        self,
+        id: InvocationId,
+        artifacts: &[bazel_mcp_types::Artifact],
+    ) -> Result<(), StoreError> {
+        self.store.replace_artifacts(id, artifacts).await
+    }
+
+    pub async fn create_invocation(
+        self,
+        record: &InvocationRecord,
+    ) -> Result<InvocationPaths, StoreError> {
+        self.store.create_invocation(record).await
+    }
+
+    pub async fn transition(
+        self,
+        id: InvocationId,
+        next: InvocationState,
+        termination: Option<Termination>,
+        summary: Option<bazel_mcp_types::InvocationSummary>,
+    ) -> Result<InvocationRecord, StoreError> {
+        self.store.transition(id, next, termination, summary).await
+    }
+}
+
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct InvocationProgress {
     pub state: InvocationState,
     pub phase: Option<&'static str>,
     pub output_base_lock_wait_ms: u64,
     pub output_base_lock_owner: Option<String>,
-}
-
-#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]
-#[serde(rename_all = "snake_case")]
-pub enum InspectView {
-    Summary,
-    Metrics,
-    Diagnostics,
-    Tests,
-    TestLog,
-    Coverage,
-    Artifacts,
-    QueryResults,
-    Log,
-    Invocations,
-}
-
-#[derive(Clone, Debug)]
-pub struct InspectRequest {
-    pub invocation_id: Option<InvocationId>,
-    pub workspace: Option<PathBuf>,
-    pub state: Option<InvocationState>,
-    pub command: Option<BazelCommand>,
-    pub view: InspectView,
-    pub cursor: Option<String>,
-    pub filter: Option<String>,
-    pub limit: u32,
-    pub max_bytes: usize,
-}
-
-#[derive(Debug, Serialize, Deserialize)]
-struct LogCursor {
-    invocation_id: InvocationId,
-    view: InspectView,
-    next_record: u64,
-    filter: Option<String>,
-}
-
-#[derive(Clone, Debug, Deserialize, Serialize)]
-struct EvidenceRecord {
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    label: Option<String>,
-    text: String,
-}
-
-impl LogCursor {
-    fn encode(&self) -> Result<String, RunnerError> {
-        Ok(URL_SAFE_NO_PAD.encode(serde_json::to_vec(self)?))
-    }
-
-    fn decode(value: &str) -> Result<Self, RunnerError> {
-        let raw = URL_SAFE_NO_PAD
-            .decode(value)
-            .map_err(|_| RunnerError::InvalidOffset)?;
-        serde_json::from_slice(&raw).map_err(|_| RunnerError::InvalidOffset)
-    }
-
-    fn decode_for(
-        value: &str,
-        invocation_id: InvocationId,
-        view: InspectView,
-        filter: Option<&str>,
-    ) -> Result<Self, RunnerError> {
-        let cursor = Self::decode(value)?;
-        if cursor.invocation_id != invocation_id
-            || cursor.view != view
-            || cursor.filter.as_deref() != filter
-        {
-            return Err(RunnerError::InvalidOffset);
-        }
-        Ok(cursor)
-    }
-}
-
-#[derive(Clone, Debug, Serialize)]
-pub struct InspectResult {
-    pub invocation_id: Option<InvocationId>,
-    pub view: InspectView,
-    pub items: serde_json::Value,
-    pub total_count: Option<u64>,
-    pub filtered_count: Option<u64>,
-    pub next_cursor: Option<String>,
-    pub truncated: bool,
 }
 
 #[derive(Clone, Debug, Serialize)]
@@ -355,22 +309,22 @@ impl InvocationService {
         })?;
         Ok(Self {
             store,
-            global: Arc::new(Semaphore::new(config.global_concurrency)),
-            pending: Arc::new(Semaphore::new(config.maximum_pending_invocations)),
+            scheduler: InvocationScheduler::new(
+                config.global_concurrency,
+                config.maximum_pending_invocations,
+            ),
             config,
             redactor,
-            workspace_locks: Arc::new(Mutex::new(HashMap::new())),
-            output_base_waits: Arc::new(Mutex::new(HashMap::new())),
-            live: Arc::new(Mutex::new(HashMap::new())),
             version_cache: Arc::new(Mutex::new(HashMap::new())),
             bes,
             reducers,
         })
     }
 
+    #[doc(hidden)]
     #[must_use]
-    pub fn store(&self) -> &Store {
-        &self.store
+    pub fn test_support(&self) -> RunnerTestSupport<'_> {
+        RunnerTestSupport { store: &self.store }
     }
 
     pub async fn run(&self, request: InvocationRequest) -> Result<InvocationRecord, RunnerError> {
@@ -388,8 +342,7 @@ impl InvocationService {
             .await?;
         let id = prepared.queued.request.id;
         let result = self.run_prepared(prepared).await;
-        self.live.lock().await.remove(&id);
-        self.output_base_waits.lock().await.remove(&id);
+        self.scheduler.remove(id).await;
         result
     }
 
@@ -439,8 +392,7 @@ impl InvocationService {
                     );
                 }
             }
-            supervisor.live.lock().await.remove(&id);
-            supervisor.output_base_waits.lock().await.remove(&id);
+            supervisor.scheduler.remove(id).await;
         });
         Ok(id)
     }
@@ -548,10 +500,11 @@ impl InvocationService {
             return Err(RunnerError::BesUploadModeConflict);
         }
         let pending_permit = self
-            .pending
-            .clone()
-            .try_acquire_owned()
-            .map_err(|_| RunnerError::QueueFull(self.config.maximum_pending_invocations))?;
+            .scheduler
+            .try_acquire_pending()
+            .ok_or(RunnerError::QueueFull(
+                self.config.maximum_pending_invocations,
+            ))?;
         let workspace = validate_workspace(&request.workspace, &self.config.policy.allowed_roots)?;
         let explicit_output_base = effective_output_base(&workspace, &request.startup_arguments)?;
         let lock_key = explicit_output_base
@@ -586,11 +539,9 @@ impl InvocationService {
             .create_invocation_with_deferred(&stored, deferred.as_ref())
             .await?;
         let output_base_wait = Arc::new(OutputBaseWaitStatus::default());
-        self.live.lock().await.insert(id, cancellation.clone());
-        self.output_base_waits
-            .lock()
-            .await
-            .insert(id, output_base_wait.clone());
+        self.scheduler
+            .register(id, cancellation.clone(), output_base_wait.clone())
+            .await;
 
         Ok(PreparedSubmission {
             queued,
@@ -622,7 +573,7 @@ impl InvocationService {
         } = prepared;
         let id = queued.request.id;
         async {
-            let workspace_lock = self.workspace_lock(&lock_key).await;
+            let workspace_lock = self.scheduler.workspace_lock(&lock_key).await;
             let workspace_guard = tokio::select! {
                 guard = workspace_lock.lock() => guard,
                 () = cancellation.cancelled() => {
@@ -652,8 +603,8 @@ impl InvocationService {
                 }
             };
             let permit = tokio::select! {
-                permit = self.global.clone().acquire_owned() => {
-                    permit.map_err(|_| RunnerError::SchedulerClosed)?
+                permit = self.scheduler.acquire_execution() => {
+                    permit.ok_or(RunnerError::SchedulerClosed)?
                 }
                 () = cancellation.cancelled() => {
                     return self.finish_cancelled(id).await;
@@ -868,16 +819,11 @@ impl InvocationService {
     /// Request cancellation for every invocation owned by this server process.
     /// Used during graceful transport and operating-system shutdown.
     pub async fn cancel_all_active(&self) -> usize {
-        let cancellations: Vec<_> = self.live.lock().await.values().cloned().collect();
-        let count = cancellations.len();
-        for cancellation in cancellations {
-            cancellation.cancel();
-        }
-        count
+        self.scheduler.cancel_all().await
     }
 
     pub async fn active_invocation_count(&self) -> usize {
-        self.live.lock().await.len()
+        self.scheduler.active_count().await
     }
 
     pub async fn cancel_with_reason(
@@ -898,7 +844,7 @@ impl InvocationService {
             let reason = self.redactor.redact_bounded(reason, 1_000);
             self.store.update_cancellation_reason(id, &reason).await?;
         }
-        let cancellation = self.live.lock().await.get(&id).cloned();
+        let cancellation = self.scheduler.cancellation(id).await;
         if let Some(cancellation) = &cancellation {
             cancellation.cancel();
         }
@@ -968,7 +914,7 @@ impl InvocationService {
         id: InvocationId,
     ) -> Result<InvocationProgress, RunnerError> {
         let state = self.store.get_invocation(id).await?.state;
-        let wait = self.output_base_waits.lock().await.get(&id).cloned();
+        let wait = self.scheduler.output_base_wait(id).await;
         let wait = wait.map(|status| status.snapshot()).unwrap_or_else(|| {
             crate::output_base_lock::OutputBaseWaitSnapshot {
                 active: false,
@@ -982,1048 +928,6 @@ impl InvocationService {
             output_base_lock_wait_ms: wait.elapsed_ms,
             output_base_lock_owner: wait.owner,
         })
-    }
-
-    pub async fn inspect(&self, request: InspectRequest) -> Result<InspectResult, RunnerError> {
-        if request.view == InspectView::Invocations {
-            let mut limit = request.limit.clamp(1, 100);
-            loop {
-                let page = self
-                    .store
-                    .list_invocations(
-                        request.workspace.as_deref(),
-                        request.state,
-                        request.command.as_ref(),
-                        PageRequest {
-                            cursor: request.cursor.clone(),
-                            limit,
-                            max_bytes: None,
-                        },
-                    )
-                    .await?;
-                let result = InspectResult {
-                    invocation_id: None,
-                    view: request.view,
-                    items: serde_json::Value::Array(
-                        page.items.iter().map(invocation_ledger_row).collect(),
-                    ),
-                    total_count: None,
-                    filtered_count: None,
-                    next_cursor: page.next_cursor,
-                    truncated: page.truncated,
-                };
-                if serialized_len(&result)? <= request.max_bytes || limit == 1 {
-                    return enforce_inspect_budget(result, request.max_bytes);
-                }
-                limit = (limit / 2).max(1);
-            }
-        }
-
-        let id = request.invocation_id.ok_or(StoreError::InvalidCursor)?;
-        let record = self.store.get_invocation(id).await?;
-        let page_request = PageRequest {
-            cursor: request.cursor.clone(),
-            limit: request.limit.clamp(1, 100),
-            max_bytes: Some(request.max_bytes.saturating_sub(512)),
-        };
-        let paths = self.store.paths_for(&record);
-        let (items, total_count, filtered_count, next_cursor, truncated) = match request.view {
-            InspectView::Summary => {
-                let items = record.summary.as_ref().map_or_else(Vec::new, |summary| {
-                    vec![serde_json::json!({
-                        "success": summary.success,
-                        "headline": summary.headline,
-                        "targets": summary.target_counts,
-                        "tests": summary.test_counts,
-                        "diagnostics": summary.diagnostics,
-                        "coverage": summary.coverage.as_ref().map(|coverage| serde_json::json!({
-                            "lines_found": coverage.lines_found,
-                            "lines_hit": coverage.lines_hit,
-                            "coverage_percent": coverage.coverage_percent,
-                        })),
-                        "query_result_count": summary.query_result_count,
-                        "query_sample": summary.query_sample,
-                        "elapsed_ms": summary.elapsed_ms,
-                        "truncated": summary.truncated,
-                        "inspect_hint": summary.inspect_hint,
-                    })]
-                });
-                (
-                    serde_json::to_value(items)?,
-                    Some(u64::from(record.summary.is_some())),
-                    Some(u64::from(record.summary.is_some())),
-                    None,
-                    record
-                        .summary
-                        .as_ref()
-                        .is_some_and(|summary| summary.truncated),
-                )
-            }
-            InspectView::Metrics => {
-                let items = vec![serde_json::json!({
-                    "state": record.state,
-                    "requested_at_ms": record.request.requested_at_ms,
-                    "started_at_ms": record.started_at_ms,
-                    "finished_at_ms": record.finished_at_ms,
-                    "termination": record.termination,
-                    "metrics": record.metrics,
-                })];
-                (serde_json::to_value(items)?, Some(1), Some(1), None, false)
-            }
-            InspectView::Diagnostics => {
-                let (page, total, filtered) = self
-                    .store
-                    .page_diagnostics(id, request.filter.as_deref(), page_request)
-                    .await?;
-                (
-                    serde_json::to_value(page.items)?,
-                    Some(total),
-                    Some(filtered),
-                    page.next_cursor,
-                    page.truncated,
-                )
-            }
-            InspectView::Tests => {
-                let (page, total, filtered) = self
-                    .store
-                    .page_tests(id, request.filter.as_deref(), page_request)
-                    .await?;
-                (
-                    serde_json::to_value(page.items)?,
-                    Some(total),
-                    Some(filtered),
-                    page.next_cursor,
-                    page.truncated,
-                )
-            }
-            InspectView::Artifacts => {
-                let (page, total, filtered) = self
-                    .store
-                    .page_artifacts(id, request.filter.as_deref(), page_request)
-                    .await?;
-                (
-                    serde_json::to_value(page.items)?,
-                    Some(total),
-                    Some(filtered),
-                    page.next_cursor,
-                    page.truncated,
-                )
-            }
-            InspectView::QueryResults => {
-                let redactor = self.redactor.clone();
-                let (page, total, filtered) = self
-                    .store
-                    .page_query_rows_mapped_into(
-                        id,
-                        request.filter.as_deref(),
-                        page_request,
-                        move |value, output| {
-                            redactor.redact_bounded_into(value, 4 * 1024, output);
-                        },
-                    )
-                    .await?;
-                (
-                    serde_json::to_value(page.items)?,
-                    Some(total),
-                    Some(filtered),
-                    page.next_cursor,
-                    page.truncated,
-                )
-            }
-            InspectView::Coverage => {
-                let (page, total, filtered) = self
-                    .store
-                    .page_coverage(id, request.filter.as_deref(), page_request)
-                    .await?;
-                let mut items = serde_json::to_value(page.items)?;
-                let mut total = total;
-                let mut filtered = filtered;
-                if items.as_array().is_some_and(Vec::is_empty) {
-                    let (artifacts, _, _) = self
-                        .store
-                        .page_artifacts(
-                            id,
-                            request.filter.as_deref(),
-                            PageRequest {
-                                cursor: None,
-                                limit: request.limit,
-                                max_bytes: Some(request.max_bytes.saturating_sub(512)),
-                            },
-                        )
-                        .await?;
-                    let unavailable = artifacts
-                        .items
-                        .into_iter()
-                        .filter(|artifact| {
-                            artifact.kind == ArtifactKind::Coverage && !artifact.locally_available
-                        })
-                        .map(|artifact| {
-                            serde_json::json!({
-                                "availability_reason": "remote_artifact_unavailable",
-                                "artifact": artifact,
-                            })
-                        })
-                        .collect::<Vec<_>>();
-                    let unavailable = if unavailable.is_empty() {
-                        vec![serde_json::json!({
-                            "availability_reason": "coverage_artifact_not_found",
-                        })]
-                    } else {
-                        unavailable
-                    };
-                    total = unavailable.len() as u64;
-                    filtered = total;
-                    items = serde_json::Value::Array(unavailable);
-                }
-                (
-                    items,
-                    Some(total),
-                    Some(filtered),
-                    page.next_cursor,
-                    page.truncated,
-                )
-            }
-            InspectView::Log => {
-                let (items, truncated, next_cursor) = self
-                    .read_evidence_page(&paths.evidence, &paths, &request)
-                    .await?;
-                (
-                    serde_json::to_value(items)?,
-                    None,
-                    None,
-                    next_cursor,
-                    truncated,
-                )
-            }
-            InspectView::TestLog => {
-                let (items, truncated, next_cursor) = if paths.test_log_evidence.exists() {
-                    self.read_evidence_page(&paths.test_log_evidence, &paths, &request)
-                        .await?
-                } else {
-                    self.read_test_log_unavailable_page(id, &request).await?
-                };
-                (
-                    serde_json::to_value(items)?,
-                    None,
-                    None,
-                    next_cursor,
-                    truncated,
-                )
-            }
-            InspectView::Invocations => unreachable!("handled above"),
-        };
-        enforce_inspect_budget(
-            InspectResult {
-                invocation_id: Some(id),
-                view: request.view,
-                items,
-                total_count,
-                filtered_count,
-                next_cursor,
-                truncated,
-            },
-            request.max_bytes,
-        )
-    }
-
-    async fn execute(
-        &self,
-        queued: &InvocationRecord,
-        paths: &InvocationPaths,
-        executable: &Path,
-        cancellation: CancellationToken,
-        explicit_output_base: Option<&Path>,
-        output_base_wait: Arc<OutputBaseWaitStatus>,
-    ) -> Result<InvocationRecord, RunnerError> {
-        if cancellation.is_cancelled() {
-            return self.finish_cancelled(queued.request.id).await;
-        }
-        let queue_ms = u64::try_from(
-            bazel_mcp_types::unix_timestamp_ms().saturating_sub(queued.request.requested_at_ms),
-        )
-        .unwrap_or_default();
-        let (stdout, stderr) = match capture::open_stdio(paths).await {
-            Ok(streams) => streams,
-            Err(error) => {
-                let message = self.redactor.redact_bounded(
-                    &format!("could not create Bazel evidence files: {error}"),
-                    1_000,
-                );
-                let summary = bazel_mcp_types::InvocationSummary {
-                    success: false,
-                    headline: format!("Could not prepare Bazel invocation: {message}"),
-                    truncated: true,
-                    ..Default::default()
-                };
-                return self
-                    .store
-                    .transition(
-                        queued.request.id,
-                        InvocationState::Failed,
-                        Some(Termination::SpawnFailure {
-                            message: message.clone(),
-                        }),
-                        Some(summary),
-                    )
-                    .await
-                    .map_err(Into::into);
-            }
-        };
-        let native_output_base_wait = NativeOutputBaseWaitObserver::start(
-            paths.stdout.clone(),
-            paths.stderr.clone(),
-            paths.bep.clone(),
-            explicit_output_base.map(Path::to_owned),
-            output_base_wait.clone(),
-        )
-        .await;
-        #[cfg(unix)]
-        let mut prepared_fifo = if queued.request.command.class() == CommandClass::BuildLike
-            && self.config.bep_transport == BepTransport::Fifo
-        {
-            match capture::PreparedFifoBepCapture::prepare(&paths.bep) {
-                Ok(prepared) => match probe_bazel_server_pid(
-                    executable,
-                    &queued.request.workspace,
-                    &queued.request.startup_arguments,
-                    &self.config,
-                    cancellation.clone(),
-                )
-                .await
-                {
-                    Ok(server_pid) => Some((prepared, server_pid)),
-                    Err(error) => {
-                        tracing::warn!(
-                            invocation_id = %queued.request.id,
-                            %error,
-                            "could not discover Bazel server PID; falling back to BEP file tail"
-                        );
-                        None
-                    }
-                },
-                Err(error) => {
-                    tracing::warn!(
-                        invocation_id = %queued.request.id,
-                        %error,
-                        "could not prepare BEP FIFO; falling back to BEP file tail"
-                    );
-                    None
-                }
-            }
-        } else {
-            None
-        };
-        #[cfg(not(unix))]
-        if queued.request.command.class() == CommandClass::BuildLike
-            && self.config.bep_transport == BepTransport::Fifo
-        {
-            tracing::debug!(
-                invocation_id = %queued.request.id,
-                "BEP FIFO transport is unavailable on this platform; using file tail"
-            );
-        }
-        if cancellation.is_cancelled() {
-            return self.finish_cancelled(queued.request.id).await;
-        }
-        let extension_limits = (!self.reducers.is_empty()).then_some({
-            (
-                self.config.starlark_reducers.limits.max_events,
-                self.config.starlark_reducers.limits.max_input_bytes,
-            )
-        });
-        let bes_bep = if queued.request.command.class() == CommandClass::BuildLike {
-            match &self.bes {
-                Some(server) => Some(capture::LiveBepCapture::Bes(capture::BesBepCapture::start(
-                    server.register(queued.request.id.to_string())?,
-                    paths.bep.clone(),
-                    extension_limits,
-                )?)),
-                None => None,
-            }
-        } else {
-            None
-        };
-        let mut command = Command::new(executable);
-        command
-            .current_dir(&queued.request.workspace)
-            .env_clear()
-            .envs(filtered_environment(&self.config.policy));
-        if let Some(output_user_root) = &self.config.output_user_root {
-            command
-                .arg(format!("--output_user_root={}", output_user_root.display()))
-                .arg(format!(
-                    "--max_idle_secs={}",
-                    self.config.isolated_bazel_server_idle_timeout.as_secs()
-                ));
-        }
-        command
-            .args(&queued.request.startup_arguments)
-            .arg(queued.request.command.as_str());
-        if queued.request.command.class() == CommandClass::BuildLike {
-            command.arg(format!("--invocation_id={}", queued.request.id));
-            match self.config.bep_transport {
-                BepTransport::Tail => {
-                    command
-                        .arg(format!("--build_event_binary_file={}", paths.bep.display()))
-                        .arg("--build_event_binary_file_path_conversion=false");
-                }
-                BepTransport::Fifo => {
-                    #[cfg(unix)]
-                    let output = prepared_fifo
-                        .as_ref()
-                        .map_or(paths.bep.as_path(), |(prepared, _)| prepared.path());
-                    #[cfg(not(unix))]
-                    let output = paths.bep.as_path();
-                    command
-                        .arg(format!("--build_event_binary_file={}", output.display()))
-                        .arg("--build_event_binary_file_path_conversion=false");
-                }
-                BepTransport::Bes => {
-                    let endpoint = self
-                        .bes
-                        .as_ref()
-                        .ok_or(RunnerError::InvalidConfiguration(
-                            "BES transport was not initialized",
-                        ))?
-                        .endpoint();
-                    command
-                        .arg(format!("--bes_backend={endpoint}"))
-                        .arg("--bes_upload_mode=wait_for_upload_complete");
-                }
-            }
-            command.args([
-                "--tool_tag=bazel-mcp",
-                "--color=no",
-                "--curses=no",
-                "--show_progress=false",
-                "--show_result=0",
-            ]);
-            if matches!(
-                queued.request.command,
-                BazelCommand::Test | BazelCommand::Coverage
-            ) {
-                command.args(["--test_output=errors", "--test_summary=none"]);
-            }
-        }
-        command.args(&queued.request.arguments);
-        command.stdout(stdout).stderr(stderr).kill_on_drop(true);
-        #[cfg(unix)]
-        {
-            use std::os::unix::process::CommandExt;
-            command.as_std_mut().process_group(0);
-        }
-
-        let mut child = match command.spawn() {
-            Ok(child) => child,
-            Err(error) => {
-                let message = self.redactor.redact_bounded(&error.to_string(), 1_000);
-                let summary = bazel_mcp_types::InvocationSummary {
-                    success: false,
-                    headline: format!("Could not start Bazel: {message}"),
-                    ..Default::default()
-                };
-                return self
-                    .store
-                    .transition(
-                        queued.request.id,
-                        InvocationState::Failed,
-                        Some(Termination::SpawnFailure { message }),
-                        Some(summary),
-                    )
-                    .await
-                    .map_err(Into::into);
-            }
-        };
-        #[cfg(unix)]
-        let fifo_bep = prepared_fifo.take().map(|(prepared, server_pid)| {
-            let client_pid = child.id().unwrap_or_default();
-            capture::LiveBepCapture::Fifo(prepared.start(
-                paths.bep.clone(),
-                server_pid,
-                client_pid,
-                extension_limits,
-            ))
-        });
-        let mut process_group = ProcessGroupGuard::for_child(&child);
-        if let Err(error) = self
-            .store
-            .transition(queued.request.id, InvocationState::Running, None, None)
-            .await
-        {
-            let _ = terminate_child(
-                &mut child,
-                self.config.cancellation_interrupt_grace,
-                self.config.cancellation_terminate_grace,
-            )
-            .await;
-            let workspace = queued.request.workspace.to_string_lossy();
-            let message = self.redactor.redact_bounded(
-                &error.to_string().replace(workspace.as_ref(), "<workspace>"),
-                1_000,
-            );
-            tracing::warn!(
-                invocation_id = %queued.request.id,
-                error = %message,
-                "could not record running Bazel invocation"
-            );
-            if self
-                .store
-                .get_invocation(queued.request.id)
-                .await
-                .is_ok_and(|record| !record.state.is_terminal())
-            {
-                let summary = bazel_mcp_types::InvocationSummary {
-                    success: false,
-                    headline: format!("Could not record Bazel execution state: {message}"),
-                    truncated: true,
-                    inspect_hint: Some("log".to_owned()),
-                    ..Default::default()
-                };
-                let _ = self
-                    .store
-                    .transition(
-                        queued.request.id,
-                        InvocationState::Failed,
-                        Some(Termination::Interrupted),
-                        Some(summary),
-                    )
-                    .await;
-            }
-            if let Ok(record) = self.store.get_invocation(queued.request.id).await
-                && record.state.is_terminal()
-                && record.summary.is_some()
-            {
-                return Ok(record);
-            }
-            return Err(error.into());
-        }
-        #[cfg(unix)]
-        let incremental_bep = fifo_bep.or(bes_bep).or_else(|| {
-            (queued.request.command.class() == CommandClass::BuildLike
-                && self.config.bep_transport != BepTransport::Bes)
-                .then(|| {
-                    capture::LiveBepCapture::Tail(capture::IncrementalBepCapture::start(
-                        paths.bep.clone(),
-                        extension_limits,
-                    ))
-                })
-        });
-        #[cfg(not(unix))]
-        let incremental_bep = bes_bep.or_else(|| {
-            (queued.request.command.class() == CommandClass::BuildLike
-                && self.config.bep_transport != BepTransport::Bes)
-                .then(|| {
-                    capture::LiveBepCapture::Tail(capture::IncrementalBepCapture::start(
-                        paths.bep.clone(),
-                        extension_limits,
-                    ))
-                })
-        });
-        let started = Instant::now();
-        let timeout = queued
-            .request
-            .timeout_ms
-            .map(Duration::from_millis)
-            .unwrap_or(self.config.default_timeout)
-            .max(Duration::from_secs(1))
-            .min(self.config.maximum_timeout);
-        let timeout_sleep = tokio::time::sleep(timeout);
-        tokio::pin!(timeout_sleep);
-        let (status, termination, state) = tokio::select! {
-            result = child.wait() => finish_from_status(result?),
-            () = cancellation.cancelled() => {
-                let status = terminate_child(
-                    &mut child,
-                    self.config.cancellation_interrupt_grace,
-                    self.config.cancellation_terminate_grace,
-                ).await?;
-                (Some(status), Termination::Cancelled, InvocationState::Cancelled)
-            }
-            () = &mut timeout_sleep => {
-                let status = terminate_child(
-                    &mut child,
-                    self.config.cancellation_interrupt_grace,
-                    self.config.cancellation_terminate_grace,
-                ).await?;
-                (Some(status), Termination::Timeout, InvocationState::TimedOut)
-            }
-        };
-        process_group.disarm();
-        native_output_base_wait.finish().await;
-        let output_base_wait_snapshot = output_base_wait.snapshot();
-        let bazel_wall_ms = duration_millis(started.elapsed());
-        let postprocess: Result<InvocationRecord, RunnerError> = async {
-            let reduction_started = Instant::now();
-            let incremental_reduction = match incremental_bep {
-                Some(capture) => {
-                    let reduction = capture.finish(BES_COMPLETION_GRACE).await?;
-                    tracing::debug!(
-                        invocation_id = %queued.request.id,
-                        source = ?reduction.source,
-                        finalize_ms = reduction.finalize_ms,
-                        events = reduction.outcome.event_count,
-                        bytes = reduction.outcome.decoded_bytes,
-                        "completed incremental BEP reduction"
-                    );
-                    Some(reduction)
-                }
-                None => None,
-            };
-            let (query_row_count, query_sample) =
-                if queued.request.command.class() == CommandClass::Query {
-                    let redactor = self.redactor.clone();
-                    let (page, total, _) = self
-                        .store
-                        .page_query_rows_mapped_into(
-                            queued.request.id,
-                            None,
-                            PageRequest {
-                                cursor: None,
-                                limit: 3,
-                                max_bytes: None,
-                            },
-                            move |value, output| {
-                                redactor.redact_bounded_into(value, 4 * 1024, output);
-                            },
-                        )
-                        .await?;
-                    (total, page.items)
-                } else {
-                    (0, Vec::new())
-                };
-            let (bep, bep_outcome) = match incremental_reduction {
-                Some(reduction) => (reduction.accumulator, reduction.outcome),
-                None => capture::reduce_bep(paths.bep.clone(), extension_limits).await?,
-            };
-            if let Some(error) = &bep_outcome.terminal_error {
-                tracing::warn!(invocation_id = %queued.request.id, %error, "partially decoded BEP");
-            }
-            // Complete structured evidence needs only a small diagnostic tail;
-            // partial or missing BEP retains a larger bounded fallback.
-            let log_limit = if bep_outcome.event_count > 0 && bep_outcome.terminal_error.is_none() {
-                COMPLETE_BEP_LOG_LIMIT
-            } else {
-                FALLBACK_LOG_LIMIT
-            };
-            let stdout = capture::read_bounded_tail(&paths.stdout, log_limit).await?;
-            let stderr = capture::read_bounded_tail(&paths.stderr, log_limit).await?;
-            let exit_code = status.as_ref().and_then(ExitStatus::code);
-            let failed = exit_code != Some(0);
-            if should_persist_failure_evidence(&queued.request.command, failed) {
-                self.persist_failure_evidence(
-                    paths,
-                    &queued.request.workspace,
-                    &queued.request.command,
-                    failed,
-                    &stdout,
-                    &stderr,
-                )
-                .await?;
-            }
-            let reduced = catch_unwind(AssertUnwindSafe(|| {
-                bep.finish(
-                    &stdout,
-                    &stderr,
-                    exit_code,
-                    bazel_wall_ms,
-                    // Enrichment can add higher-value failed-test evidence.
-                    // Apply the public result budget only after that evidence
-                    // is present so ranking and aggregation precede limits.
-                    Budget {
-                        max_bytes: usize::MAX,
-                        max_items: usize::MAX,
-                    },
-                )
-            }));
-            let StreamReductionOutput {
-                mut summary,
-                mut artifacts,
-                canonical_arguments,
-                reducer_events,
-                reducer_input_truncated,
-            } = reduced.unwrap_or_else(|_| {
-                tracing::warn!(
-                    invocation_id = %queued.request.id,
-                    "streaming BEP reducer panicked; using bounded fallback summary"
-                );
-                StreamReductionOutput {
-                    summary: fallback_summary(exit_code, bazel_wall_ms, &stderr, &stdout),
-                    artifacts: Vec::new(),
-                    canonical_arguments: None,
-                    reducer_events: Vec::new(),
-                    reducer_input_truncated: false,
-                }
-            });
-            let canonical_arguments = canonical_arguments.map(|mut arguments| {
-                let workspace = queued.request.workspace.to_string_lossy();
-                for argument in &mut arguments {
-                    *argument = self.redactor.redact_bounded(
-                        &argument.replace(workspace.as_ref(), "<workspace>"),
-                        64 * 1024,
-                    );
-                }
-                arguments
-            });
-            for artifact in &mut artifacts {
-                artifact.name = self.redactor.redact_bounded(&artifact.name, 1_000);
-                artifact.uri = self.redactor.redact_bounded(&artifact.uri, 1_000);
-            }
-            if queued.request.command.class() == CommandClass::Query && exit_code == Some(0) {
-                summary.headline = format!("Bazel query returned {query_row_count} rows");
-                summary.inspect_hint = (query_row_count > 0).then(|| "query_results".to_owned());
-                summary.query_result_count = Some(query_row_count);
-                summary.query_sample = query_sample;
-            } else if matches!(
-                queued.request.command.class(),
-                CommandClass::Informational | CommandClass::Unknown
-            ) && exit_code == Some(0)
-            {
-                let text = if stdout.is_empty() { &stderr } else { &stdout };
-                let excerpt = normalize_terminal_text(text);
-                if !excerpt.is_empty() {
-                    summary.headline = bounded_text(&excerpt, 1_000);
-                    if excerpt.len() > 1_000 {
-                        summary.truncated = true;
-                        summary.inspect_hint = Some("log".to_owned());
-                    }
-                }
-            }
-            self.enrich_tests(paths, &queued.request.workspace, &mut summary, &artifacts)
-                .await;
-            if queued.request.command == BazelCommand::Coverage {
-                summary.coverage = self
-                    .load_coverage(&queued.request.workspace, &artifacts)
-                    .await;
-            }
-            let mut custom_headline = None;
-            let mut custom_notices = Vec::new();
-            if !self.reducers.is_empty() {
-                let context = self.reducer_context(
-                    &queued.request,
-                    exit_code,
-                    bazel_wall_ms,
-                    &stdout,
-                    &stderr,
-                    reducer_events,
-                    reducer_input_truncated,
-                    &summary,
-                );
-                let reducers = self.reducers.clone();
-                let (next_summary, report) = task::spawn_blocking(move || {
-                    let mut next_summary = summary;
-                    let report = reducers.apply(&context, &mut next_summary);
-                    (next_summary, report)
-                })
-                .await?;
-                summary = next_summary;
-                if report.headline_applied {
-                    custom_headline = Some(summary.headline.clone());
-                }
-                for name in report.applied {
-                    let name = self.redactor.redact_bounded(&name, 128);
-                    tracing::debug!(invocation_id = %queued.request.id, reducer = %name, "applied custom reducer");
-                }
-                for failure in report.failures {
-                    let name = self.redactor.redact_bounded(&failure.name, 128);
-                    let error = self.redactor.redact_bounded(&failure.error, 2 * 1024);
-                    tracing::warn!(
-                        invocation_id = %queued.request.id,
-                        reducer = %name,
-                        %error,
-                        "custom reducer failed; native result retained"
-                    );
-                    custom_notices.push(custom_reducer_notice(format!(
-                        "Custom reducer {:?} failed; native reducer output was retained",
-                        name
-                    )));
-                }
-                for collision in report.override_collisions {
-                    let collision = self.redactor.redact_bounded(&collision, 512);
-                    tracing::warn!(invocation_id = %queued.request.id, %collision, "custom reducer override collision");
-                    custom_notices.push(custom_reducer_notice(collision));
-                }
-            }
-            finalize_with_custom_notices(&mut summary, custom_notices);
-            if let Some(headline) = custom_headline {
-                summary.headline = headline;
-            }
-            if !summary.success && summary.inspect_hint.is_none() {
-                let view = if summary
-                    .tests
-                    .iter()
-                    .any(|test| test.status != TestStatus::Passed && test.test_log_available)
-                {
-                    "test_log"
-                } else {
-                    "log"
-                };
-                summary.inspect_hint = Some(view.to_owned());
-            }
-            self.sanitize_summary(queued.request.id, &queued.request.workspace, &mut summary);
-            let metrics = InvocationMetrics {
-                raw_output_bytes: capture::file_size(&paths.stdout)
-                    .await
-                    .saturating_add(capture::file_size(&paths.stderr).await),
-                bep_bytes: capture::file_size(&paths.bep).await,
-                bep_events: u64::try_from(bep_outcome.event_count).unwrap_or(u64::MAX),
-                queue_ms,
-                output_base_lock_wait_ms: output_base_wait_snapshot.elapsed_ms,
-                bazel_wall_ms,
-                reduction_ms: duration_millis(reduction_started.elapsed()),
-                ..Default::default()
-            };
-            self.store
-                .finish_invocation(
-                    queued.request.id,
-                    InvocationCompletion {
-                        state,
-                        termination: termination.clone(),
-                        summary,
-                        metrics,
-                        canonical_arguments,
-                        artifacts,
-                    },
-                )
-                .await
-                .map_err(Into::into)
-        }
-        .await;
-
-        if let Err(error) = &postprocess {
-            let workspace = queued.request.workspace.to_string_lossy();
-            let message = self.redactor.redact_bounded(
-                &error.to_string().replace(workspace.as_ref(), "<workspace>"),
-                1_000,
-            );
-            tracing::warn!(
-                invocation_id = %queued.request.id,
-                error = %message,
-                "Bazel result post-processing failed"
-            );
-            if self
-                .store
-                .get_invocation(queued.request.id)
-                .await
-                .is_ok_and(|record| !record.state.is_terminal())
-            {
-                let terminal_state = if state == InvocationState::Succeeded {
-                    InvocationState::Failed
-                } else {
-                    state
-                };
-                let summary = bazel_mcp_types::InvocationSummary {
-                    success: false,
-                    headline: format!("Could not finish processing Bazel results: {message}"),
-                    elapsed_ms: bazel_wall_ms,
-                    truncated: true,
-                    inspect_hint: Some("log".to_owned()),
-                    ..Default::default()
-                };
-                let _ = self
-                    .store
-                    .transition(
-                        queued.request.id,
-                        terminal_state,
-                        Some(termination),
-                        Some(summary),
-                    )
-                    .await;
-            }
-            if let Ok(record) = self.store.get_invocation(queued.request.id).await
-                && record.state.is_terminal()
-                && record.summary.is_some()
-            {
-                return Ok(record);
-            }
-        }
-        postprocess
-    }
-
-    async fn workspace_lock(&self, workspace: &Path) -> Arc<Mutex<()>> {
-        let mut locks = self.workspace_locks.lock().await;
-        locks.retain(|_, lock| lock.strong_count() > 0);
-        if let Some(lock) = locks.get(workspace).and_then(Weak::upgrade) {
-            return lock;
-        }
-        let lock = Arc::new(Mutex::new(()));
-        locks.insert(workspace.to_owned(), Arc::downgrade(&lock));
-        lock
-    }
-
-    fn sanitize_summary(
-        &self,
-        _id: InvocationId,
-        workspace: &Path,
-        summary: &mut bazel_mcp_types::InvocationSummary,
-    ) {
-        let workspace = workspace.to_string_lossy();
-        let sanitize = |value: &str, maximum_bytes| {
-            self.redactor.redact_bounded(
-                &value.replace(workspace.as_ref(), "<workspace>"),
-                maximum_bytes,
-            )
-        };
-        summary.headline = sanitize(&summary.headline, 1_000);
-        for target in &mut summary.targets {
-            target.label = sanitize(&target.label, 1_000);
-        }
-        for diagnostic in &mut summary.diagnostics {
-            diagnostic.message = sanitize(&diagnostic.message, 1_000);
-            if let Some(location) = &mut diagnostic.location {
-                let path = location.path.replace(workspace.as_ref(), "<workspace>");
-                let path = path
-                    .strip_prefix("<workspace>/")
-                    .or_else(|| path.strip_prefix("<workspace>\\"))
-                    .or_else(|| path.strip_prefix("<WORKSPACE>/"))
-                    .or_else(|| path.strip_prefix("<WORKSPACE>\\"))
-                    .unwrap_or(&path);
-                location.path = self.redactor.redact_bounded(path, 1_000);
-            }
-            diagnostic.target = diagnostic
-                .target
-                .as_deref()
-                .map(|target| sanitize(target, 1_000));
-            diagnostic.action = diagnostic
-                .action
-                .as_deref()
-                .map(|action| sanitize(action, 1_000));
-        }
-        for test in &mut summary.tests {
-            test.label = sanitize(&test.label, 1_000);
-            for case in &mut test.cases {
-                case.name = sanitize(&case.name, 512);
-                case.message = case
-                    .message
-                    .as_deref()
-                    .map(|message| sanitize(message, 1_000));
-            }
-        }
-        if let Some(coverage) = &mut summary.coverage {
-            for file in &mut coverage.files {
-                file.path = sanitize(&file.path, 1_000);
-            }
-        }
-    }
-
-    #[allow(clippy::too_many_arguments)]
-    fn reducer_context(
-        &self,
-        request: &InvocationRequest,
-        exit_code: Option<i32>,
-        elapsed_ms: u64,
-        stdout: &[u8],
-        stderr: &[u8],
-        mut events: Vec<bazel_mcp_reducer::ReducerEvent>,
-        mut input_truncated: bool,
-        summary: &bazel_mcp_types::InvocationSummary,
-    ) -> ReducerContext {
-        let maximum_input = self.config.starlark_reducers.limits.max_input_bytes;
-        let workspace = request.workspace.to_string_lossy();
-        let sanitize = |value: &str, maximum_bytes| {
-            self.redactor.redact_bounded(
-                &value.replace(workspace.as_ref(), "<workspace>"),
-                maximum_bytes,
-            )
-        };
-        let stdout = normalize_terminal_text(stdout);
-        let stderr = normalize_terminal_text(stderr);
-        let (stdout_limit, stderr_limit) = match (stdout.is_empty(), stderr.is_empty()) {
-            (false, true) => (maximum_input, 0),
-            (true, false) => (0, maximum_input),
-            _ => (
-                maximum_input / 2,
-                maximum_input.saturating_sub(maximum_input / 2),
-            ),
-        };
-        input_truncated |= stdout.len() > stdout_limit || stderr.len() > stderr_limit;
-        let stdout = sanitize(&stdout, stdout_limit);
-        let stderr = sanitize(&stderr, stderr_limit);
-        for event in &mut events {
-            event.label = event
-                .label
-                .as_deref()
-                .map(|value| sanitize(value, 4 * 1024));
-            event.target_kind = event
-                .target_kind
-                .as_deref()
-                .map(|value| sanitize(value, 4 * 1024));
-            event.action_type = event
-                .action_type
-                .as_deref()
-                .map(|value| sanitize(value, 4 * 1024));
-            event.message = event
-                .message
-                .as_deref()
-                .map(|value| sanitize(value, 64 * 1024));
-        }
-        const MAX_ARGUMENTS: usize = 1_024;
-        let raw_arguments = request
-            .startup_arguments
-            .iter()
-            .chain(request.arguments.iter());
-        let arguments = raw_arguments
-            .take(MAX_ARGUMENTS)
-            .map(|value| sanitize(value, 4 * 1024))
-            .collect::<Vec<_>>();
-        input_truncated |= request
-            .startup_arguments
-            .len()
-            .saturating_add(request.arguments.len())
-            > MAX_ARGUMENTS;
-        let mut baseline = summary.clone();
-        finalize_diagnostics(
-            &mut baseline,
-            Budget {
-                max_bytes: maximum_input / 4,
-                max_items: self.config.starlark_reducers.limits.max_output_items,
-            },
-        );
-        self.sanitize_summary(request.id, &request.workspace, &mut baseline);
-        ReducerContext {
-            api_version: REDUCER_API_VERSION,
-            command: request.command.as_str().to_owned(),
-            arguments,
-            exit_code,
-            elapsed_ms,
-            stdout,
-            stderr,
-            events,
-            input_truncated,
-            baseline,
-        }
-    }
-
-    async fn finish_cancelled(&self, id: InvocationId) -> Result<InvocationRecord, RunnerError> {
-        let current = self.store.get_invocation(id).await?;
-        if current.state.is_terminal() {
-            return Ok(current);
-        }
-        match self
-            .store
-            .transition(
-                id,
-                InvocationState::Cancelled,
-                Some(Termination::Cancelled),
-                Some(cancelled_summary()),
-            )
-            .await
-        {
-            Ok(record) => Ok(record),
-            Err(StoreError::State(_)) => {
-                let record = self.store.get_invocation(id).await?;
-                if record.state.is_terminal() {
-                    Ok(record)
-                } else {
-                    Err(RunnerError::Store(StoreError::State(
-                        bazel_mcp_types::StateTransitionError {
-                            current: record.state,
-                            next: InvocationState::Cancelled,
-                        },
-                    )))
-                }
-            }
-            Err(error) => Err(error.into()),
-        }
     }
 
     fn redacted_request(&self, request: &InvocationRequest) -> InvocationRequest {
@@ -2040,926 +944,9 @@ impl InvocationService {
         }
         request
     }
-
-    async fn enrich_tests(
-        &self,
-        paths: &InvocationPaths,
-        workspace: &Path,
-        summary: &mut bazel_mcp_types::InvocationSummary,
-        artifacts: &[bazel_mcp_types::Artifact],
-    ) {
-        if !summary
-            .tests
-            .iter()
-            .any(|test| test.status != TestStatus::Passed)
-        {
-            return;
-        }
-
-        let raw_temporary = paths.test_logs_raw.with_extension("tmp");
-        let evidence_temporary = paths.test_log_evidence.with_extension("tmp");
-        if tokio::fs::try_exists(&paths.test_logs_raw)
-            .await
-            .unwrap_or(false)
-            || tokio::fs::try_exists(&paths.test_log_evidence)
-                .await
-                .unwrap_or(false)
-        {
-            for test in summary
-                .tests
-                .iter_mut()
-                .filter(|test| test.status != TestStatus::Passed)
-            {
-                test.test_log_available = false;
-                test.test_log_unavailable_reason =
-                    Some("test_log_snapshot_already_exists".to_owned());
-            }
-            return;
-        }
-
-        let raw = tokio::fs::OpenOptions::new()
-            .create_new(true)
-            .write(true)
-            .open(&raw_temporary)
-            .await;
-        let evidence = tokio::fs::OpenOptions::new()
-            .create_new(true)
-            .write(true)
-            .open(&evidence_temporary)
-            .await;
-        let (Ok(mut raw), Ok(mut evidence)) = (raw, evidence) else {
-            let _ = tokio::fs::remove_file(&raw_temporary).await;
-            let _ = tokio::fs::remove_file(&evidence_temporary).await;
-            set_test_log_unavailable(summary, "test_log_snapshot_failed");
-            return;
-        };
-
-        let workspace_text = workspace.to_string_lossy();
-        let any_remote_test_log = artifacts.iter().any(|artifact| {
-            artifact.kind == ArtifactKind::TestLog
-                && artifact.name.ends_with("test.log")
-                && !artifact.locally_available
-        });
-        let mut diagnostics = Vec::new();
-        let mut copied_any = false;
-        for test in summary
-            .tests
-            .iter_mut()
-            .filter(|test| test.status != TestStatus::Passed)
-        {
-            if let Some(xml) = artifacts.iter().find(|artifact| {
-                artifact.kind == ArtifactKind::TestLog
-                    && artifact.name.ends_with("test.xml")
-                    && artifact_matches_test(artifact, &test.label)
-            }) && let Some(path) = self.validated_artifact_path(workspace, xml).await
-            {
-                let small_enough = tokio::fs::metadata(&path)
-                    .await
-                    .is_ok_and(|metadata| metadata.len() <= 16 * 1024 * 1024);
-                if small_enough
-                    && let Ok(contents) = tokio::fs::read_to_string(path).await
-                    && let Ok(cases) = parse_test_xml(&contents)
-                {
-                    test.cases = cases
-                        .into_iter()
-                        .filter(|case| case.status != TestStatus::Passed)
-                        .take(20)
-                        .map(|mut case| {
-                            case.name = bounded_text(&case.name, 512);
-                            case.message =
-                                case.message.map(|message| bounded_text(&message, 1_000));
-                            case
-                        })
-                        .collect();
-                }
-            }
-
-            let matching_logs = artifacts.iter().filter(|artifact| {
-                artifact.kind == ArtifactKind::TestLog
-                    && artifact.name.ends_with("test.log")
-                    && artifact_matches_test(artifact, &test.label)
-            });
-            let mut saw_artifact = false;
-            let mut copied_for_test = false;
-            let mut saw_remote = false;
-            let mut extracted_failures = Vec::<TestFailureEvidence>::new();
-            let mut fallback_excerpt = None::<(u8, Diagnostic)>;
-            for log in matching_logs {
-                saw_artifact = true;
-                if !log.locally_available {
-                    saw_remote = true;
-                    continue;
-                }
-                let Some(path) = self.validated_artifact_path(workspace, log).await else {
-                    continue;
-                };
-                let Ok(file) = tokio::fs::File::open(&path).await else {
-                    continue;
-                };
-                let mut javascript_parser = JavaScriptTestDiagnosticParser::default();
-                let mut java_parser = JavaTestDiagnosticParser::default();
-                let mut python_parser = PythonDiagnosticParser::default();
-                let marker = format!("\n===== {} :: {} =====\n", test.label, log.name);
-                if raw.write_all(marker.as_bytes()).await.is_err() {
-                    continue;
-                }
-                let mut reader = BufReader::new(file);
-                let mut failure_accumulator = TestFailureAccumulator::default();
-                let mut line = Vec::new();
-                let mut complete = true;
-                loop {
-                    line.clear();
-                    let read = match reader.read_until(b'\n', &mut line).await {
-                        Ok(read) => read,
-                        Err(_) => {
-                            complete = false;
-                            break;
-                        }
-                    };
-                    if read == 0 {
-                        break;
-                    }
-                    if raw.write_all(&line).await.is_err() {
-                        complete = false;
-                        break;
-                    }
-                    for visible_line in normalize_terminal_text(&line).lines() {
-                        let visible_line = visible_line.trim();
-                        if visible_line.is_empty() {
-                            continue;
-                        }
-                        let text = self.redactor.redact_bounded(
-                            &visible_line.replace(workspace_text.as_ref(), "<workspace>"),
-                            4 * 1024,
-                        );
-                        failure_accumulator.observe_line(&text);
-                        let javascript_diagnostic = javascript_parser.observe_line(&text);
-                        let java_diagnostic = java_parser.observe_line(&text);
-                        let candidate = if let Some(mut diagnostic) = parse_go_diagnostic(&text) {
-                            diagnostic.category = DiagnosticCategory::Test;
-                            diagnostic.target = Some(test.label.clone());
-                            diagnostic.message = bounded_text(&diagnostic.message, 1_000);
-                            Some((0, diagnostic))
-                        } else if let Some(mut diagnostic) = javascript_diagnostic {
-                            diagnostic.target = Some(test.label.clone());
-                            diagnostic.message = bounded_text(&diagnostic.message, 1_000);
-                            Some((0, diagnostic))
-                        } else if let Some(mut diagnostic) = java_diagnostic {
-                            diagnostic.target = Some(test.label.clone());
-                            diagnostic.message = bounded_text(&diagnostic.message, 1_000);
-                            Some((0, diagnostic))
-                        } else if let Some(mut diagnostic) = python_parser.observe_line(&text) {
-                            diagnostic.category = DiagnosticCategory::Test;
-                            diagnostic.target = Some(test.label.clone());
-                            diagnostic.message = bounded_text(&diagnostic.message, 1_000);
-                            Some((0, diagnostic))
-                        } else {
-                            failure_evidence_priority(&text).map(|priority| {
-                                (
-                                    priority,
-                                    Diagnostic {
-                                        severity: Severity::Error,
-                                        category: DiagnosticCategory::Test,
-                                        message: bounded_text(&text, 1_000),
-                                        location: None,
-                                        target: Some(test.label.clone()),
-                                        action: None,
-                                        repetition_count: 1,
-                                    },
-                                )
-                            })
-                        };
-                        if let Some((priority, diagnostic)) = candidate
-                            && fallback_excerpt.as_ref().is_none_or(
-                                |(current, current_diagnostic)| {
-                                    priority < *current
-                                        || (priority == *current
-                                            && diagnostic.location.is_some()
-                                            && current_diagnostic.location.is_none())
-                                },
-                            )
-                        {
-                            fallback_excerpt = Some((priority, diagnostic));
-                        }
-                        let record = EvidenceRecord {
-                            label: Some(test.label.clone()),
-                            text: format!("[{}] {text}", test.label),
-                        };
-                        let Ok(mut encoded) = serde_json::to_vec(&record) else {
-                            complete = false;
-                            break;
-                        };
-                        encoded.push(b'\n');
-                        if evidence.write_all(&encoded).await.is_err() {
-                            complete = false;
-                            break;
-                        }
-                    }
-                    if !complete {
-                        break;
-                    }
-                }
-                if complete {
-                    for mut diagnostic in [javascript_parser.finish(), java_parser.finish()]
-                        .into_iter()
-                        .flatten()
-                    {
-                        diagnostic.target = Some(test.label.clone());
-                        diagnostic.message = bounded_text(&diagnostic.message, 1_000);
-                        if fallback_excerpt.as_ref().is_none_or(|(priority, current)| {
-                            *priority > 0
-                                || (*priority == 0
-                                    && diagnostic.location.is_some()
-                                    && current.location.is_none())
-                        }) {
-                            fallback_excerpt = Some((0, diagnostic));
-                        }
-                    }
-                }
-                if complete {
-                    for failure in failure_accumulator.finish() {
-                        if extracted_failures.len() >= 20 {
-                            break;
-                        }
-                        if !extracted_failures.iter().any(|current| {
-                            current.name == failure.name && current.message == failure.message
-                        }) {
-                            extracted_failures.push(failure);
-                        }
-                    }
-                    copied_for_test = true;
-                    copied_any = true;
-                }
-            }
-            if copied_for_test {
-                test.test_log_available = true;
-                test.test_log_unavailable_reason = None;
-                if extracted_failures.is_empty() {
-                    if let Some((_, diagnostic)) = fallback_excerpt {
-                        diagnostics.push(diagnostic);
-                    }
-                } else {
-                    let previous_cases = std::mem::take(&mut test.cases);
-                    let mut cases = Vec::<TestCase>::new();
-                    for failure in &extracted_failures {
-                        if cases.len() >= 20 {
-                            break;
-                        }
-                        if cases.iter().any(|case| case.name == failure.name) {
-                            continue;
-                        }
-                        cases.push(TestCase {
-                            name: failure.name.clone(),
-                            status: TestStatus::Failed,
-                            duration_ms: None,
-                            message: Some(failure.message.clone()),
-                        });
-                    }
-                    for case in previous_cases {
-                        if cases.len() >= 20 {
-                            break;
-                        }
-                        if !cases.iter().any(|current| {
-                            current.name == case.name && current.message == case.message
-                        }) {
-                            cases.push(case);
-                        }
-                    }
-                    test.cases = cases;
-                    for failure in extracted_failures.into_iter().take(20) {
-                        diagnostics.push(Diagnostic {
-                            severity: Severity::Error,
-                            category: DiagnosticCategory::Test,
-                            message: failure.message,
-                            location: failure.location,
-                            target: Some(test.label.clone()),
-                            action: None,
-                            repetition_count: 1,
-                        });
-                    }
-                }
-            } else {
-                test.test_log_available = false;
-                test.test_log_unavailable_reason = Some(
-                    if saw_remote || (!saw_artifact && any_remote_test_log) {
-                        "remote_test_log_unavailable"
-                    } else if saw_artifact {
-                        "test_log_outside_allowed_roots_or_unreadable"
-                    } else {
-                        "test_log_not_found"
-                    }
-                    .to_owned(),
-                );
-            }
-        }
-
-        let flushed = raw.flush().await.is_ok() && evidence.flush().await.is_ok();
-        drop(raw);
-        drop(evidence);
-        let committed = if copied_any {
-            flushed
-                && set_private_file(&raw_temporary).await.is_ok()
-                && set_private_file(&evidence_temporary).await.is_ok()
-                && tokio::fs::rename(&raw_temporary, &paths.test_logs_raw)
-                    .await
-                    .is_ok()
-                && tokio::fs::rename(&evidence_temporary, &paths.test_log_evidence)
-                    .await
-                    .is_ok()
-        } else {
-            false
-        };
-        if committed {
-            for diagnostic in &diagnostics {
-                summary.diagnostics.retain(|existing| {
-                    !((existing.category == DiagnosticCategory::Compilation
-                        || (existing.category == diagnostic.category && existing.target.is_none()))
-                        && existing.message == diagnostic.message
-                        && (existing.location == diagnostic.location
-                            || existing.location.is_none()))
-                });
-            }
-            summary.diagnostics.extend(diagnostics);
-        } else {
-            let _ = tokio::fs::remove_file(&raw_temporary).await;
-            let _ = tokio::fs::remove_file(&evidence_temporary).await;
-            if copied_any {
-                set_test_log_unavailable(summary, "test_log_snapshot_failed");
-            }
-        }
-    }
-
-    async fn load_coverage(
-        &self,
-        workspace: &Path,
-        artifacts: &[bazel_mcp_types::Artifact],
-    ) -> Option<bazel_mcp_types::CoverageSummary> {
-        for artifact in artifacts
-            .iter()
-            .filter(|artifact| artifact.kind == ArtifactKind::Coverage)
-        {
-            let Some(canonical) = self.validated_artifact_path(workspace, artifact).await else {
-                continue;
-            };
-            let parsed = tokio::task::spawn_blocking(move || {
-                let file = std::fs::File::open(canonical)?;
-                parse_lcov_reader(std::io::BufReader::new(file))
-                    .map_err(|error| io::Error::new(io::ErrorKind::InvalidData, error))
-            })
-            .await;
-            if let Ok(Ok(coverage)) = parsed {
-                return Some(coverage);
-            }
-        }
-        None
-    }
-
-    async fn validated_artifact_path(
-        &self,
-        workspace: &Path,
-        artifact: &bazel_mcp_types::Artifact,
-    ) -> Option<PathBuf> {
-        let path = local_artifact_path(artifact)?;
-        let canonical = tokio::fs::canonicalize(&path).await.ok()?;
-        let in_workspace = canonical.starts_with(workspace);
-        let in_output_root = if let Some(root) = &self.config.output_user_root {
-            tokio::fs::canonicalize(root)
-                .await
-                .is_ok_and(|root| canonical.starts_with(root))
-        } else {
-            false
-        };
-        let in_bazel_testlogs = if artifact.kind == ArtifactKind::TestLog {
-            match bazel_test_log_output_base(&path).zip(bazel_test_log_output_base(&canonical)) {
-                Some((lexical_root, canonical_root)) => tokio::fs::canonicalize(lexical_root)
-                    .await
-                    .is_ok_and(|lexical_root| {
-                        lexical_root == canonical_root && canonical.starts_with(&lexical_root)
-                    }),
-                None => false,
-            }
-        } else {
-            false
-        };
-        (in_workspace || in_output_root || in_bazel_testlogs).then_some(canonical)
-    }
-
-    async fn persist_failure_evidence(
-        &self,
-        paths: &InvocationPaths,
-        workspace: &Path,
-        command: &BazelCommand,
-        failed: bool,
-        stdout: &[u8],
-        stderr: &[u8],
-    ) -> Result<(), RunnerError> {
-        let records = failure_evidence_records(command, failed, stdout, stderr);
-        let workspace = workspace.to_string_lossy();
-        let mut bytes = Vec::new();
-        for mut record in records {
-            record.text = self.redactor.redact_bounded(
-                &record.text.replace(workspace.as_ref(), "<workspace>"),
-                4 * 1024,
-            );
-            serde_json::to_writer(&mut bytes, &record)?;
-            bytes.push(b'\n');
-        }
-        write_private_atomic(&paths.evidence, &bytes).await?;
-        Ok(())
-    }
-
-    async fn read_evidence_page(
-        &self,
-        path: &Path,
-        paths: &InvocationPaths,
-        request: &InspectRequest,
-    ) -> Result<(Vec<String>, bool, Option<String>), RunnerError> {
-        let invocation_id = request.invocation_id.ok_or(StoreError::InvalidCursor)?;
-        let start = request
-            .cursor
-            .as_deref()
-            .map(|value| {
-                LogCursor::decode_for(
-                    value,
-                    invocation_id,
-                    request.view,
-                    request.filter.as_deref(),
-                )
-            })
-            .transpose()?
-            .map_or(0, |cursor| cursor.next_record);
-        let file = match tokio::fs::File::open(path).await {
-            Ok(file) => file,
-            Err(error)
-                if error.kind() == io::ErrorKind::NotFound && request.view == InspectView::Log =>
-            {
-                let stdout = capture::read_bounded_tail(&paths.stdout, 1024 * 1024).await?;
-                let stderr = capture::read_bounded_tail(&paths.stderr, 1024 * 1024).await?;
-                let records = failure_evidence_records(
-                    &BazelCommand::Custom("retained".to_owned()),
-                    true,
-                    &stdout,
-                    &stderr,
-                );
-                return page_evidence_records(records.into_iter(), start, request, invocation_id);
-            }
-            Err(error) => return Err(error.into()),
-        };
-        let mut lines = BufReader::new(file).lines();
-        let mut records = Vec::new();
-        while let Some(line) = lines.next_line().await? {
-            records.push(serde_json::from_str::<EvidenceRecord>(&line)?);
-        }
-        page_evidence_records(records.into_iter(), start, request, invocation_id)
-    }
-
-    async fn read_test_log_unavailable_page(
-        &self,
-        invocation_id: InvocationId,
-        request: &InspectRequest,
-    ) -> Result<(Vec<String>, bool, Option<String>), RunnerError> {
-        let start = request
-            .cursor
-            .as_deref()
-            .map(|value| {
-                LogCursor::decode_for(
-                    value,
-                    invocation_id,
-                    request.view,
-                    request.filter.as_deref(),
-                )
-            })
-            .transpose()?
-            .map_or(0, |cursor| cursor.next_record);
-        let maximum_bytes = request.max_bytes.saturating_sub(512).max(1);
-        let maximum_items = usize::try_from(request.limit.clamp(1, 100)).unwrap_or(100);
-        let filter = request.filter.as_deref().map(str::to_ascii_lowercase);
-        let mut items = Vec::new();
-        let mut used_bytes = 2_usize;
-        let mut reason_index = 0_u64;
-        let mut storage_cursor = None;
-
-        loop {
-            let (page, _, _) = self
-                .store
-                .page_tests(
-                    invocation_id,
-                    None,
-                    PageRequest {
-                        cursor: storage_cursor,
-                        limit: 100,
-                        max_bytes: Some(128 * 1024),
-                    },
-                )
-                .await?;
-            for test in page.items {
-                let Some(reason) = test.test_log_unavailable_reason else {
-                    continue;
-                };
-                let index = reason_index;
-                reason_index = reason_index.saturating_add(1);
-                if index < start {
-                    continue;
-                }
-                let text = self
-                    .redactor
-                    .redact_bounded(&format!("{}: {reason}", test.label), 4 * 1024);
-                if !filter
-                    .as_ref()
-                    .is_none_or(|filter| text.to_ascii_lowercase().contains(filter))
-                {
-                    continue;
-                }
-                let item_bytes = serde_json::to_vec(&text)?.len();
-                let separator = usize::from(!items.is_empty());
-                if items.len() == maximum_items
-                    || (!items.is_empty()
-                        && used_bytes
-                            .saturating_add(separator)
-                            .saturating_add(item_bytes)
-                            > maximum_bytes)
-                {
-                    let next_cursor = LogCursor {
-                        invocation_id,
-                        view: request.view,
-                        next_record: index,
-                        filter: request.filter.clone(),
-                    }
-                    .encode()?;
-                    return Ok((items, true, Some(next_cursor)));
-                }
-                used_bytes = used_bytes
-                    .saturating_add(separator)
-                    .saturating_add(item_bytes);
-                items.push(text);
-            }
-            if !page.truncated {
-                return Ok((items, false, None));
-            }
-            storage_cursor = page.next_cursor;
-        }
-    }
 }
 
-fn page_evidence_records(
-    records: impl Iterator<Item = EvidenceRecord>,
-    start: u64,
-    request: &InspectRequest,
-    invocation_id: InvocationId,
-) -> Result<(Vec<String>, bool, Option<String>), RunnerError> {
-    let maximum_bytes = request.max_bytes.saturating_sub(512).max(1);
-    let maximum_items = usize::try_from(request.limit.clamp(1, 100)).unwrap_or(100);
-    let filter = request.filter.as_deref().map(str::to_ascii_lowercase);
-    let mut items = Vec::new();
-    let mut used_bytes = 2_usize;
-    let mut next_record = start;
-    let mut truncated = false;
-    for (index, record) in records.enumerate() {
-        let index = u64::try_from(index).unwrap_or(u64::MAX);
-        if index < start {
-            continue;
-        }
-        let matches = filter.as_ref().is_none_or(|filter| {
-            record.text.to_ascii_lowercase().contains(filter)
-                || record
-                    .label
-                    .as_deref()
-                    .is_some_and(|label| label.to_ascii_lowercase().contains(filter))
-        });
-        if !matches {
-            next_record = index.saturating_add(1);
-            continue;
-        }
-        let item_bytes = serde_json::to_vec(&record.text)?.len();
-        let separator = usize::from(!items.is_empty());
-        if items.len() == maximum_items
-            || (!items.is_empty()
-                && used_bytes
-                    .saturating_add(separator)
-                    .saturating_add(item_bytes)
-                    > maximum_bytes)
-        {
-            next_record = index;
-            truncated = true;
-            break;
-        }
-        used_bytes = used_bytes
-            .saturating_add(separator)
-            .saturating_add(item_bytes);
-        items.push(record.text);
-        next_record = index.saturating_add(1);
-    }
-    let next_cursor = truncated
-        .then_some(LogCursor {
-            invocation_id,
-            view: request.view,
-            next_record,
-            filter: request.filter.clone(),
-        })
-        .map(|cursor| cursor.encode())
-        .transpose()?;
-    Ok((items, truncated, next_cursor))
-}
-
-fn should_persist_failure_evidence(command: &BazelCommand, failed: bool) -> bool {
-    failed || command.class() != CommandClass::Query
-}
-
-fn failure_evidence_records(
-    command: &BazelCommand,
-    failed: bool,
-    stdout: &[u8],
-    stderr: &[u8],
-) -> Vec<EvidenceRecord> {
-    let test_like = matches!(command, BazelCommand::Test | BazelCommand::Coverage);
-    let streams = if (failed && test_like) || (!failed && !stdout.is_empty()) {
-        [stdout, stderr]
-    } else {
-        [stderr, stdout]
-    };
-    let mut positions = BTreeMap::<String, usize>::new();
-    let mut lines = Vec::<(String, u32)>::new();
-    for stream in streams {
-        for line in normalize_terminal_text(stream).lines() {
-            let line = line.trim();
-            if line.is_empty() {
-                continue;
-            }
-            let line = bounded_text(line, 4 * 1024);
-            if let Some(index) = positions.get(&line).copied() {
-                lines[index].1 = lines[index].1.saturating_add(1);
-            } else {
-                positions.insert(line.clone(), lines.len());
-                lines.push((line, 1));
-            }
-        }
-    }
-    let mut actionable = Vec::new();
-    let mut fallback = Vec::new();
-    for (line, count) in lines {
-        let record = EvidenceRecord {
-            label: None,
-            text: if count > 1 {
-                format!("{line} [repeated {count} times]")
-            } else {
-                line
-            },
-        };
-        if is_actionable_evidence(&record.text) {
-            actionable.push(record);
-        } else {
-            fallback.push(record);
-        }
-    }
-    let fallback_start = fallback.len().saturating_sub(2_000);
-    actionable.truncate(1_000);
-    actionable.extend(fallback.into_iter().skip(fallback_start));
-    actionable.truncate(3_000);
-    actionable
-}
-
-fn is_actionable_evidence(line: &str) -> bool {
-    failure_evidence_priority(line).is_some()
-}
-
-fn failure_evidence_priority(line: &str) -> Option<u8> {
-    let line = line.trim();
-    let lower = line.to_ascii_lowercase();
-    let base = lower
-        .split_once(" [repeated ")
-        .map_or(lower.as_str(), |(base, _)| base);
-    if matches!(base, "failure:" | "failures:")
-        || (line.starts_with("test ") && base.ends_with(" ... ok"))
-    {
-        return None;
-    }
-    if lower.contains("root_cause")
-        || lower.contains("panicked at")
-        || (lower.contains("assertion") && lower.contains(" failed"))
-    {
-        Some(0)
-    } else if lower.contains("error:")
-        || lower.starts_with("error ")
-        || lower.contains("fatal:")
-        || lower.contains("no such target")
-        || lower.contains("no such package")
-        || lower.contains("undefined reference")
-        || lower.contains("missing strict dependencies")
-        || (lower.contains(".go: import of \"") && lower.ends_with('"'))
-    {
-        Some(1)
-    } else if lower.contains("failed:")
-        || lower.contains("failure")
-        || lower.starts_with("test result: failed")
-        || (line.starts_with("test ") && line.ends_with(" ... FAILED"))
-    {
-        Some(2)
-    } else {
-        None
-    }
-}
-
-async fn write_private_atomic(path: &Path, bytes: &[u8]) -> Result<(), io::Error> {
-    let temporary = path.with_extension("tmp");
-    let mut file = tokio::fs::File::create(&temporary).await?;
-    file.write_all(bytes).await?;
-    file.flush().await?;
-    drop(file);
-    set_private_file(&temporary).await?;
-    tokio::fs::rename(temporary, path).await
-}
-
-#[cfg(unix)]
-async fn set_private_file(path: &Path) -> Result<(), io::Error> {
-    use std::os::unix::fs::PermissionsExt;
-    tokio::fs::set_permissions(path, std::fs::Permissions::from_mode(0o600)).await
-}
-
-#[cfg(not(unix))]
-async fn set_private_file(_path: &Path) -> Result<(), io::Error> {
-    Ok(())
-}
-
-fn local_artifact_path(artifact: &bazel_mcp_types::Artifact) -> Option<PathBuf> {
-    if !artifact.locally_available {
-        return None;
-    }
-    if let Some(path) = artifact.uri.strip_prefix("file://") {
-        return Some(PathBuf::from(path));
-    }
-    let path = PathBuf::from(&artifact.uri);
-    path.is_absolute().then_some(path)
-}
-
-fn artifact_matches_test(artifact: &bazel_mcp_types::Artifact, label: &str) -> bool {
-    let label = label.rsplit_once("//").map_or(label, |(_, label)| label);
-    let (package, target) = label
-        .split_once(':')
-        .map_or(("", label.trim_start_matches("//")), |(package, target)| {
-            (package.trim_start_matches("//"), target)
-        });
-    let fragment = if package.is_empty() {
-        format!("/testlogs/{target}/")
-    } else {
-        format!("/testlogs/{package}/{target}/")
-    };
-    artifact.uri.replace('\\', "/").contains(&fragment)
-}
-
-#[cfg(unix)]
-async fn probe_bazel_server_pid(
-    executable: &Path,
-    workspace: &Path,
-    startup_arguments: &[String],
-    config: &RunnerConfig,
-    cancellation: CancellationToken,
-) -> io::Result<u32> {
-    let mut command = Command::new(executable);
-    command
-        .current_dir(workspace)
-        .env_clear()
-        .envs(filtered_environment(&config.policy));
-    if let Some(output_user_root) = &config.output_user_root {
-        command
-            .arg(format!("--output_user_root={}", output_user_root.display()))
-            .arg(format!(
-                "--max_idle_secs={}",
-                config.isolated_bazel_server_idle_timeout.as_secs()
-            ));
-    }
-    command
-        .args(startup_arguments)
-        .arg("info")
-        .arg("server_pid")
-        .stdin(std::process::Stdio::null())
-        .stdout(std::process::Stdio::piped())
-        .stderr(std::process::Stdio::null())
-        .kill_on_drop(true);
-
-    let output = tokio::select! {
-        result = tokio::time::timeout(config.version_check_timeout, command.output()) => {
-            result.map_err(|_| io::Error::new(io::ErrorKind::TimedOut, "Bazel server PID probe timed out"))??
-        }
-        () = cancellation.cancelled() => {
-            return Err(io::Error::new(io::ErrorKind::Interrupted, "Bazel server PID probe cancelled"));
-        }
-    };
-    if !output.status.success() {
-        return Err(io::Error::other(format!(
-            "Bazel server PID probe exited with {:?}",
-            output.status.code()
-        )));
-    }
-    let stdout = String::from_utf8(output.stdout).map_err(|_| {
-        io::Error::new(io::ErrorKind::InvalidData, "Bazel server PID was not UTF-8")
-    })?;
-    stdout
-        .lines()
-        .find_map(|line| {
-            let value = line
-                .trim()
-                .strip_prefix("server_pid:")
-                .map_or_else(|| line.trim(), str::trim);
-            value.parse::<u32>().ok()
-        })
-        .filter(|pid| *pid > 0 && *pid <= i32::MAX as u32)
-        .ok_or_else(|| {
-            io::Error::new(
-                io::ErrorKind::InvalidData,
-                "Bazel server PID probe returned no valid PID",
-            )
-        })
-}
-
-fn bazel_test_log_output_base(path: &Path) -> Option<PathBuf> {
-    let components = path.components().collect::<Vec<_>>();
-    let execroot = components
-        .iter()
-        .position(|component| component.as_os_str() == "execroot")?;
-    let bazel_out = components
-        .iter()
-        .enumerate()
-        .skip(execroot + 1)
-        .find(|(_, component)| component.as_os_str() == "bazel-out")?
-        .0;
-    components
-        .iter()
-        .enumerate()
-        .skip(bazel_out + 1)
-        .find(|(_, component)| component.as_os_str() == "testlogs")?;
-    if !matches!(
-        path.extension().and_then(|value| value.to_str()),
-        Some("log" | "xml")
-    ) {
-        return None;
-    }
-    Some(components[..execroot].iter().collect())
-}
-
-fn set_test_log_unavailable(summary: &mut bazel_mcp_types::InvocationSummary, reason: &str) {
-    for test in summary
-        .tests
-        .iter_mut()
-        .filter(|test| test.status != TestStatus::Passed)
-    {
-        test.test_log_available = false;
-        test.test_log_unavailable_reason = Some(reason.to_owned());
-    }
-}
-
-fn custom_reducer_notice(message: String) -> Diagnostic {
-    Diagnostic {
-        severity: Severity::Note,
-        category: DiagnosticCategory::Bazel,
-        message,
-        location: None,
-        target: None,
-        action: None,
-        repetition_count: 1,
-    }
-}
-
-fn finalize_with_custom_notices(
-    summary: &mut bazel_mcp_types::InvocationSummary,
-    notices: Vec<Diagnostic>,
-) {
-    if notices.is_empty() {
-        finalize_diagnostics(summary, Budget::result_default());
-        return;
-    }
-    let mut notice_summary = bazel_mcp_types::InvocationSummary {
-        success: true,
-        diagnostics: notices,
-        ..Default::default()
-    };
-    finalize_diagnostics(
-        &mut notice_summary,
-        Budget {
-            max_bytes: 1024,
-            max_items: 4,
-        },
-    );
-    let notices = notice_summary.diagnostics;
-    let notice_bytes = notices
-        .iter()
-        .map(|notice| notice.message.len())
-        .sum::<usize>();
-    let budget = Budget::result_default();
-    finalize_diagnostics(
-        summary,
-        Budget {
-            max_bytes: budget.max_bytes.saturating_sub(notice_bytes),
-            max_items: budget.max_items.saturating_sub(notices.len()),
-        },
-    );
-    summary.diagnostics.extend(notices);
-    if notice_summary.truncated {
-        summary.truncated = true;
-        summary.inspect_hint = Some("diagnostics".to_owned());
-    }
-}
-
-fn bounded_text(value: &str, maximum_bytes: usize) -> String {
+pub(crate) fn bounded_text(value: &str, maximum_bytes: usize) -> String {
     if value.len() <= maximum_bytes {
         return value.to_owned();
     }
@@ -2970,216 +957,11 @@ fn bounded_text(value: &str, maximum_bytes: usize) -> String {
     format!("{}…", &value[..boundary])
 }
 
-fn invocation_ledger_row(record: &InvocationRecord) -> serde_json::Value {
-    let arguments = record
-        .request
-        .arguments
-        .iter()
-        .take(3)
-        .map(|argument| bounded_text(argument, 128))
-        .collect::<Vec<_>>();
-    let exit_code = match record.termination {
-        Some(Termination::Exit { code }) => Some(code),
-        _ => None,
-    };
-    serde_json::json!({
-        "invocation_id": record.request.id,
-        "workspace": bounded_text(&record.request.workspace.to_string_lossy(), 256),
-        "state": record.state,
-        "command": record.request.command,
-        "arguments": arguments,
-        "arguments_truncated": record.request.arguments.len() > 3,
-        "requested_at_ms": record.request.requested_at_ms,
-        "finished_at_ms": record.finished_at_ms,
-        "exit_code": exit_code,
-        "duration_ms": record.metrics.bazel_wall_ms,
-        "headline": record
-            .summary
-            .as_ref()
-            .map(|summary| bounded_text(&summary.headline, 256)),
-        "targets": record.summary.as_ref().map(|summary| &summary.target_counts),
-        "tests": record.summary.as_ref().map(|summary| &summary.test_counts),
-        "raw_output_bytes": record.metrics.raw_output_bytes,
-        "model_visible_bytes": record.metrics.model_visible_bytes,
-        "inspect_calls": record.metrics.inspect_calls,
-    })
-}
-
-fn enforce_inspect_budget(
-    mut result: InspectResult,
-    requested_bytes: usize,
-) -> Result<InspectResult, RunnerError> {
-    let hard_limit = requested_bytes.min(32 * 1024);
-    if serialized_len(&result)? <= hard_limit {
-        return Ok(result);
-    }
-    result.truncated = true;
-
-    match result.view {
-        InspectView::Summary => {
-            while serialized_len(&result)? > hard_limit {
-                let Some(summary) = result
-                    .items
-                    .as_array_mut()
-                    .and_then(|items| items.first_mut())
-                else {
-                    break;
-                };
-                let Some(diagnostics) = summary
-                    .get_mut("diagnostics")
-                    .and_then(serde_json::Value::as_array_mut)
-                else {
-                    break;
-                };
-                if diagnostics.pop().is_none() {
-                    break;
-                }
-                summary["truncated"] = serde_json::Value::Bool(true);
-            }
-        }
-        InspectView::Tests => {
-            while serialized_len(&result)? > hard_limit {
-                let Some(tests) = result.items.as_array_mut() else {
-                    break;
-                };
-                let Some(cases) = tests.iter_mut().rev().find_map(|test| {
-                    test.get_mut("cases")
-                        .and_then(serde_json::Value::as_array_mut)
-                        .filter(|cases| !cases.is_empty())
-                }) else {
-                    break;
-                };
-                cases.pop();
-            }
-        }
-        _ => {}
-    }
-
-    for string_limit in [1_000, 512, 256, 64, 0] {
-        if serialized_len(&result)? <= hard_limit {
-            return Ok(result);
-        }
-        bound_json_strings(&mut result.items, string_limit);
-    }
-    if serialized_len(&result)? > hard_limit {
-        return Err(RunnerError::ResponseTooLarge(hard_limit));
-    }
-    Ok(result)
-}
-
-fn serialized_len(result: &InspectResult) -> Result<usize, RunnerError> {
-    Ok(serde_json::to_vec(result)?.len())
-}
-
-fn bound_json_strings(value: &mut serde_json::Value, maximum_bytes: usize) {
-    match value {
-        serde_json::Value::String(text) => {
-            if maximum_bytes == 0 {
-                text.clear();
-            } else if text.len() > maximum_bytes {
-                *text = bounded_text(text, maximum_bytes);
-            }
-        }
-        serde_json::Value::Array(items) => {
-            for item in items {
-                bound_json_strings(item, maximum_bytes);
-            }
-        }
-        serde_json::Value::Object(fields) => {
-            for value in fields.values_mut() {
-                bound_json_strings(value, maximum_bytes);
-            }
-        }
-        serde_json::Value::Null | serde_json::Value::Bool(_) | serde_json::Value::Number(_) => {}
-    }
-}
-
 fn is_flag(argument: &str, flag: &str) -> bool {
     argument == flag
         || argument
             .strip_prefix(flag)
             .is_some_and(|suffix| suffix.starts_with('='))
-}
-
-fn finish_from_status(status: ExitStatus) -> (Option<ExitStatus>, Termination, InvocationState) {
-    let state = if status.success() {
-        InvocationState::Succeeded
-    } else {
-        InvocationState::Failed
-    };
-    if let Some(code) = status.code() {
-        (Some(status), Termination::Exit { code }, state)
-    } else {
-        #[cfg(unix)]
-        {
-            use std::os::unix::process::ExitStatusExt;
-            let signal = status.signal().unwrap_or_default();
-            (Some(status), Termination::Signal { signal }, state)
-        }
-        #[cfg(not(unix))]
-        {
-            (Some(status), Termination::Exit { code: -1 }, state)
-        }
-    }
-}
-
-fn duration_millis(duration: Duration) -> u64 {
-    u64::try_from(duration.as_millis()).unwrap_or(u64::MAX)
-}
-
-fn cancelled_summary() -> bazel_mcp_types::InvocationSummary {
-    bazel_mcp_types::InvocationSummary {
-        success: false,
-        headline: "Bazel invocation was cancelled before starting".to_owned(),
-        ..Default::default()
-    }
-}
-
-fn fallback_summary(
-    exit_code: Option<i32>,
-    elapsed_ms: u64,
-    stderr: &[u8],
-    stdout: &[u8],
-) -> bazel_mcp_types::InvocationSummary {
-    let success = exit_code == Some(0);
-    let text = if stderr.is_empty() { stdout } else { stderr };
-    let message = normalize_terminal_text(text)
-        .lines()
-        .rev()
-        .find(|line| !line.trim().is_empty())
-        .map(|line| bounded_text(line, 1_000));
-    let diagnostics = if success {
-        Vec::new()
-    } else {
-        message
-            .as_ref()
-            .map(|message| Diagnostic {
-                severity: Severity::Error,
-                category: DiagnosticCategory::Unknown,
-                message: message.clone(),
-                location: None,
-                target: None,
-                action: None,
-                repetition_count: 1,
-            })
-            .into_iter()
-            .collect()
-    };
-    bazel_mcp_types::InvocationSummary {
-        success,
-        headline: if success {
-            format!("Bazel completed successfully in {elapsed_ms} ms")
-        } else if let Some(message) = message {
-            format!("Bazel failed: {message}")
-        } else {
-            format!("Bazel failed with exit code {exit_code:?}")
-        },
-        diagnostics,
-        elapsed_ms,
-        truncated: true,
-        inspect_hint: Some("log".to_owned()),
-        ..Default::default()
-    }
 }
 
 #[cfg(test)]
@@ -3203,24 +985,6 @@ mod tests {
             &BazelCommand::Version,
             false
         ));
-    }
-
-    #[tokio::test]
-    async fn workspace_lock_registry_discards_inactive_output_bases() {
-        let root = tempdir().unwrap();
-        let store = Store::open(root.path()).await.unwrap();
-        let service = InvocationService::new(store, RunnerConfig::default()).unwrap();
-
-        for index in 0..100 {
-            let lock = service
-                .workspace_lock(Path::new(&format!("/tmp/output-base-{index}")))
-                .await;
-            drop(lock);
-        }
-        let retained = service.workspace_lock(Path::new("/tmp/retained")).await;
-
-        assert_eq!(service.workspace_locks.lock().await.len(), 1);
-        assert!(Arc::strong_count(&retained) >= 1);
     }
 
     #[tokio::test]

--- a/crates/bazel-mcp-runner/src/test_evidence.rs
+++ b/crates/bazel-mcp-runner/src/test_evidence.rs
@@ -1,0 +1,291 @@
+//! Failed-test artifact acquisition and durable snapshot orchestration.
+
+use std::path::Path;
+
+use bazel_mcp_reducer::{
+    TestEvidenceInput, TestEvidenceReducer, normalize_terminal_text, parse_test_xml,
+};
+use bazel_mcp_store::InvocationPaths;
+use bazel_mcp_types::{ArtifactKind, DiagnosticCategory, TestStatus};
+use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+
+use crate::{
+    evidence::set_private_file,
+    inspection::EvidenceRecord,
+    service::{InvocationService, bounded_text},
+};
+
+impl InvocationService {
+    pub(crate) async fn enrich_tests(
+        &self,
+        paths: &InvocationPaths,
+        workspace: &Path,
+        summary: &mut bazel_mcp_types::InvocationSummary,
+        artifacts: &[bazel_mcp_types::Artifact],
+    ) {
+        if !summary
+            .tests
+            .iter()
+            .any(|test| test.status != TestStatus::Passed)
+        {
+            return;
+        }
+
+        let raw_temporary = paths.test_logs_raw.with_extension("tmp");
+        let evidence_temporary = paths.test_log_evidence.with_extension("tmp");
+        if tokio::fs::try_exists(&paths.test_logs_raw)
+            .await
+            .unwrap_or(false)
+            || tokio::fs::try_exists(&paths.test_log_evidence)
+                .await
+                .unwrap_or(false)
+        {
+            for test in summary
+                .tests
+                .iter_mut()
+                .filter(|test| test.status != TestStatus::Passed)
+            {
+                test.test_log_available = false;
+                test.test_log_unavailable_reason =
+                    Some("test_log_snapshot_already_exists".to_owned());
+            }
+            return;
+        }
+
+        let raw = tokio::fs::OpenOptions::new()
+            .create_new(true)
+            .write(true)
+            .open(&raw_temporary)
+            .await;
+        let evidence = tokio::fs::OpenOptions::new()
+            .create_new(true)
+            .write(true)
+            .open(&evidence_temporary)
+            .await;
+        let (Ok(mut raw), Ok(mut evidence)) = (raw, evidence) else {
+            let _ = tokio::fs::remove_file(&raw_temporary).await;
+            let _ = tokio::fs::remove_file(&evidence_temporary).await;
+            set_test_log_unavailable(summary, "test_log_snapshot_failed");
+            return;
+        };
+
+        let workspace_text = workspace.to_string_lossy();
+        let any_remote_test_log = artifacts.iter().any(|artifact| {
+            artifact.kind == ArtifactKind::TestLog
+                && artifact.name.ends_with("test.log")
+                && !artifact.locally_available
+        });
+        let mut diagnostics = Vec::new();
+        let mut copied_any = false;
+        for test in summary
+            .tests
+            .iter_mut()
+            .filter(|test| test.status != TestStatus::Passed)
+        {
+            if let Some(xml) = artifacts.iter().find(|artifact| {
+                artifact.kind == ArtifactKind::TestLog
+                    && artifact.name.ends_with("test.xml")
+                    && artifact_matches_test(artifact, &test.label)
+            }) && let Some(path) = self.validated_artifact_path(workspace, xml).await
+            {
+                let small_enough = tokio::fs::metadata(&path)
+                    .await
+                    .is_ok_and(|metadata| metadata.len() <= 16 * 1024 * 1024);
+                if small_enough
+                    && let Ok(contents) = tokio::fs::read_to_string(path).await
+                    && let Ok(cases) = parse_test_xml(&contents)
+                {
+                    test.cases = cases
+                        .into_iter()
+                        .filter(|case| case.status != TestStatus::Passed)
+                        .take(20)
+                        .map(|mut case| {
+                            case.name = bounded_text(&case.name, 512);
+                            case.message =
+                                case.message.map(|message| bounded_text(&message, 1_000));
+                            case
+                        })
+                        .collect();
+                }
+            }
+
+            let matching_logs = artifacts.iter().filter(|artifact| {
+                artifact.kind == ArtifactKind::TestLog
+                    && artifact.name.ends_with("test.log")
+                    && artifact_matches_test(artifact, &test.label)
+            });
+            let mut saw_artifact = false;
+            let mut copied_for_test = false;
+            let mut saw_remote = false;
+            let mut reducer = TestEvidenceReducer::new(TestEvidenceInput { label: &test.label });
+            for log in matching_logs {
+                saw_artifact = true;
+                if !log.locally_available {
+                    saw_remote = true;
+                    continue;
+                }
+                let Some(path) = self.validated_artifact_path(workspace, log).await else {
+                    continue;
+                };
+                let Ok(file) = tokio::fs::File::open(&path).await else {
+                    continue;
+                };
+                let marker = format!("\n===== {} :: {} =====\n", test.label, log.name);
+                if raw.write_all(marker.as_bytes()).await.is_err() {
+                    continue;
+                }
+                let mut reader = BufReader::new(file);
+                let mut line = Vec::new();
+                let mut complete = true;
+                loop {
+                    line.clear();
+                    let read = match reader.read_until(b'\n', &mut line).await {
+                        Ok(read) => read,
+                        Err(_) => {
+                            complete = false;
+                            break;
+                        }
+                    };
+                    if read == 0 {
+                        break;
+                    }
+                    if raw.write_all(&line).await.is_err() {
+                        complete = false;
+                        break;
+                    }
+                    for visible_line in normalize_terminal_text(&line).lines() {
+                        let visible_line = visible_line.trim();
+                        if visible_line.is_empty() {
+                            continue;
+                        }
+                        let text = self.redactor.redact_bounded(
+                            &visible_line.replace(workspace_text.as_ref(), "<workspace>"),
+                            4 * 1024,
+                        );
+                        reducer.observe_line(&text);
+                        let record = EvidenceRecord {
+                            label: Some(test.label.clone()),
+                            text: format!("[{}] {text}", test.label),
+                        };
+                        let Ok(mut encoded) = serde_json::to_vec(&record) else {
+                            complete = false;
+                            break;
+                        };
+                        encoded.push(b'\n');
+                        if evidence.write_all(&encoded).await.is_err() {
+                            complete = false;
+                            break;
+                        }
+                    }
+                    if !complete {
+                        break;
+                    }
+                }
+                reducer.finish_log(complete);
+                if complete {
+                    copied_for_test = true;
+                    copied_any = true;
+                }
+            }
+            if copied_for_test {
+                test.test_log_available = true;
+                test.test_log_unavailable_reason = None;
+                let reduced = reducer.finish();
+                if reduced.cases.is_empty() {
+                    diagnostics.extend(reduced.diagnostics);
+                } else {
+                    let previous_cases = std::mem::take(&mut test.cases);
+                    let mut cases = reduced.cases;
+                    for case in previous_cases {
+                        if cases.len() >= 20 {
+                            break;
+                        }
+                        if !cases.iter().any(|current| {
+                            current.name == case.name && current.message == case.message
+                        }) {
+                            cases.push(case);
+                        }
+                    }
+                    test.cases = cases;
+                    diagnostics.extend(reduced.diagnostics);
+                }
+            } else {
+                test.test_log_available = false;
+                test.test_log_unavailable_reason = Some(
+                    if saw_remote || (!saw_artifact && any_remote_test_log) {
+                        "remote_test_log_unavailable"
+                    } else if saw_artifact {
+                        "test_log_outside_allowed_roots_or_unreadable"
+                    } else {
+                        "test_log_not_found"
+                    }
+                    .to_owned(),
+                );
+            }
+        }
+
+        let flushed = raw.flush().await.is_ok() && evidence.flush().await.is_ok();
+        drop(raw);
+        drop(evidence);
+        let committed = if copied_any {
+            flushed
+                && set_private_file(&raw_temporary).await.is_ok()
+                && set_private_file(&evidence_temporary).await.is_ok()
+                && tokio::fs::rename(&raw_temporary, &paths.test_logs_raw)
+                    .await
+                    .is_ok()
+                && tokio::fs::rename(&evidence_temporary, &paths.test_log_evidence)
+                    .await
+                    .is_ok()
+        } else {
+            false
+        };
+        if committed {
+            for diagnostic in &diagnostics {
+                summary.diagnostics.retain(|existing| {
+                    !((existing.category == DiagnosticCategory::Compilation
+                        || (existing.category == diagnostic.category && existing.target.is_none()))
+                        && existing.message == diagnostic.message
+                        && (existing.location == diagnostic.location
+                            || existing.location.is_none()))
+                });
+            }
+            summary.diagnostics.extend(diagnostics);
+        } else {
+            let _ = tokio::fs::remove_file(&raw_temporary).await;
+            let _ = tokio::fs::remove_file(&evidence_temporary).await;
+            if copied_any {
+                set_test_log_unavailable(summary, "test_log_snapshot_failed");
+            }
+        }
+    }
+}
+
+pub(crate) fn artifact_matches_test(artifact: &bazel_mcp_types::Artifact, label: &str) -> bool {
+    let label = label.rsplit_once("//").map_or(label, |(_, label)| label);
+    let (package, target) = label
+        .split_once(':')
+        .map_or(("", label.trim_start_matches("//")), |(package, target)| {
+            (package.trim_start_matches("//"), target)
+        });
+    let fragment = if package.is_empty() {
+        format!("/testlogs/{target}/")
+    } else {
+        format!("/testlogs/{package}/{target}/")
+    };
+    artifact.uri.replace('\\', "/").contains(&fragment)
+}
+
+pub(crate) fn set_test_log_unavailable(
+    summary: &mut bazel_mcp_types::InvocationSummary,
+    reason: &str,
+) {
+    for test in summary
+        .tests
+        .iter_mut()
+        .filter(|test| test.status != TestStatus::Passed)
+    {
+        test.test_log_available = false;
+        test.test_log_unavailable_reason = Some(reason.to_owned());
+    }
+}

--- a/crates/bazel-mcp-runner/tests/process.rs
+++ b/crates/bazel-mcp-runner/tests/process.rs
@@ -84,7 +84,7 @@ async fn wait_for_path(path: &Path) {
 
 async fn wait_for_invocation(service: &InvocationService, id: bazel_mcp_types::InvocationId) {
     for _ in 0..500 {
-        if service.store().get_invocation(id).await.is_ok() {
+        if service.test_support().get_invocation(id).await.is_ok() {
             return;
         }
         tokio::time::sleep(Duration::from_millis(10)).await;
@@ -407,7 +407,7 @@ async fn redacts_secrets_from_metadata_normalized_rows_and_log_inspection() {
     assert!(secret_filter.items.as_array().unwrap().is_empty());
 
     service
-        .store()
+        .test_support()
         .replace_artifacts(
             id,
             &[Artifact {
@@ -470,7 +470,7 @@ async fn preserves_raw_bep_before_redacting_every_persisted_and_visible_projecti
     assert_eq!(record.state, InvocationState::Failed);
     assert!(!serde_json::to_string(&record).unwrap().contains(secret));
 
-    let paths = service.store().paths_for(&record);
+    let paths = service.test_support().paths_for(&record);
     let retained = std::fs::read(&paths.bep).unwrap();
     assert_eq!(retained, raw_bep);
     assert!(
@@ -786,7 +786,7 @@ async fn failed_test_logs_are_snapshotted_and_retrieved_without_a_public_uri() {
             .any(|item| item.as_str().unwrap().contains("got 1, want 2"))
     );
 
-    let failed_paths = service.store().paths_for(&failed);
+    let failed_paths = service.test_support().paths_for(&failed);
     let retained_before = tokio::fs::read(&failed_paths.test_logs_raw).await.unwrap();
     assert!(String::from_utf8_lossy(&retained_before).contains("got 1, want 2"));
     tokio::fs::remove_file(&flag_marker).await.unwrap();
@@ -1315,7 +1315,13 @@ async fn deferred_submission_commits_before_completion_and_survives_wait_cancell
             .await
             .is_err()
     );
-    assert!(service.store().get_invocation(rejected_id).await.is_err());
+    assert!(
+        service
+            .test_support()
+            .get_invocation(rejected_id)
+            .await
+            .is_err()
+    );
 }
 
 #[tokio::test]
@@ -2027,7 +2033,7 @@ async fn fifo_transport_spools_private_evidence_and_cleans_up_the_pipe() {
         .await
         .unwrap();
     assert_eq!(record.state, InvocationState::Succeeded);
-    let paths = service.store().paths_for(&record);
+    let paths = service.test_support().paths_for(&record);
     assert_eq!(
         std::fs::read(&paths.bep).unwrap(),
         std::fs::read(fixture).unwrap()
@@ -2061,7 +2067,7 @@ async fn fifo_transport_falls_back_to_file_tail_when_pid_probe_fails() {
         .unwrap();
     assert_eq!(record.state, InvocationState::Succeeded);
     assert_eq!(
-        std::fs::read(service.store().paths_for(&record).bep).unwrap(),
+        std::fs::read(service.test_support().paths_for(&record).bep).unwrap(),
         std::fs::read(fixture).unwrap()
     );
 }
@@ -2174,17 +2180,17 @@ async fn inspect_shrinks_nested_results_to_the_hard_byte_budget() {
     let request = InvocationRequest::new(workspace, BazelCommand::Test, vec!["//...".into()]);
     let id = request.id;
     service
-        .store()
+        .test_support()
         .create_invocation(&InvocationRecord::queued(request))
         .await
         .unwrap();
     service
-        .store()
+        .test_support()
         .transition(id, InvocationState::Starting, None, None)
         .await
         .unwrap();
     service
-        .store()
+        .test_support()
         .transition(id, InvocationState::Running, None, None)
         .await
         .unwrap();
@@ -2222,7 +2228,7 @@ async fn inspect_shrinks_nested_results_to_the_hard_byte_budget() {
         ..InvocationSummary::default()
     };
     service
-        .store()
+        .test_support()
         .transition(
             id,
             InvocationState::Failed,
@@ -2314,7 +2320,7 @@ async fn evidence_file_failures_become_terminal_instead_of_stranding_starting_ro
     });
     loop {
         if service
-            .store()
+            .test_support()
             .get_invocation(blocker_id)
             .await
             .is_ok_and(|record| record.state == InvocationState::Running)
@@ -2332,8 +2338,8 @@ async fn evidence_file_failures_become_terminal_instead_of_stranding_starting_ro
         async move { service.run(request).await }
     });
     let paths = loop {
-        if let Ok(record) = service.store().get_invocation(id).await {
-            break service.store().paths_for(&record);
+        if let Ok(record) = service.test_support().get_invocation(id).await {
+            break service.test_support().paths_for(&record);
         }
         tokio::time::sleep(Duration::from_millis(10)).await;
     };


### PR DESCRIPTION
## Summary

- keep `InvocationService` as the public lifecycle facade while extracting scheduling, process execution, inspection, artifact containment, evidence persistence, and failed-test acquisition into focused runner modules
- move language/framework-specific failed-test interpretation behind reducer-owned `TestEvidenceInput`, `TestEvidenceReducer`, and `TestEvidenceResult` types
- replace the public raw `Store` accessor with a narrow, hidden `RunnerTestSupport` surface for process-level integration tests
- preserve cross-process output-base locking, wait metrics, cancellation, deferred execution, and progress behavior from `main`

## Why

The runner service had accumulated scheduling, process management, inspection shaping, artifact handling, and cross-language test reduction in one module. That made ownership unclear and coupled the runner directly to language parser state. This restores explicit boundaries while preserving the existing invocation facade, raw-before-redaction ordering, durable evidence behavior, and model-visible budgets.

## Impact

This is behavior-preserving. The MCP tool surface, invocation lifecycle, storage format, reducer ordering, redaction, and response budgets are unchanged. `service.rs` falls from 3,393 lines at the rebased base to 1,157 total lines, with about 970 production lines; extracted responsibilities now have named module boundaries.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo shear`
- `cargo test --workspace --all-features` (all suites pass, including all 34 runner process tests)
- `git diff --check`
- Bazel MCP: `build //:bazel-mcp` and reducer golden tests pass
- exact base commit `b3e27d3` Criterion baselines and identical branch comparisons for `reduction` and `custom_reducers`: all six general reduction samples are within noise; an order-balanced 1,000-event rerun measured native at +1.9% and Starlark at +0.7% (within noise)
- complete GitHub CI is green: Linux/macOS tests, Windows check and release smoke, Bazel build and version matrix, reducer replay on all three platforms, lint, fuzz, audit/deny, Nix, MCP conformance, and compatibility suites

The Linux Cargo job initially hit the existing `bazel-mcp-store::two_os_processes_share_one_cache_root` concurrency flake; its isolated rerun passed. The branch does not modify the store.

## Local environment notes

- `make check` could not enter its Nix wrapper because `nix` is unavailable on this host; its direct constituent commands pass and CI `nix-flake-check` is green.
- Default local Bazel test invocations without `--config=ci` expose existing fixture/runfiles gaps for SWC, `test-outcomes.bep`, and two FIFO cases. The official `bazel-build` job passes `bazelisk test --config=ci //crates/...`.