### PR TITLE
ci: enforce Cargo and Bazel test parity

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,7 @@ jobs:
             bazel-cache-${{ runner.os }}-${{ runner.arch }}-${{ github.job }}-
       - run: go install github.com/bazelbuild/bazelisk@v1.26.0
       - run: PATH="$HOME/go/bin:$PATH" bazelisk test --config=ci //tools:preset.update_test
+      - run: PATH="$HOME/go/bin:$PATH" bazelisk test --config=ci //crates/...
       - run: PATH="$HOME/go/bin:$PATH" make build BAZEL_BUILD_FLAGS=--config=ci
   cargo-test-linux:
     runs-on: ubuntu-latest

--- a/crates/bazel-mcp-reducer/BUILD.bazel
+++ b/crates/bazel-mcp-reducer/BUILD.bazel
@@ -16,9 +16,21 @@ rust_library(
     visibility = ["//visibility:public"],
 )
 
+filegroup(
+    name = "capture_fixture",
+    srcs = ["tests/fixtures/bazel-9/test-outcomes.bep"],
+    visibility = ["//visibility:public"],
+)
+
+filegroup(
+    name = "swc_fixtures",
+    srcs = glob(["tests/fixtures/swc/**"]),
+)
+
 rust_test(
     name = "unit_test",
     crate = ":bazel_mcp_reducer",
+    compile_data = [":swc_fixtures"],
     size = "small",
     deps = all_crate_deps(
         cargo_only = True,

--- a/crates/bazel-mcp-runner/BUILD.bazel
+++ b/crates/bazel-mcp-runner/BUILD.bazel
@@ -23,6 +23,9 @@ rust_library(
 rust_test(
     name = "unit_test",
     crate = ":bazel_mcp_runner",
+    compile_data = [
+        "//crates/bazel-mcp-reducer:capture_fixture",
+    ],
     size = "small",
     deps = all_crate_deps(
         cargo_only = True,
@@ -33,6 +36,7 @@ rust_test(
 rust_test(
     name = "process_test",
     srcs = ["tests/process.rs"],
+    compile_data = ["//crates/bazel-mcp-reducer:capture_fixture"],
     size = "small",
     deps = [
         ":bazel_mcp_runner",

--- a/crates/bazel-mcp-runner/tests/process.rs
+++ b/crates/bazel-mcp-runner/tests/process.rs
@@ -25,6 +25,9 @@ use bazel_mcp_types::{
 use tempfile::TempDir;
 use tokio_util::sync::CancellationToken;
 
+const TEST_OUTCOMES_BEP: &[u8] =
+    include_bytes!("../../bazel-mcp-reducer/tests/fixtures/bazel-9/test-outcomes.bep");
+
 fn failed_test_bep(log_uri: &str, xml_uri: &str) -> Vec<u8> {
     let output = |name: &str, uri: &str| File {
         name: name.to_owned(),
@@ -2006,8 +2009,8 @@ async fn fifo_transport_spools_private_evidence_and_cleans_up_the_pipe() {
     let root = tempfile::tempdir().unwrap();
     let workspace = root.path().join("workspace");
     tokio::fs::create_dir(&workspace).await.unwrap();
-    let fixture = Path::new(env!("CARGO_MANIFEST_DIR"))
-        .join("../bazel-mcp-reducer/tests/fixtures/bazel-9/test-outcomes.bep");
+    let fixture = root.path().join("test-outcomes.bep");
+    std::fs::write(&fixture, TEST_OUTCOMES_BEP).unwrap();
     let script = format!(
         "#!/bin/sh\nif [ \"${{1:-}}\" = --version ]; then echo 'bazel 9.1.0'; exit 0; fi\nfor arg in \"$@\"; do [ \"$arg\" = info ] && is_info=1; done\nif [ \"${{is_info:-0}}\" = 1 ]; then echo '{}'; exit 0; fi\nfor arg in \"$@\"; do case \"$arg\" in --build_event_binary_file=*) bep_path=${{arg#*=}} ;; esac; done\ncp '{}' \"$bep_path\"\n",
         std::process::id(),
@@ -2040,8 +2043,8 @@ async fn fifo_transport_falls_back_to_file_tail_when_pid_probe_fails() {
     let root = tempfile::tempdir().unwrap();
     let workspace = root.path().join("workspace");
     tokio::fs::create_dir(&workspace).await.unwrap();
-    let fixture = Path::new(env!("CARGO_MANIFEST_DIR"))
-        .join("../bazel-mcp-reducer/tests/fixtures/bazel-9/test-outcomes.bep");
+    let fixture = root.path().join("test-outcomes.bep");
+    std::fs::write(&fixture, TEST_OUTCOMES_BEP).unwrap();
     let script = format!(
         "#!/bin/sh\nif [ \"${{1:-}}\" = --version ]; then echo 'bazel 9.1.0'; exit 0; fi\nfor arg in \"$@\"; do [ \"$arg\" = info ] && exit 1; done\nfor arg in \"$@\"; do case \"$arg\" in --build_event_binary_file=*) bep_path=${{arg#*=}} ;; esac; done\n[ -f \"$bep_path\" ] || exit 42\ncp '{}' \"$bep_path\"\n",
         fixture.display(),

--- a/examples/README.md
+++ b/examples/README.md
@@ -9,6 +9,23 @@ Each workspace pins its own Bzlmod dependencies. Successful targets demonstrate
 normal use; targets tagged `manual` and `reducer-fixture` intentionally fail and
 are invoked explicitly by the `reducer-cases` harness through `bazel.run`.
 
+Do not include the intentionally failing packages in a wildcard `//...` test:
+
+- `bazel-core`: `//cases` and `//consumer`
+- `cpp`: `//cases`
+- `go`: `//cases`
+- `jvm`: `//cases`
+- `node`: `//cases`
+- `protobuf`: `//cases`
+- `python`: `//cases`
+- `rust`: `//cases`
+- `starlark`: `//cases/analysis`, `//cases/loading`, `//cases/macro`, and
+  `//cases/syntax`
+
+These packages are expected to fail. The repository CI test target is
+`//crates/...`, which covers the intended Rust tests without traversing these
+standalone reducer workspaces.
+
 ```bash
 cargo build -p bazel-mcp-server --bin bazel-mcp
 cargo run -p bazel-mcp-reducer-cases -- list


### PR DESCRIPTION
## Summary

- Run the intended Rust Bazel tests in CI alongside Cargo validation.
- Declare shared reducer fixtures for Bazel compile actions.
- Make runner FIFO fixture tests independent of Cargo or Bazel runtime paths.
- Document intentionally failing example packages that must be excluded from `//...`.

## Why

CI previously built the Bazel binary but did not test the Rust targets. Fixture-dependent tests also failed under Bazel because their `include_bytes!` inputs were not declared for the test targets.

## Validation

- `cargo fmt --all -- --check`
- `cargo test --workspace --all-features`
- `cargo test --workspace --doc`
- `cargo test -p bazel-mcp-reducer --lib` (62 passed)
- MCP-backed Bazel: `test --config=ci //crates/...` (32/32 targets, 14/14 tests passed)
