### PR TITLE
perf(bep): borrow frames during streaming reduction

### DIFF
--- a/LEARNINGS.md
+++ b/LEARNINGS.md
@@ -154,6 +154,13 @@ unrelated to MCP efficiency. Do not include secrets or raw sensitive output.
   output bytes without materializing JSON, decode the typed patch in place,
   and extend the nested-schema contract test when reducer context fields
   evolve. Thread: `019f6db7-4010-7191-8796-1c83ff2a7f42`.
+- Streaming a 3.8 MB BEP fixture copied 3,793,500 payload bytes into retained
+  frame allocations even though `BepAccumulator` immediately reduced each
+  event to bounded owned fields; current-main DHAT measured 5.19 MB in 23,455
+  allocations for the complete decode. Expose a lifetime-bounded borrowed
+  frame visitor, keep raw-byte durability ahead of reduction, and retain the
+  owned decoder only for callers that intentionally keep events. Thread:
+  `019f6db7-4010-7191-8796-1c83ff2a7f42`.
 - Recorded BEP strings used fixed-length uppercase workspace markers while
   service locations used lowercase markers, complicating live/replay parity and
   leaking padding into visible messages; normalize both marker forms before

--- a/crates/bazel-mcp-benchmark/src/bin/storage-benchmark.rs
+++ b/crates/bazel-mcp-benchmark/src/bin/storage-benchmark.rs
@@ -12,7 +12,7 @@ use std::{
 use anyhow::Context;
 use bazel_mcp_bep::{
     DEFAULT_MAX_FRAME_BYTES, DEFAULT_MAX_STREAM_BYTES, DEFAULT_MAX_STREAM_EVENTS,
-    IncrementalStreamDecoder, visit_stream_partial_bounded,
+    IncrementalStreamDecoder, visit_stream_partial_borrowed_bounded,
 };
 use bazel_mcp_reducer::BepAccumulator;
 use bazel_mcp_store::{InvocationCompletion, Store};
@@ -459,7 +459,7 @@ fn tail_complete_bep_frames(
         if read > 0 {
             hasher.update(&buffer[..read]);
             tailed_bytes = tailed_bytes.saturating_add(read as u64);
-            decoder.push(&buffer[..read], |event| accumulator.observe(event));
+            decoder.push_borrowed(&buffer[..read], |event| accumulator.observe_borrowed(event));
             observed_bytes.store(tailed_bytes, Ordering::Release);
             continue;
         }
@@ -503,12 +503,12 @@ fn hash_bep_file(path: PathBuf) -> anyhow::Result<(u64, [u8; 32])> {
 fn decode_bep(bytes: &[u8]) -> anyhow::Result<(usize, f64)> {
     let mut accumulator = BepAccumulator::default();
     let started = Instant::now();
-    let outcome = visit_stream_partial_bounded(
+    let outcome = visit_stream_partial_borrowed_bounded(
         std::io::Cursor::new(bytes),
         DEFAULT_MAX_FRAME_BYTES,
         DEFAULT_MAX_STREAM_BYTES,
         DEFAULT_MAX_STREAM_EVENTS,
-        |event| accumulator.observe(event),
+        |event| accumulator.observe_borrowed(event),
     );
     let elapsed_ms = millis(started.elapsed());
     anyhow::ensure!(

--- a/crates/bazel-mcp-bep/src/framing.rs
+++ b/crates/bazel-mcp-bep/src/framing.rs
@@ -69,6 +69,36 @@ impl BepEvent {
     }
 }
 
+/// A decoded BEP event that borrows its protobuf frame.
+///
+/// Borrowed events are valid only for the duration of the visitor call that
+/// receives them. Consumers that retain an event beyond that call should use
+/// [`BepEvent`] instead.
+#[derive(Clone, Debug)]
+pub struct BorrowedBepEvent<'a> {
+    inner: BuildEventView<'a>,
+    frame: &'a [u8],
+}
+
+impl<'a> BorrowedBepEvent<'a> {
+    fn decode(frame: &'a [u8]) -> Result<Self, buffa::DecodeError> {
+        Ok(Self {
+            inner: BuildEventView::decode_view(frame)?,
+            frame,
+        })
+    }
+
+    #[must_use]
+    pub fn view(&self) -> &BuildEventView<'_> {
+        &self.inner
+    }
+
+    #[must_use]
+    pub fn frame_bytes(&self) -> &'a [u8] {
+        self.frame
+    }
+}
+
 #[derive(Debug)]
 pub struct PartialStream {
     pub events: Vec<BepEvent>,
@@ -145,9 +175,44 @@ impl IncrementalStreamDecoder {
     /// [`IncrementalStreamControl::ResetAfterFrame`] resets stream byte/event
     /// accounting after that frame, which lets retry-aware transports retain
     /// only the next attempt even when two writers' bytes arrive in one read.
-    pub fn push_framed<F>(&mut self, mut input: &[u8], mut visitor: F)
+    pub fn push_framed<F>(&mut self, input: &[u8], mut visitor: F)
     where
         F: FnMut(BepEvent, &[u8]) -> IncrementalStreamControl,
+    {
+        self.push_frames(input, |decoder, frame, framed| {
+            decoder.decode_owned_frame(frame, framed, &mut visitor);
+        });
+    }
+
+    /// Consume a stream chunk and visit every complete event as a borrowed
+    /// view into the caller's chunk or the decoder's one pending frame.
+    ///
+    /// The higher-ranked visitor prevents the borrowed event from escaping the
+    /// callback, so the decoder can safely reuse its input storage afterward.
+    pub fn push_borrowed<F>(&mut self, input: &[u8], mut visitor: F)
+    where
+        F: for<'frame> FnMut(BorrowedBepEvent<'frame>),
+    {
+        self.push_framed_borrowed(input, |event, _frame| {
+            visitor(event);
+            IncrementalStreamControl::Continue
+        });
+    }
+
+    /// Consume a stream chunk while exposing a borrowed event and its exact
+    /// original length-delimited frame.
+    pub fn push_framed_borrowed<F>(&mut self, input: &[u8], mut visitor: F)
+    where
+        F: for<'frame> FnMut(BorrowedBepEvent<'frame>, &'frame [u8]) -> IncrementalStreamControl,
+    {
+        self.push_frames(input, |decoder, frame, framed| {
+            decoder.decode_borrowed_frame(frame, framed, &mut visitor);
+        });
+    }
+
+    fn push_frames<F>(&mut self, mut input: &[u8], mut decode: F)
+    where
+        F: for<'frame> FnMut(&mut Self, &'frame [u8], &'frame [u8]),
     {
         if self.terminal_error.is_some() {
             return;
@@ -161,11 +226,7 @@ impl IncrementalStreamDecoder {
                         frame_bytes,
                     }) => {
                         let consumed = prefix_bytes.saturating_add(frame_bytes);
-                        self.decode_frame(
-                            &input[prefix_bytes..consumed],
-                            &input[..consumed],
-                            &mut visitor,
-                        );
+                        decode(self, &input[prefix_bytes..consumed], &input[..consumed]);
                         if self.terminal_error.is_some() {
                             return;
                         }
@@ -209,11 +270,7 @@ impl IncrementalStreamDecoder {
                 }) => {
                     let consumed = prefix_bytes.saturating_add(frame_bytes);
                     let framed = std::mem::take(&mut self.pending);
-                    self.decode_frame(
-                        &framed[prefix_bytes..consumed],
-                        &framed[..consumed],
-                        &mut visitor,
-                    );
+                    decode(self, &framed[prefix_bytes..consumed], &framed[..consumed]);
                     if self.terminal_error.is_some() {
                         return;
                     }
@@ -236,11 +293,7 @@ impl IncrementalStreamDecoder {
                 }) => {
                     let consumed = prefix_bytes.saturating_add(frame_bytes);
                     let framed = std::mem::take(&mut self.pending);
-                    self.decode_frame(
-                        &framed[prefix_bytes..consumed],
-                        &framed[..consumed],
-                        &mut visitor,
-                    );
+                    decode(self, &framed[prefix_bytes..consumed], &framed[..consumed]);
                 }
                 Ok(FrameState::NeedPrefix | FrameState::NeedPayload { .. }) => {}
                 Err(error) => self.terminal_error = Some(error),
@@ -266,11 +319,35 @@ impl IncrementalStreamDecoder {
         }
     }
 
-    fn decode_frame<F>(&mut self, frame: &[u8], framed: &[u8], visitor: &mut F)
+    fn decode_owned_frame<F>(&mut self, frame: &[u8], framed: &[u8], visitor: &mut F)
     where
         F: FnMut(BepEvent, &[u8]) -> IncrementalStreamControl,
     {
-        let next_bytes = self.decoded_bytes.saturating_add(frame.len());
+        self.visit_decoded_frame(frame.len(), || {
+            let event = BepEvent::decode_slice(frame)?;
+            Ok(visitor(event, framed))
+        });
+    }
+
+    fn decode_borrowed_frame<'frame, F>(
+        &mut self,
+        frame: &'frame [u8],
+        framed: &'frame [u8],
+        visitor: &mut F,
+    ) where
+        F: for<'a> FnMut(BorrowedBepEvent<'a>, &'a [u8]) -> IncrementalStreamControl,
+    {
+        self.visit_decoded_frame(frame.len(), || {
+            let event = BorrowedBepEvent::decode(frame)?;
+            Ok(visitor(event, framed))
+        });
+    }
+
+    fn visit_decoded_frame<F>(&mut self, frame_bytes: usize, decode: F)
+    where
+        F: FnOnce() -> Result<IncrementalStreamControl, buffa::DecodeError>,
+    {
+        let next_bytes = self.decoded_bytes.saturating_add(frame_bytes);
         if next_bytes > self.max_stream_bytes {
             self.terminal_error = Some(FrameError::StreamTooLarge {
                 actual: next_bytes,
@@ -286,8 +363,8 @@ impl IncrementalStreamDecoder {
             return;
         }
         self.decoded_bytes = next_bytes;
-        match BepEvent::decode_slice(frame) {
-            Ok(event) => match visitor(event, framed) {
+        match decode() {
+            Ok(control) => match control {
                 IncrementalStreamControl::Continue => {
                     self.event_count = self.event_count.saturating_add(1);
                 }
@@ -449,6 +526,43 @@ where
             Ok(0) => break,
             Ok(read) => {
                 decoder.push(&buffer[..read], &mut visitor);
+                if decoder.is_terminal() {
+                    break;
+                }
+            }
+            Err(error) => {
+                decoder.fail(FrameError::Io(error));
+                break;
+            }
+        }
+    }
+    decoder.finish()
+}
+
+/// Decode a length-delimited BEP stream one frame at a time while borrowing
+/// each decoded event from the reusable read buffer.
+///
+/// The visitor must reduce or copy any state it needs before returning. This
+/// avoids allocating a retained frame for consumers such as
+/// `BepAccumulator` that already keep only bounded, reducer-relevant fields.
+pub fn visit_stream_partial_borrowed_bounded<R, F>(
+    mut reader: R,
+    max_frame_bytes: usize,
+    max_stream_bytes: usize,
+    max_events: usize,
+    mut visitor: F,
+) -> StreamOutcome
+where
+    R: Read,
+    F: for<'frame> FnMut(BorrowedBepEvent<'frame>),
+{
+    let mut decoder = IncrementalStreamDecoder::new(max_frame_bytes, max_stream_bytes, max_events);
+    let mut buffer = [0_u8; 64 * 1024];
+    loop {
+        match reader.read(&mut buffer) {
+            Ok(0) => break,
+            Ok(read) => {
+                decoder.push_borrowed(&buffer[..read], &mut visitor);
                 if decoder.is_terminal() {
                     break;
                 }
@@ -668,6 +782,62 @@ mod tests {
     }
 
     #[test]
+    fn borrowed_incremental_decoder_handles_every_chunk_boundary() {
+        let first = BuildEvent {
+            payload: Some(crate::proto::build_event::Payload::Progress(Box::new(
+                crate::proto::Progress {
+                    stdout: "borrowed".repeat(32),
+                    stderr: String::new(),
+                },
+            ))),
+            ..Default::default()
+        };
+        let second = BuildEvent::default();
+        let mut framed = encode_frame(&first);
+        framed.extend_from_slice(&encode_frame(&second));
+
+        for split in 0..=framed.len() {
+            let mut decoder = IncrementalStreamDecoder::new(
+                DEFAULT_MAX_FRAME_BYTES,
+                DEFAULT_MAX_STREAM_BYTES,
+                DEFAULT_MAX_STREAM_EVENTS,
+            );
+            let mut payloads = Vec::new();
+            for chunk in [&framed[..split], &framed[split..]] {
+                decoder.push_borrowed(chunk, |event| {
+                    let stdout = match event.view().payload.as_ref() {
+                        Some(crate::view::build_event::Payload::Progress(progress)) => {
+                            Some(progress.stdout.to_owned())
+                        }
+                        _ => None,
+                    };
+                    payloads.push((event.frame_bytes().len(), stdout));
+                });
+            }
+            let outcome = decoder.finish();
+            assert_eq!(outcome.event_count, 2, "split at byte {split}");
+            assert_eq!(
+                outcome.decoded_bytes,
+                first.encoded_len() as usize + second.encoded_len() as usize,
+                "split at byte {split}"
+            );
+            assert!(
+                outcome.terminal_error.is_none(),
+                "split at byte {split}: {:?}",
+                outcome.terminal_error
+            );
+            assert_eq!(
+                payloads,
+                [
+                    (first.encoded_len() as usize, Some("borrowed".repeat(32))),
+                    (second.encoded_len() as usize, None),
+                ],
+                "split at byte {split}"
+            );
+        }
+    }
+
+    #[test]
     fn framed_incremental_decoder_preserves_bytes_and_resets_between_attempts() {
         let first = BuildEvent {
             payload: Some(crate::proto::build_event::Payload::Progress(Box::new(
@@ -713,6 +883,67 @@ mod tests {
             }
             let outcome = decoder.finish();
             assert_eq!(frames, [first_frame.clone(), second_frame.clone()]);
+            assert_eq!(outcome.event_count, 1, "split at byte {split}");
+            assert_eq!(
+                outcome.decoded_bytes,
+                second.encoded_len() as usize,
+                "split at byte {split}"
+            );
+            assert!(outcome.terminal_error.is_none(), "split at byte {split}");
+        }
+    }
+
+    #[test]
+    fn borrowed_framed_decoder_preserves_bytes_and_resets_between_attempts() {
+        let first = BuildEvent {
+            payload: Some(crate::proto::build_event::Payload::Progress(Box::new(
+                crate::proto::Progress {
+                    stdout: "abandoned".into(),
+                    stderr: String::new(),
+                },
+            ))),
+            ..Default::default()
+        };
+        let second = BuildEvent {
+            payload: Some(crate::proto::build_event::Payload::Progress(Box::new(
+                crate::proto::Progress {
+                    stdout: "retained".into(),
+                    stderr: String::new(),
+                },
+            ))),
+            ..Default::default()
+        };
+        let first_frame = encode_frame(&first);
+        let second_frame = encode_frame(&second);
+        let mut input = first_frame.clone();
+        input.extend_from_slice(&second_frame);
+
+        for split in 0..=input.len() {
+            let mut decoder = IncrementalStreamDecoder::new(
+                DEFAULT_MAX_FRAME_BYTES,
+                DEFAULT_MAX_STREAM_BYTES,
+                DEFAULT_MAX_STREAM_EVENTS,
+            );
+            let mut frames = Vec::new();
+            for chunk in [&input[..split], &input[split..]] {
+                decoder.push_framed_borrowed(chunk, |event, framed| {
+                    frames.push((event.frame_bytes().to_vec(), framed.to_vec()));
+                    if frames.len() == 1 {
+                        IncrementalStreamControl::ResetAfterFrame
+                    } else {
+                        IncrementalStreamControl::Continue
+                    }
+                });
+            }
+            let outcome = decoder.finish();
+            assert_eq!(
+                frames,
+                [
+                    (first.encode_to_vec(), first_frame.clone()),
+                    (second.encode_to_vec(), second_frame.clone()),
+                ],
+                "split at byte {split}"
+            );
             assert_eq!(outcome.event_count, 1, "split at byte {split}");
             assert_eq!(
                 outcome.decoded_bytes,
@@ -799,6 +1030,13 @@ mod tests {
             1,
             |_| {},
         );
+        let borrowed_reader_outcome = visit_stream_partial_borrowed_bounded(
+            input.as_slice(),
+            DEFAULT_MAX_FRAME_BYTES,
+            DEFAULT_MAX_STREAM_BYTES,
+            1,
+            |_| {},
+        );
         let mut incremental =
             IncrementalStreamDecoder::new(DEFAULT_MAX_FRAME_BYTES, DEFAULT_MAX_STREAM_BYTES, 1);
         incremental.push(&input[..1], |_| {});
@@ -807,11 +1045,29 @@ mod tests {
 
         assert_eq!(incremental_outcome.event_count, reader_outcome.event_count);
         assert_eq!(
+            borrowed_reader_outcome.event_count,
+            reader_outcome.event_count
+        );
+        assert_eq!(
             incremental_outcome.decoded_bytes,
             reader_outcome.decoded_bytes
         );
         assert_eq!(
+            borrowed_reader_outcome.decoded_bytes,
+            reader_outcome.decoded_bytes
+        );
+        assert_eq!(
             incremental_outcome
+                .terminal_error
+                .as_ref()
+                .map(ToString::to_string),
+            reader_outcome
+                .terminal_error
+                .as_ref()
+                .map(ToString::to_string)
+        );
+        assert_eq!(
+            borrowed_reader_outcome
                 .terminal_error
                 .as_ref()
                 .map(ToString::to_string),

--- a/crates/bazel-mcp-bep/src/lib.rs
+++ b/crates/bazel-mcp-bep/src/lib.rs
@@ -26,9 +26,9 @@ pub mod view {
 }
 
 pub use framing::{
-    BepEvent, DEFAULT_MAX_FRAME_BYTES, DEFAULT_MAX_STREAM_BYTES, DEFAULT_MAX_STREAM_EVENTS,
-    FrameError, IncrementalStreamControl, IncrementalStreamDecoder, PartialStream, StreamOutcome,
-    decode_event, decode_event_id, decode_stream, decode_stream_partial,
-    decode_stream_partial_bounded, encode_event_id, encode_frame, read_frame,
-    visit_stream_partial_bounded,
+    BepEvent, BorrowedBepEvent, DEFAULT_MAX_FRAME_BYTES, DEFAULT_MAX_STREAM_BYTES,
+    DEFAULT_MAX_STREAM_EVENTS, FrameError, IncrementalStreamControl, IncrementalStreamDecoder,
+    PartialStream, StreamOutcome, decode_event, decode_event_id, decode_stream,
+    decode_stream_partial, decode_stream_partial_bounded, encode_event_id, encode_frame,
+    read_frame, visit_stream_partial_borrowed_bounded, visit_stream_partial_bounded,
 };

--- a/crates/bazel-mcp-reducer/src/build.rs
+++ b/crates/bazel-mcp-reducer/src/build.rs
@@ -1,5 +1,5 @@
 use bazel_mcp_bep::{
-    BepEvent, decode_event_id,
+    BepEvent, BorrowedBepEvent, decode_event_id,
     view::{BuildEventIdView, FileView, NamedSetOfFilesView, build_event, build_event_id, file},
 };
 use bazel_mcp_types::{
@@ -80,7 +80,14 @@ impl BepAccumulator {
     }
 
     pub fn observe(&mut self, event: BepEvent) {
-        let event = event.view();
+        self.observe_view(event.view());
+    }
+
+    pub fn observe_borrowed(&mut self, event: BorrowedBepEvent<'_>) {
+        self.observe_view(event.view());
+    }
+
+    fn observe_view(&mut self, event: &bazel_mcp_bep::view::BuildEventView<'_>) {
         let id = decode_event_id(event.id).ok();
         let ordinal = self.next_event_ordinal;
         self.next_event_ordinal = self.next_event_ordinal.saturating_add(1);

--- a/crates/bazel-mcp-runner/src/capture.rs
+++ b/crates/bazel-mcp-runner/src/capture.rs
@@ -407,10 +407,10 @@ impl ReductionSubscriber {
         }
     }
 
-    fn observe(&mut self, event: bazel_mcp_bep::BepEvent) {
+    fn observe(&mut self, event: bazel_mcp_bep::BorrowedBepEvent<'_>) {
         self.decoded_bytes = self.decoded_bytes.saturating_add(event.frame_bytes().len());
         self.event_count = self.event_count.saturating_add(1);
-        self.accumulator.observe(event);
+        self.accumulator.observe_borrowed(event);
     }
 
     fn outcome(&self) -> StreamOutcome {
@@ -561,7 +561,7 @@ impl CapturePipeline {
         let pending_raw = &mut self.pending_raw;
         let extension_limits = self.extension_limits;
         let mut pipeline_error = None;
-        self.decoder.push_framed(input, |event, framed| {
+        self.decoder.push_framed_borrowed(input, |event, framed| {
             if pipeline_error.is_some() {
                 return IncrementalStreamControl::Continue;
             }


### PR DESCRIPTION
## Summary

- add lifetime-bounded borrowed BEP event visitors for incremental and reader-based decoding
- reduce live capture and benchmark streams directly from borrowed protobuf frames
- preserve the existing owned event APIs for callers that intentionally retain events
- retain raw-byte durability before reduction and record the allocation finding in `LEARNINGS.md`

## Why

The incremental decoder copied every protobuf payload into an owned `Bytes` allocation before calling `BepAccumulator`, even though the accumulator immediately extracted bounded owned fields and discarded the event. The profiled 3.8 MB stream therefore copied 3,793,500 payload bytes unnecessarily.

The new higher-ranked visitor prevents borrowed events from escaping the callback while allowing the read buffer or pending-frame storage to be reused after reduction.

## Impact

Measured on the identical 3.8 MB BEP workload:

| Metric | Before | After | Improvement |
| --- | ---: | ---: | ---: |
| Allocated bytes | 5,194,047 | 1,400,547 | 73.04% lower |
| Allocation count | 23,455 | 16,155 | 31.12% lower |
| Runtime, 20 decodes | 38.69 ms | 29.04 ms | 1.33x faster |

The full 3,793,500-byte payload ownership copy is removed.

## Safety and compatibility

- exact raw framed bytes are still committed durably before reduction observes an event
- existing owned decoding and event-retention APIs remain available
- borrowed and owned paths have matching framing, stream-limit, and retry-reset accounting
- tests exercise every possible split boundary for borrowed events and exact framed bytes

## Validation

- `make test`
- `make check NIX_DEVELOP=`
- `cargo clippy -p bazel-mcp-bep -p bazel-mcp-reducer -p bazel-mcp-runner -p bazel-mcp-benchmark --all-targets --all-features -- -D warnings`
- `git diff --check`
- DHAT allocation profile before/after
- Hyperfine timing comparison, 15 runs after 3 warmups
