### PR TITLE
perf: streamline private filesystem writes

### DIFF
--- a/LEARNINGS.md
+++ b/LEARNINGS.md
@@ -172,3 +172,10 @@ unrelated to MCP efficiency. Do not include secrets or raw sensitive output.
   targeted test rerun; return a small bounded context window around matching
   test-log lines so the causal message stays visible without another tool call.
   Thread: `019f6df4-be14-75b2-8e2b-654b60a669c3`.
+- Each `bazel.run` lifecycle committed its manifest four times through separate
+  write, chmod, and rename blocking-pool operations while also re-chmodding
+  shared day and shard directories; this consumed server CPU without reducing
+  model-visible bytes or tool calls. Keep private modes at file and directory
+  creation, perform each atomic publication in one blocking operation, and
+  preserve startup cleanup of interrupted temporary files. Thread:
+  `019f6e39-5686-7362-83fb-bdfa398e7cf5`.

--- a/crates/bazel-mcp-runner/src/capture.rs
+++ b/crates/bazel-mcp-runner/src/capture.rs
@@ -957,18 +957,11 @@ pub(crate) async fn file_size(path: &Path) -> u64 {
 }
 
 fn private_file(path: &Path) -> io::Result<std::fs::File> {
-    let file = OpenOptions::new()
-        .create(true)
-        .truncate(true)
-        .read(true)
-        .write(true)
-        .open(path)?;
+    let mut options = OpenOptions::new();
+    options.create(true).truncate(true).read(true).write(true);
     #[cfg(unix)]
-    {
-        use std::os::unix::fs::PermissionsExt;
-        file.set_permissions(std::fs::Permissions::from_mode(0o600))?;
-    }
-    Ok(file)
+    options.mode(0o600);
+    options.open(path)
 }
 
 #[cfg(test)]
@@ -978,6 +971,25 @@ mod tests {
     use tokio::io::AsyncWriteExt;
 
     use super::*;
+
+    #[cfg(unix)]
+    #[test]
+    fn private_files_are_private_at_creation_and_can_be_reopened() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let root = tempdir().unwrap();
+        let path = root.path().join("capture.log");
+        let mut file = private_file(&path).unwrap();
+        file.write_all(b"evidence").unwrap();
+        drop(file);
+
+        assert_eq!(
+            std::fs::metadata(&path).unwrap().permissions().mode() & 0o777,
+            0o600
+        );
+        drop(private_file(&path).unwrap());
+        assert_eq!(std::fs::metadata(path).unwrap().len(), 0);
+    }
 
     #[tokio::test]
     async fn bounded_tail_reads_only_the_requested_suffix() {

--- a/crates/bazel-mcp-runner/src/evidence.rs
+++ b/crates/bazel-mcp-runner/src/evidence.rs
@@ -2,25 +2,68 @@
 
 use std::{io, path::Path};
 
-use tokio::io::AsyncWriteExt;
-
-pub(crate) async fn write_private_atomic(path: &Path, bytes: &[u8]) -> Result<(), io::Error> {
-    let temporary = path.with_extension("tmp");
-    let mut file = tokio::fs::File::create(&temporary).await?;
-    file.write_all(bytes).await?;
-    file.flush().await?;
-    drop(file);
-    set_private_file(&temporary).await?;
-    tokio::fs::rename(temporary, path).await
-}
-
 #[cfg(unix)]
-pub(crate) async fn set_private_file(path: &Path) -> Result<(), io::Error> {
-    use std::os::unix::fs::PermissionsExt;
-    tokio::fs::set_permissions(path, std::fs::Permissions::from_mode(0o600)).await
+use std::os::unix::fs::OpenOptionsExt;
+
+pub(crate) async fn write_private_atomic(path: &Path, bytes: Vec<u8>) -> Result<(), io::Error> {
+    let path = path.to_owned();
+    tokio::task::spawn_blocking(move || {
+        use std::io::Write as _;
+
+        let temporary = path.with_extension("tmp");
+        let result = (|| {
+            let mut options = std::fs::OpenOptions::new();
+            options.create_new(true).write(true);
+            #[cfg(unix)]
+            options.mode(0o600);
+            let mut file = options.open(&temporary)?;
+            file.write_all(&bytes)?;
+            file.flush()?;
+            drop(file);
+            std::fs::rename(&temporary, &path)
+        })();
+        if result.is_err() {
+            let _ = std::fs::remove_file(temporary);
+        }
+        result
+    })
+    .await
+    .map_err(io::Error::other)?
 }
 
-#[cfg(not(unix))]
-pub(crate) async fn set_private_file(_path: &Path) -> Result<(), io::Error> {
-    Ok(())
+pub(crate) async fn create_private_file(path: &Path) -> Result<tokio::fs::File, io::Error> {
+    let mut options = tokio::fs::OpenOptions::new();
+    options.create_new(true).write(true);
+    #[cfg(unix)]
+    options.mode(0o600);
+    options.open(path).await
+}
+
+#[cfg(test)]
+mod tests {
+    use tempfile::tempdir;
+
+    use super::*;
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn private_atomic_writes_publish_private_complete_files() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let root = tempdir().unwrap();
+        let path = root.path().join("failure-evidence.jsonl");
+        write_private_atomic(&path, b"first".to_vec())
+            .await
+            .unwrap();
+        write_private_atomic(&path, b"second".to_vec())
+            .await
+            .unwrap();
+
+        assert_eq!(tokio::fs::read(&path).await.unwrap(), b"second");
+        assert_eq!(
+            std::fs::metadata(&path).unwrap().permissions().mode() & 0o777,
+            0o600
+        );
+        assert!(!path.with_extension("tmp").exists());
+    }
 }

--- a/crates/bazel-mcp-runner/src/inspection.rs
+++ b/crates/bazel-mcp-runner/src/inspection.rs
@@ -368,7 +368,7 @@ impl InvocationService {
             serde_json::to_writer(&mut bytes, &record)?;
             bytes.push(b'\n');
         }
-        write_private_atomic(&paths.evidence, &bytes).await?;
+        write_private_atomic(&paths.evidence, bytes).await?;
         Ok(())
     }
 

--- a/crates/bazel-mcp-runner/src/test_evidence.rs
+++ b/crates/bazel-mcp-runner/src/test_evidence.rs
@@ -10,7 +10,7 @@ use bazel_mcp_types::{ArtifactKind, DiagnosticCategory, TestStatus};
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
 
 use crate::{
-    evidence::set_private_file,
+    evidence::create_private_file,
     inspection::EvidenceRecord,
     service::{InvocationService, bounded_text},
 };
@@ -52,16 +52,10 @@ impl InvocationService {
             return;
         }
 
-        let raw = tokio::fs::OpenOptions::new()
-            .create_new(true)
-            .write(true)
-            .open(&raw_temporary)
-            .await;
-        let evidence = tokio::fs::OpenOptions::new()
-            .create_new(true)
-            .write(true)
-            .open(&evidence_temporary)
-            .await;
+        let (raw, evidence) = tokio::join!(
+            create_private_file(&raw_temporary),
+            create_private_file(&evidence_temporary)
+        );
         let (Ok(mut raw), Ok(mut evidence)) = (raw, evidence) else {
             let _ = tokio::fs::remove_file(&raw_temporary).await;
             let _ = tokio::fs::remove_file(&evidence_temporary).await;
@@ -229,8 +223,6 @@ impl InvocationService {
         drop(evidence);
         let committed = if copied_any {
             flushed
-                && set_private_file(&raw_temporary).await.is_ok()
-                && set_private_file(&evidence_temporary).await.is_ok()
                 && tokio::fs::rename(&raw_temporary, &paths.test_logs_raw)
                     .await
                     .is_ok()

--- a/crates/bazel-mcp-store/src/files.rs
+++ b/crates/bazel-mcp-store/src/files.rs
@@ -1,4 +1,11 @@
-use std::path::{Path, PathBuf};
+use std::{
+    fs::{DirBuilder, OpenOptions},
+    io::{self, Write},
+    path::{Path, PathBuf},
+};
+
+#[cfg(unix)]
+use std::os::unix::fs::{DirBuilderExt, OpenOptionsExt};
 
 use bazel_mcp_types::InvocationId;
 use tokio::fs;
@@ -59,17 +66,14 @@ impl InvocationPaths {
         let parent = self
             .directory
             .parent()
-            .ok_or_else(|| std::io::Error::other("invocation directory does not have a parent"))?;
-        fs::create_dir_all(parent).await?;
-        set_private_directory(parent).await?;
-        if let Some(day) = parent.parent() {
-            set_private_directory(day).await?;
-        }
-        fs::create_dir(&self.directory).await?;
-        if let Err(error) = set_private_directory(&self.directory).await {
-            let _ = fs::remove_dir(&self.directory).await;
-            return Err(error);
-        }
+            .ok_or_else(|| io::Error::other("invocation directory does not have a parent"))?
+            .to_owned();
+        let directory = self.directory.clone();
+        tokio::task::spawn_blocking(move || {
+            create_private_directory_all_blocking(&parent)?;
+            create_private_directory_blocking(&directory)
+        })
+        .await??;
         Ok(())
     }
 }
@@ -79,14 +83,12 @@ pub(crate) async fn write_json_atomic<T: serde::Serialize + ?Sized>(
     value: &T,
 ) -> Result<(), StoreError> {
     let bytes = serde_json::to_vec(value)?;
-    write_bytes_atomic(path, &bytes).await
+    write_bytes_atomic(path, bytes).await
 }
 
-pub(crate) async fn write_bytes_atomic(path: &Path, bytes: &[u8]) -> Result<(), StoreError> {
-    let temporary = path.with_extension("tmp");
-    fs::write(&temporary, bytes).await?;
-    set_private_file(&temporary).await?;
-    fs::rename(temporary, path).await?;
+pub(crate) async fn write_bytes_atomic(path: &Path, bytes: Vec<u8>) -> Result<(), StoreError> {
+    let path = path.to_owned();
+    tokio::task::spawn_blocking(move || write_bytes_atomic_blocking(&path, &bytes)).await??;
     Ok(())
 }
 
@@ -98,26 +100,78 @@ pub(crate) async fn remove_if_exists(path: &Path) -> Result<(), StoreError> {
     }
 }
 
-#[cfg(unix)]
-pub(crate) async fn set_private_directory(path: &Path) -> Result<(), StoreError> {
-    use std::os::unix::fs::PermissionsExt;
-    fs::set_permissions(path, std::fs::Permissions::from_mode(0o700)).await?;
+pub(crate) async fn create_private_directory_all(path: &Path) -> Result<(), StoreError> {
+    let path = path.to_owned();
+    tokio::task::spawn_blocking(move || create_private_directory_all_blocking(&path)).await??;
     Ok(())
+}
+
+pub(crate) async fn create_private_directory(path: &Path) -> Result<(), StoreError> {
+    let path = path.to_owned();
+    tokio::task::spawn_blocking(move || create_private_directory_blocking(&path)).await??;
+    Ok(())
+}
+
+fn create_private_directory_all_blocking(path: &Path) -> io::Result<()> {
+    let mut builder = private_directory_builder();
+    builder.recursive(true).create(path)
+}
+
+fn create_private_directory_blocking(path: &Path) -> io::Result<()> {
+    private_directory_builder().create(path)
+}
+
+#[cfg(unix)]
+fn private_directory_builder() -> DirBuilder {
+    let mut builder = DirBuilder::new();
+    builder.mode(0o700);
+    builder
 }
 
 #[cfg(not(unix))]
-pub(crate) async fn set_private_directory(_path: &Path) -> Result<(), StoreError> {
-    Ok(())
+fn private_directory_builder() -> DirBuilder {
+    DirBuilder::new()
 }
 
-#[cfg(unix)]
-pub(crate) async fn set_private_file(path: &Path) -> Result<(), StoreError> {
-    use std::os::unix::fs::PermissionsExt;
-    fs::set_permissions(path, std::fs::Permissions::from_mode(0o600)).await?;
-    Ok(())
+fn write_bytes_atomic_blocking(path: &Path, bytes: &[u8]) -> io::Result<()> {
+    let temporary = path.with_extension("tmp");
+    let result = (|| {
+        let mut options = OpenOptions::new();
+        options.create_new(true).write(true);
+        #[cfg(unix)]
+        options.mode(0o600);
+        let mut file = options.open(&temporary)?;
+        file.write_all(bytes)?;
+        drop(file);
+        std::fs::rename(&temporary, path)
+    })();
+    if result.is_err() {
+        let _ = std::fs::remove_file(temporary);
+    }
+    result
 }
 
-#[cfg(not(unix))]
-pub(crate) async fn set_private_file(_path: &Path) -> Result<(), StoreError> {
-    Ok(())
+#[cfg(test)]
+mod tests {
+    use tempfile::TempDir;
+
+    use super::*;
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn atomic_writes_are_private_and_replace_the_committed_file() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let root = TempDir::new().unwrap();
+        let path = root.path().join("manifest.json");
+        write_bytes_atomic(&path, b"first".to_vec()).await.unwrap();
+        write_bytes_atomic(&path, b"second".to_vec()).await.unwrap();
+
+        assert_eq!(std::fs::read(&path).unwrap(), b"second");
+        assert_eq!(
+            std::fs::metadata(&path).unwrap().permissions().mode() & 0o777,
+            0o600
+        );
+        assert!(!path.with_extension("tmp").exists());
+    }
 }

--- a/crates/bazel-mcp-store/src/storage.rs
+++ b/crates/bazel-mcp-store/src/storage.rs
@@ -1,6 +1,7 @@
 use std::{
     collections::BTreeMap,
     fs::{File, OpenOptions},
+    io::Write,
     path::{Path, PathBuf},
     sync::{
         Arc, OnceLock, Weak,
@@ -27,7 +28,10 @@ use tokio::sync::{Mutex, RwLock};
 use crate::{
     InvocationPaths,
     cursor::FileCursor,
-    files::{remove_if_exists, set_private_directory, write_bytes_atomic, write_json_atomic},
+    files::{
+        create_private_directory, create_private_directory_all, remove_if_exists,
+        write_bytes_atomic, write_json_atomic,
+    },
     index::{
         Index, IndexEntry, ensure_exists, insert as insert_index_entry, mark_telemetry_flushed,
         merge_index_telemetry, merge_pending_telemetry, merge_telemetry,
@@ -132,16 +136,11 @@ pub struct InvocationCompletion {
 impl Store {
     pub async fn open(cache_root: impl AsRef<Path>) -> Result<Self, StoreError> {
         let cache_root = cache_root.as_ref().to_owned();
-        tokio::fs::create_dir_all(&cache_root).await?;
-        set_private_directory(&cache_root).await?;
-        tokio::fs::create_dir_all(cache_root.join("invocations")).await?;
-        tokio::fs::create_dir_all(cache_root.join("trash")).await?;
-        tokio::fs::create_dir_all(cache_root.join("owners")).await?;
-        tokio::fs::create_dir_all(cache_root.join("mutations")).await?;
-        set_private_directory(&cache_root.join("invocations")).await?;
-        set_private_directory(&cache_root.join("trash")).await?;
-        set_private_directory(&cache_root.join("owners")).await?;
-        set_private_directory(&cache_root.join("mutations")).await?;
+        create_private_directory_all(&cache_root).await?;
+        create_private_directory_all(&cache_root.join("invocations")).await?;
+        create_private_directory_all(&cache_root.join("trash")).await?;
+        create_private_directory_all(&cache_root.join("owners")).await?;
+        create_private_directory_all(&cache_root.join("mutations")).await?;
 
         let _maintenance = ProcessLock::acquire(cache_root.join("MAINTENANCE")).await?;
         let _metadata = ProcessLock::acquire(cache_root.join("LOCK")).await?;
@@ -933,7 +932,7 @@ async fn persist_durable(
     }
     let bytes = serde_json::to_vec(durable)?;
     let manifest_bytes = u64::try_from(bytes.len()).unwrap_or(u64::MAX);
-    write_bytes_atomic(&paths.manifest, &bytes).await?;
+    write_bytes_atomic(&paths.manifest, bytes).await?;
     Ok(PersistOutcome {
         retained_bytes: durable.payload_bytes.saturating_add(manifest_bytes),
         manifest_bytes,
@@ -1301,8 +1300,7 @@ pub(crate) async fn stage_raw_evidence(
         Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
         Err(error) => return Err(error.into()),
     }
-    tokio::fs::create_dir(&trash).await?;
-    set_private_directory(&trash).await?;
+    create_private_directory(&trash).await?;
     for source in [
         &paths.stdout,
         &paths.stderr,
@@ -1446,18 +1444,6 @@ fn open_lock_file(path: &Path) -> Result<File, std::io::Error> {
     options.open(path)
 }
 
-#[cfg(unix)]
-fn set_private_file_blocking(path: &Path) -> Result<(), StoreError> {
-    use std::os::unix::fs::PermissionsExt;
-    std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o600))?;
-    Ok(())
-}
-
-#[cfg(not(unix))]
-fn set_private_file_blocking(_path: &Path) -> Result<(), StoreError> {
-    Ok(())
-}
-
 pub(crate) fn owner_lock_path(cache_root: &Path, id: InvocationId) -> PathBuf {
     cache_root.join("owners").join(format!("{id}.lock"))
 }
@@ -1498,8 +1484,16 @@ fn write_generation(cache_root: &Path, generation: u64) -> Result<u64, StoreErro
         )));
     }
     let temporary = path.with_extension("tmp");
-    std::fs::write(&temporary, generation.to_string())?;
-    set_private_file_blocking(&temporary)?;
+    let mut options = OpenOptions::new();
+    options.create(true).truncate(true).write(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        options.mode(0o600);
+    }
+    let mut file = options.open(&temporary)?;
+    file.write_all(generation.to_string().as_bytes())?;
+    drop(file);
     std::fs::rename(temporary, path)?;
     Ok(generation)
 }
@@ -1507,10 +1501,7 @@ fn write_generation(cache_root: &Path, generation: u64) -> Result<u64, StoreErro
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::{
-        io::Write as _,
-        sync::atomic::{AtomicUsize, Ordering as AtomicOrdering},
-    };
+    use std::sync::atomic::{AtomicUsize, Ordering as AtomicOrdering};
 
     use bazel_mcp_types::{
         BazelCommand, CoverageSummary, InvocationRequest, TargetCounts, TestCounts, TestStatus,
@@ -2233,46 +2224,43 @@ mod tests {
     async fn canonical_directories_and_files_remain_private() {
         use std::os::unix::fs::PermissionsExt;
 
-        let root = TempDir::new().unwrap();
-        let store = Store::open(root.path()).await.unwrap();
-        let record = record(root.path());
+        let container = TempDir::new().unwrap();
+        let cache_root = container.path().join("cache");
+        let store = Store::open(&cache_root).await.unwrap();
+        let record = record(container.path());
         let paths = store.create_invocation(&record).await.unwrap();
-        assert_eq!(
-            std::fs::metadata(&paths.directory)
-                .unwrap()
-                .permissions()
-                .mode()
-                & 0o777,
-            0o700
-        );
-        assert_eq!(
-            std::fs::metadata(&paths.manifest)
-                .unwrap()
-                .permissions()
-                .mode()
-                & 0o777,
-            0o600
-        );
+        let shard = paths.directory.parent().unwrap();
+        let day = shard.parent().unwrap();
         for directory in [
-            root.path().join("owners"),
-            root.path().join("mutations"),
-            root.path().join("trash"),
+            cache_root.clone(),
+            cache_root.join("invocations"),
+            cache_root.join("trash"),
+            cache_root.join("owners"),
+            cache_root.join("mutations"),
+            day.to_owned(),
+            shard.to_owned(),
+            paths.directory.clone(),
         ] {
             assert_eq!(
-                std::fs::metadata(directory).unwrap().permissions().mode() & 0o777,
-                0o700
+                std::fs::metadata(&directory).unwrap().permissions().mode() & 0o777,
+                0o700,
+                "{} was not private",
+                directory.display()
             );
         }
         for file in [
-            root.path().join("LOCK"),
-            root.path().join("MAINTENANCE"),
-            root.path().join("GENERATION"),
-            owner_lock_path(root.path(), record.request.id),
-            mutation_lock_path(root.path(), record.request.id),
+            cache_root.join("LOCK"),
+            cache_root.join("MAINTENANCE"),
+            cache_root.join("GENERATION"),
+            owner_lock_path(&cache_root, record.request.id),
+            mutation_lock_path(&cache_root, record.request.id),
+            paths.manifest.clone(),
         ] {
             assert_eq!(
-                std::fs::metadata(file).unwrap().permissions().mode() & 0o777,
-                0o600
+                std::fs::metadata(&file).unwrap().permissions().mode() & 0o777,
+                0o600,
+                "{} was not private",
+                file.display()
             );
         }
     }


### PR DESCRIPTION
## Summary

- create cache directories, capture files, evidence snapshots, lock files, and generation records with private permissions from the outset
- consolidate each manifest or evidence publication into one blocking open/write/rename operation
- remove recurring chmod calls from invocation day/shard directories and the multiprocess generation path
- retain atomic rename publication, startup cleanup of interrupted temporary records, and raw-evidence-before-reduction ordering

## Why

CPU profiling showed that every `bazel.run` lifecycle performs four manifest commits. Each commit crossed the blocking pool separately for write, chmod, and rename, while invocation creation repeatedly chmodded shared day and shard directories. The newer multiprocess generation record had the same create-then-chmod pattern.

That work consumed server CPU without changing model-visible output or reducing tool calls. The optimized path applies permissions at creation and keeps each atomic publication inside one blocking operation. Existing cache modes are intentionally not repaired on every access.

## Performance

Five interleaved runs on macOS arm64, comparing the pre-change baseline (`d0482da`) with this branch under 128 lifecycle operations:

| Metric | main | branch | Change |
| --- | ---: | ---: | ---: |
| Lifecycle latency | 2.585 ms | 2.256 ms | -12.7% |
| Single-writer throughput | 485.8/s | 544.3/s | +12.0% |
| 8-writer throughput | 1,019.5/s | 1,135.6/s | +11.4% |
| 32-writer throughput | 931.6/s | 1,031.1/s | +10.7% |
| Reopen, 100 invocations | 3.517 ms | 3.072 ms | -12.6% |

## Validation

- `make test`
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo shear`
- live MCP `bazel.run` build of `//:bazel-mcp` on a fresh isolated Bazel root
- live MCP `bazel.run` test of `//crates/bazel-mcp-server:all --nocache_test_results`
