### PR TITLE
perf: reduce recurring allocation buffers

### DIFF
--- a/crates/bazel-mcp-bep/src/framing.rs
+++ b/crates/bazel-mcp-bep/src/framing.rs
@@ -10,6 +10,7 @@ use crate::proto::{
 pub const DEFAULT_MAX_FRAME_BYTES: usize = 64 * 1024 * 1024;
 pub const DEFAULT_MAX_STREAM_BYTES: usize = 128 * 1024 * 1024;
 pub const DEFAULT_MAX_STREAM_EVENTS: usize = 1_000_000;
+const MAX_RETAINED_PENDING_BYTES: usize = 64 * 1024;
 
 #[derive(Debug, Error)]
 pub enum FrameError {
@@ -271,6 +272,7 @@ impl IncrementalStreamDecoder {
                     let consumed = prefix_bytes.saturating_add(frame_bytes);
                     let framed = std::mem::take(&mut self.pending);
                     decode(self, &framed[prefix_bytes..consumed], &framed[..consumed]);
+                    self.recycle_pending(framed);
                     if self.terminal_error.is_some() {
                         return;
                     }
@@ -294,6 +296,7 @@ impl IncrementalStreamDecoder {
                     let consumed = prefix_bytes.saturating_add(frame_bytes);
                     let framed = std::mem::take(&mut self.pending);
                     decode(self, &framed[prefix_bytes..consumed], &framed[..consumed]);
+                    self.recycle_pending(framed);
                 }
                 Ok(FrameState::NeedPrefix | FrameState::NeedPayload { .. }) => {}
                 Err(error) => self.terminal_error = Some(error),
@@ -316,6 +319,13 @@ impl IncrementalStreamDecoder {
             event_count: self.event_count,
             decoded_bytes: self.decoded_bytes,
             terminal_error: self.terminal_error,
+        }
+    }
+
+    fn recycle_pending(&mut self, mut framed: Vec<u8>) {
+        if framed.capacity() <= MAX_RETAINED_PENDING_BYTES {
+            framed.clear();
+            self.pending = framed;
         }
     }
 
@@ -779,6 +789,69 @@ mod tests {
             );
             assert_eq!(events.len(), 2, "split at byte {split}");
         }
+    }
+
+    #[test]
+    fn incremental_decoder_reuses_pending_frame_capacity() {
+        let event = BuildEvent {
+            payload: Some(crate::proto::build_event::Payload::Progress(Box::new(
+                crate::proto::Progress {
+                    stdout: "retained".repeat(512),
+                    stderr: String::new(),
+                },
+            ))),
+            ..Default::default()
+        };
+        let framed = encode_frame(&event);
+        let split = framed.len() / 2;
+        let mut decoder = IncrementalStreamDecoder::new(
+            DEFAULT_MAX_FRAME_BYTES,
+            DEFAULT_MAX_STREAM_BYTES,
+            DEFAULT_MAX_STREAM_EVENTS,
+        );
+        let mut events = 0;
+
+        decoder.push_borrowed(&framed[..split], |_| events += 1);
+        decoder.push_borrowed(&framed[split..], |_| events += 1);
+        let retained_capacity = decoder.pending.capacity();
+        assert!(decoder.pending.is_empty());
+        assert!(retained_capacity >= framed.len());
+
+        decoder.push_borrowed(&framed[..split], |_| events += 1);
+        assert_eq!(decoder.pending.capacity(), retained_capacity);
+        decoder.push_borrowed(&framed[split..], |_| events += 1);
+
+        let outcome = decoder.finish();
+        assert_eq!(events, 2);
+        assert_eq!(outcome.event_count, 2);
+        assert!(outcome.terminal_error.is_none());
+    }
+
+    #[test]
+    fn incremental_decoder_drops_oversized_pending_capacity() {
+        let event = BuildEvent {
+            payload: Some(crate::proto::build_event::Payload::Progress(Box::new(
+                crate::proto::Progress {
+                    stdout: "x".repeat(MAX_RETAINED_PENDING_BYTES * 2),
+                    stderr: String::new(),
+                },
+            ))),
+            ..Default::default()
+        };
+        let framed = encode_frame(&event);
+        let split = framed.len() / 2;
+        let mut decoder = IncrementalStreamDecoder::new(
+            DEFAULT_MAX_FRAME_BYTES,
+            DEFAULT_MAX_STREAM_BYTES,
+            DEFAULT_MAX_STREAM_EVENTS,
+        );
+
+        decoder.push_borrowed(&framed[..split], |_| {});
+        decoder.push_borrowed(&framed[split..], |_| {});
+
+        assert!(decoder.pending.is_empty());
+        assert_eq!(decoder.pending.capacity(), 0);
+        assert!(decoder.finish().terminal_error.is_none());
     }
 
     #[test]

--- a/crates/bazel-mcp-reducer/src/starlark.rs
+++ b/crates/bazel-mcp-reducer/src/starlark.rs
@@ -3,7 +3,7 @@ use std::{
     fs::File,
     io::Read,
     path::{Path, PathBuf},
-    sync::Arc,
+    sync::{Arc, OnceLock},
     time::{Duration, Instant},
 };
 
@@ -193,7 +193,7 @@ impl LoadedStarlarkReducer {
             evaluator.set_print_handler(&no_print);
             evaluator.enable_static_typechecking(true);
             evaluator
-                .eval_module(ast, &globals)
+                .eval_module(ast, globals)
                 .map_err(|error| anyhow!(error))?;
             drop(evaluator);
             module.freeze().map_err(|error| anyhow!(error))
@@ -925,8 +925,9 @@ impl PrintHandler for NoPrint {
     }
 }
 
-fn reducer_globals() -> Globals {
-    GlobalsBuilder::standard().with(reducer_api).build()
+fn reducer_globals() -> &'static Globals {
+    static GLOBALS: OnceLock<Globals> = OnceLock::new();
+    GLOBALS.get_or_init(|| GlobalsBuilder::standard().with(reducer_api).build())
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -1148,6 +1149,11 @@ mod tests {
             input_truncated: false,
             baseline: InvocationSummary::default(),
         }
+    }
+
+    #[test]
+    fn caches_reducer_globals() {
+        assert!(std::ptr::eq(reducer_globals(), reducer_globals()));
     }
 
     #[test]

--- a/crates/bazel-mcp-store/src/query_paging.rs
+++ b/crates/bazel-mcp-store/src/query_paging.rs
@@ -16,6 +16,7 @@ use crate::{
 };
 
 pub(crate) const QUERY_LINE_LIMIT: usize = 64 * 1024;
+const QUERY_COUNT_BUFFER_BYTES: usize = 64 * 1024;
 
 pub(crate) fn page_records<T, F>(
     scope: &str,
@@ -215,23 +216,25 @@ where
 }
 
 fn count_query_rows(mut file: &File) -> Result<u64, StoreError> {
-    use std::io::{Read, Seek, SeekFrom};
+    use std::io::{Seek, SeekFrom};
 
     file.seek(SeekFrom::Start(0))?;
-    let mut buffer = vec![0_u8; 1024 * 1024];
+    let mut reader = BufReader::with_capacity(QUERY_COUNT_BUFFER_BYTES, file);
     let mut rows = 0_u64;
     let mut saw_bytes = false;
     let mut last_byte = b'\n';
     loop {
-        let read = file.read(&mut buffer)?;
-        if read == 0 {
+        let buffer = reader.fill_buf()?;
+        if buffer.is_empty() {
             break;
         }
         saw_bytes = true;
-        last_byte = buffer[read - 1];
+        last_byte = buffer[buffer.len() - 1];
         rows = rows.saturating_add(
-            u64::try_from(memchr::memchr_iter(b'\n', &buffer[..read]).count()).unwrap_or(u64::MAX),
+            u64::try_from(memchr::memchr_iter(b'\n', buffer).count()).unwrap_or(u64::MAX),
         );
+        let consumed = buffer.len();
+        reader.consume(consumed);
     }
     if saw_bytes && last_byte != b'\n' {
         rows = rows.saturating_add(1);


### PR DESCRIPTION
## Summary

- replace the per-query 1 MiB row-count allocation with a bounded 64 KiB buffered scan
- cache the immutable Starlark reducer globals table
- reuse incremental BEP pending-frame capacity up to 64 KiB while dropping oversized buffers
- add regression coverage for globals caching, BEP capacity reuse, and oversized-buffer release

## Why

Allocation profiling found three localized recurring allocations that could be removed without changing protocol behavior or evidence semantics. Query counting allocated a fresh 1 MiB buffer for every unfiltered query page. Incremental BEP decoding dropped its pending-frame allocation after each completed split frame. Starlark reducer loads rebuilt a small globals table after the runtime's first initialization.

## Measured impact

| Workload | Before | After | Reduction |
| --- | ---: | ---: | ---: |
| Query row count | 1,069,474 B | 86,434 B | 983,040 B (91.9%) |
| 3.8 MB BEP stream | 1,400,547 B | 920,645 B | 479,902 B (34.3%) |
| Five Starlark loads | 9,606,505 B / 14,541 allocs | 9,570,249 B / 14,337 allocs | 36,256 B / 204 allocs |

The Starlark result corrects the initial attribution: most first-load allocation is one-time initialization inside Starlark itself, so the application-level globals cache has a modest steady-state benefit.

BEP capacity reuse is capped at 64 KiB so a valid but very large frame cannot remain retained for the rest of the decoder lifetime.

## Validation

- `make test`
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo shear` using the CI-pinned cargo-shear 1.12.0
- identical before/after DHAT workloads for all three paths

Rebased onto current `main` after the store repository split; the query-count change now lives in `query_paging.rs`.
