### PR TITLE
refactor(runner): notify invocation lifecycle changes

### DIFF
--- a/crates/bazel-mcp-runner/src/execution.rs
+++ b/crates/bazel-mcp-runner/src/execution.rs
@@ -70,8 +70,7 @@ impl InvocationService {
                     ..Default::default()
                 };
                 return self
-                    .store
-                    .transition(
+                    .transition_invocation(
                         queued.request.id,
                         InvocationState::Failed,
                         Some(Termination::SpawnFailure {
@@ -237,8 +236,7 @@ impl InvocationService {
                     ..Default::default()
                 };
                 return self
-                    .store
-                    .transition(
+                    .transition_invocation(
                         queued.request.id,
                         InvocationState::Failed,
                         Some(Termination::SpawnFailure { message }),
@@ -260,8 +258,7 @@ impl InvocationService {
         });
         let mut process_group = ProcessGroupGuard::for_child(&child);
         if let Err(error) = self
-            .store
-            .transition(queued.request.id, InvocationState::Running, None, None)
+            .transition_invocation(queued.request.id, InvocationState::Running, None, None)
             .await
         {
             let _ = terminate_child(
@@ -294,8 +291,7 @@ impl InvocationService {
                     ..Default::default()
                 };
                 let _ = self
-                    .store
-                    .transition(
+                    .transition_invocation(
                         queued.request.id,
                         InvocationState::Failed,
                         Some(Termination::Interrupted),
@@ -586,20 +582,19 @@ impl InvocationService {
                 reduction_ms: duration_millis(reduction_started.elapsed()),
                 ..Default::default()
             };
-            self.store
-                .finish_invocation(
-                    queued.request.id,
-                    InvocationCompletion {
-                        state,
-                        termination: termination.clone(),
-                        summary,
-                        metrics,
-                        canonical_arguments,
-                        artifacts,
-                    },
-                )
-                .await
-                .map_err(Into::into)
+            self.finish_invocation(
+                queued.request.id,
+                InvocationCompletion {
+                    state,
+                    termination: termination.clone(),
+                    summary,
+                    metrics,
+                    canonical_arguments,
+                    artifacts,
+                },
+            )
+            .await
+            .map_err(Into::into)
         }
         .await;
 
@@ -634,8 +629,7 @@ impl InvocationService {
                     ..Default::default()
                 };
                 let _ = self
-                    .store
-                    .transition(
+                    .transition_invocation(
                         queued.request.id,
                         terminal_state,
                         Some(termination),
@@ -805,8 +799,7 @@ impl InvocationService {
             return Ok(current);
         }
         match self
-            .store
-            .transition(
+            .transition_invocation(
                 id,
                 InvocationState::Cancelled,
                 Some(Termination::Cancelled),

--- a/crates/bazel-mcp-runner/src/scheduler.rs
+++ b/crates/bazel-mcp-runner/src/scheduler.rs
@@ -3,11 +3,11 @@
 use std::{
     collections::HashMap,
     path::{Path, PathBuf},
-    sync::{Arc, Weak},
+    sync::{Arc, Mutex as StdMutex, MutexGuard, Weak},
 };
 
-use bazel_mcp_types::InvocationId;
-use tokio::sync::{Mutex, OwnedSemaphorePermit, Semaphore};
+use bazel_mcp_types::{InvocationId, InvocationState};
+use tokio::sync::{Mutex, OwnedSemaphorePermit, Semaphore, watch};
 use tokio_util::sync::CancellationToken;
 
 use crate::output_base_lock::OutputBaseWaitStatus;
@@ -19,19 +19,30 @@ pub(crate) struct InvocationScheduler {
     global: Arc<Semaphore>,
     pending: Arc<Semaphore>,
     workspace_locks: Arc<Mutex<HashMap<PathBuf, Weak<Mutex<()>>>>>,
-    output_base_waits: Arc<Mutex<HashMap<InvocationId, Arc<OutputBaseWaitStatus>>>>,
-    live: Arc<Mutex<HashMap<InvocationId, CancellationToken>>>,
+    live: Arc<StdMutex<HashMap<InvocationId, LiveInvocation>>>,
+    active_count: watch::Sender<usize>,
+}
+
+struct LiveInvocation {
+    cancellation: CancellationToken,
+    output_base_wait: Arc<OutputBaseWaitStatus>,
+    lifecycle: watch::Sender<InvocationState>,
 }
 
 impl InvocationScheduler {
     pub(crate) fn new(global_concurrency: usize, maximum_pending: usize) -> Self {
+        let (active_count, _) = watch::channel(0);
         Self {
             global: Arc::new(Semaphore::new(global_concurrency)),
             pending: Arc::new(Semaphore::new(maximum_pending)),
             workspace_locks: Arc::new(Mutex::new(HashMap::new())),
-            output_base_waits: Arc::new(Mutex::new(HashMap::new())),
-            live: Arc::new(Mutex::new(HashMap::new())),
+            live: Arc::new(StdMutex::new(HashMap::new())),
+            active_count,
         }
+    }
+
+    fn live(&self) -> MutexGuard<'_, HashMap<InvocationId, LiveInvocation>> {
+        self.live.lock().unwrap_or_else(|error| error.into_inner())
     }
 
     pub(crate) fn try_acquire_pending(&self) -> Option<OwnedSemaphorePermit> {
@@ -53,37 +64,69 @@ impl InvocationScheduler {
         lock
     }
 
-    pub(crate) async fn register(
+    pub(crate) fn register(
         &self,
         id: InvocationId,
         cancellation: CancellationToken,
         output_base_wait: Arc<OutputBaseWaitStatus>,
+        initial_state: InvocationState,
     ) {
-        self.live.lock().await.insert(id, cancellation);
-        self.output_base_waits
-            .lock()
-            .await
-            .insert(id, output_base_wait);
+        let (lifecycle, _) = watch::channel(initial_state);
+        let mut live = self.live();
+        live.insert(
+            id,
+            LiveInvocation {
+                cancellation,
+                output_base_wait,
+                lifecycle,
+            },
+        );
+        self.active_count.send_replace(live.len());
     }
 
-    pub(crate) async fn remove(&self, id: InvocationId) {
-        self.live.lock().await.remove(&id);
-        self.output_base_waits.lock().await.remove(&id);
+    pub(crate) fn remove(&self, id: InvocationId) {
+        let mut live = self.live();
+        if live.remove(&id).is_some() {
+            self.active_count.send_replace(live.len());
+        }
     }
 
-    pub(crate) async fn cancellation(&self, id: InvocationId) -> Option<CancellationToken> {
-        self.live.lock().await.get(&id).cloned()
+    pub(crate) fn cancellation(&self, id: InvocationId) -> Option<CancellationToken> {
+        self.live()
+            .get(&id)
+            .map(|invocation| invocation.cancellation.clone())
     }
 
-    pub(crate) async fn output_base_wait(
-        &self,
-        id: InvocationId,
-    ) -> Option<Arc<OutputBaseWaitStatus>> {
-        self.output_base_waits.lock().await.get(&id).cloned()
+    pub(crate) fn output_base_wait(&self, id: InvocationId) -> Option<Arc<OutputBaseWaitStatus>> {
+        self.live()
+            .get(&id)
+            .map(|invocation| invocation.output_base_wait.clone())
     }
 
-    pub(crate) async fn cancel_all(&self) -> usize {
-        let cancellations: Vec<_> = self.live.lock().await.values().cloned().collect();
+    pub(crate) fn lifecycle(&self, id: InvocationId) -> Option<watch::Receiver<InvocationState>> {
+        self.live()
+            .get(&id)
+            .map(|invocation| invocation.lifecycle.subscribe())
+    }
+
+    pub(crate) fn lifecycle_state(&self, id: InvocationId) -> Option<InvocationState> {
+        self.live()
+            .get(&id)
+            .map(|invocation| *invocation.lifecycle.borrow())
+    }
+
+    pub(crate) fn publish_state(&self, id: InvocationId, state: InvocationState) {
+        if let Some(invocation) = self.live().get(&id) {
+            invocation.lifecycle.send_replace(state);
+        }
+    }
+
+    pub(crate) fn cancel_all(&self) -> usize {
+        let cancellations: Vec<_> = self
+            .live()
+            .values()
+            .map(|invocation| invocation.cancellation.clone())
+            .collect();
         let count = cancellations.len();
         for cancellation in cancellations {
             cancellation.cancel();
@@ -91,14 +134,28 @@ impl InvocationScheduler {
         count
     }
 
-    pub(crate) async fn active_count(&self) -> usize {
-        self.live.lock().await.len()
+    pub(crate) fn active_count(&self) -> usize {
+        self.live().len()
+    }
+
+    pub(crate) async fn wait_until_idle(&self) {
+        let mut active_count = self.active_count.subscribe();
+        while *active_count.borrow_and_update() > 0 {
+            if active_count.changed().await.is_err() {
+                return;
+            }
+        }
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use std::{path::Path, sync::Arc};
+    use std::{path::Path, sync::Arc, time::Duration};
+
+    use bazel_mcp_types::{InvocationId, InvocationState};
+    use tokio_util::sync::CancellationToken;
+
+    use crate::output_base_lock::OutputBaseWaitStatus;
 
     use super::InvocationScheduler;
 
@@ -116,5 +173,39 @@ mod tests {
 
         assert_eq!(scheduler.workspace_locks.lock().await.len(), 1);
         assert!(Arc::strong_count(&retained) >= 1);
+    }
+
+    #[tokio::test]
+    async fn lifecycle_watch_broadcasts_state_and_idle_without_polling() {
+        let scheduler = InvocationScheduler::new(1, 1);
+        let id = InvocationId::new();
+        scheduler.register(
+            id,
+            CancellationToken::new(),
+            Arc::new(OutputBaseWaitStatus::default()),
+            InvocationState::Queued,
+        );
+        let mut lifecycle = scheduler.lifecycle(id).unwrap();
+        assert_eq!(*lifecycle.borrow_and_update(), InvocationState::Queued);
+
+        scheduler.publish_state(id, InvocationState::Starting);
+        lifecycle.changed().await.unwrap();
+        assert_eq!(*lifecycle.borrow_and_update(), InvocationState::Starting);
+
+        let mut waiting = tokio::spawn({
+            let scheduler = scheduler.clone();
+            async move { scheduler.wait_until_idle().await }
+        });
+        assert!(
+            tokio::time::timeout(Duration::from_millis(20), &mut waiting)
+                .await
+                .is_err()
+        );
+
+        scheduler.publish_state(id, InvocationState::Succeeded);
+        scheduler.remove(id);
+        waiting.await.unwrap();
+        lifecycle.changed().await.unwrap();
+        assert_eq!(*lifecycle.borrow_and_update(), InvocationState::Succeeded);
     }
 }

--- a/crates/bazel-mcp-runner/src/service.rs
+++ b/crates/bazel-mcp-runner/src/service.rs
@@ -13,7 +13,7 @@ use bazel_mcp_policy::{
     validate_workspace,
 };
 use bazel_mcp_reducer::{ReducerPipeline, StarlarkReducerConfig, load_starlark_reducers};
-use bazel_mcp_store::{InvocationPaths, Store, StoreError};
+use bazel_mcp_store::{InvocationCompletion, InvocationPaths, Store, StoreError};
 use bazel_mcp_types::{
     DeferredFailure, DeferredFailureKind, DeferredResultRecord, DeferredResultView,
     DeferredRetrieval, DeferredTerminalState, InvocationId, InvocationRecord, InvocationRequest,
@@ -49,6 +49,7 @@ use bazel_mcp_types::{ArtifactKind, BazelCommand};
 pub(crate) const COMPLETE_BEP_LOG_LIMIT: usize = 2 * 1024 * 1024;
 pub(crate) const FALLBACK_LOG_LIMIT: usize = 8 * 1024 * 1024;
 pub(crate) const BES_COMPLETION_GRACE: Duration = Duration::from_secs(2);
+const DURABLE_LIFECYCLE_RECHECK: Duration = Duration::from_millis(250);
 
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
@@ -353,7 +354,7 @@ impl InvocationService {
             .await?;
         let id = prepared.queued.request.id;
         let result = self.run_prepared(prepared).await;
-        self.scheduler.remove(id).await;
+        self.scheduler.remove(id);
         result
     }
 
@@ -403,7 +404,7 @@ impl InvocationService {
                     );
                 }
             }
-            supervisor.scheduler.remove(id).await;
+            supervisor.scheduler.remove(id);
         });
         Ok(id)
     }
@@ -415,6 +416,24 @@ impl InvocationService {
         cancellation: CancellationToken,
     ) -> Result<InvocationRecord, RunnerError> {
         loop {
+            if let Some(mut lifecycle) = self.scheduler.lifecycle(id) {
+                loop {
+                    if lifecycle.borrow_and_update().is_terminal() {
+                        return Ok(self.store.get_invocation(id).await?);
+                    }
+                    tokio::select! {
+                        () = cancellation.cancelled() => {
+                            return Err(RunnerError::WaitCancelled(id));
+                        }
+                        changed = lifecycle.changed() => {
+                            if changed.is_err() {
+                                break;
+                            }
+                        }
+                    }
+                }
+            }
+
             if self
                 .store
                 .get_invocation_header(id)
@@ -424,9 +443,13 @@ impl InvocationService {
             {
                 return Ok(self.store.get_invocation(id).await?);
             }
+
+            // A restarted service has no in-memory publisher, while another
+            // process may still own the durable invocation. Recheck that rare
+            // fallback at the store generation cadence; live work never polls.
             tokio::select! {
                 () = cancellation.cancelled() => return Err(RunnerError::WaitCancelled(id)),
-                () = tokio::time::sleep(Duration::from_millis(25)) => {}
+                () = tokio::time::sleep(DURABLE_LIFECYCLE_RECHECK) => {}
             }
         }
     }
@@ -555,9 +578,12 @@ impl InvocationService {
             .create_invocation_with_deferred(&stored, deferred.as_ref())
             .await?;
         let output_base_wait = Arc::new(OutputBaseWaitStatus::default());
-        self.scheduler
-            .register(id, cancellation.clone(), output_base_wait.clone())
-            .await;
+        self.scheduler.register(
+            id,
+            cancellation.clone(),
+            output_base_wait.clone(),
+            stored.state,
+        );
 
         Ok(PreparedSubmission {
             queued,
@@ -631,8 +657,7 @@ impl InvocationService {
                 return self.finish_cancelled(id).await;
             }
             if let Err(error) = self
-                .store
-                .transition(id, InvocationState::Starting, None, None)
+                .transition_invocation(id, InvocationState::Starting, None, None)
                 .await
             {
                 let message = self.redactor.redact_bounded(
@@ -647,8 +672,7 @@ impl InvocationService {
                     .is_ok_and(|record| !record.state.is_terminal())
                 {
                     let _ = self
-                        .store
-                        .transition(
+                        .transition_invocation(
                             id,
                             InvocationState::Failed,
                             Some(Termination::SpawnFailure {
@@ -701,8 +725,7 @@ impl InvocationService {
         }
         if current.state == InvocationState::Queued
             && let Err(error) = self
-                .store
-                .transition(id, InvocationState::Starting, None, None)
+                .transition_invocation(id, InvocationState::Starting, None, None)
                 .await
             && !matches!(error, StoreError::State(_))
         {
@@ -712,22 +735,21 @@ impl InvocationService {
         if current.state.is_terminal() {
             return Ok(current);
         }
-        self.store
-            .transition(
-                id,
-                InvocationState::Failed,
-                Some(Termination::SpawnFailure {
-                    message: message.clone(),
-                }),
-                Some(bazel_mcp_types::InvocationSummary {
-                    success: false,
-                    headline: format!("Could not start Bazel: {message}"),
-                    truncated: true,
-                    ..Default::default()
-                }),
-            )
-            .await
-            .map_err(Into::into)
+        self.transition_invocation(
+            id,
+            InvocationState::Failed,
+            Some(Termination::SpawnFailure {
+                message: message.clone(),
+            }),
+            Some(bazel_mcp_types::InvocationSummary {
+                success: false,
+                headline: format!("Could not start Bazel: {message}"),
+                truncated: true,
+                ..Default::default()
+            }),
+        )
+        .await
+        .map_err(Into::into)
     }
 
     async fn materialize_worker_failure(
@@ -760,8 +782,7 @@ impl InvocationService {
             .is_ok_and(|record| !record.state.is_terminal())
         {
             let _ = self
-                .store
-                .transition(
+                .transition_invocation(
                     id,
                     InvocationState::Failed,
                     Some(Termination::SpawnFailure {
@@ -835,11 +856,17 @@ impl InvocationService {
     /// Request cancellation for every invocation owned by this server process.
     /// Used during graceful transport and operating-system shutdown.
     pub async fn cancel_all_active(&self) -> usize {
-        self.scheduler.cancel_all().await
+        self.scheduler.cancel_all()
     }
 
     pub async fn active_invocation_count(&self) -> usize {
-        self.scheduler.active_count().await
+        self.scheduler.active_count()
+    }
+
+    /// Wait until every invocation owned by this process has left the live
+    /// registry. Lifecycle changes wake this future without periodic checks.
+    pub async fn wait_until_idle(&self) {
+        self.scheduler.wait_until_idle().await;
     }
 
     pub async fn cancel_with_reason(
@@ -860,14 +887,13 @@ impl InvocationService {
             let reason = self.redactor.redact_bounded(reason, 1_000);
             self.store.update_cancellation_reason(id, &reason).await?;
         }
-        let cancellation = self.scheduler.cancellation(id).await;
+        let cancellation = self.scheduler.cancellation(id);
         if let Some(cancellation) = &cancellation {
             cancellation.cancel();
         }
         if record.state == InvocationState::Queued {
             match self
-                .store
-                .transition(
+                .transition_invocation(
                     id,
                     InvocationState::Cancelled,
                     Some(Termination::Cancelled),
@@ -922,6 +948,9 @@ impl InvocationService {
     }
 
     pub async fn invocation_state(&self, id: InvocationId) -> Result<InvocationState, RunnerError> {
+        if let Some(state) = self.scheduler.lifecycle_state(id) {
+            return Ok(state);
+        }
         Ok(self.store.get_invocation_header(id).await?.state)
     }
 
@@ -929,8 +958,8 @@ impl InvocationService {
         &self,
         id: InvocationId,
     ) -> Result<InvocationProgress, RunnerError> {
-        let state = self.store.get_invocation_header(id).await?.state;
-        let wait = self.scheduler.output_base_wait(id).await;
+        let state = self.invocation_state(id).await?;
+        let wait = self.scheduler.output_base_wait(id);
         let wait = wait.map(|status| status.snapshot()).unwrap_or_else(|| {
             crate::output_base_lock::OutputBaseWaitSnapshot {
                 active: false,
@@ -944,6 +973,31 @@ impl InvocationService {
             output_base_lock_wait_ms: wait.elapsed_ms,
             output_base_lock_owner: wait.owner,
         })
+    }
+
+    pub(crate) async fn transition_invocation(
+        &self,
+        id: InvocationId,
+        next: InvocationState,
+        termination: Option<Termination>,
+        summary: Option<bazel_mcp_types::InvocationSummary>,
+    ) -> Result<InvocationRecord, StoreError> {
+        let record = self
+            .store
+            .transition(id, next, termination, summary)
+            .await?;
+        self.scheduler.publish_state(id, record.state);
+        Ok(record)
+    }
+
+    pub(crate) async fn finish_invocation(
+        &self,
+        id: InvocationId,
+        completion: InvocationCompletion,
+    ) -> Result<InvocationRecord, StoreError> {
+        let record = self.store.finish_invocation(id, completion).await?;
+        self.scheduler.publish_state(id, record.state);
+        Ok(record)
     }
 
     fn redacted_request(&self, request: &InvocationRequest) -> InvocationRequest {

--- a/crates/bazel-mcp-runner/tests/process.rs
+++ b/crates/bazel-mcp-runner/tests/process.rs
@@ -1287,14 +1287,20 @@ async fn deferred_submission_commits_before_completion_and_survives_wait_cancell
         Err(bazel_mcp_runner::RunnerError::WaitCancelled(found)) if found == id
     ));
 
-    let completed = tokio::time::timeout(
-        Duration::from_secs(3),
-        service.wait(id, CancellationToken::new()),
-    )
-    .await
-    .unwrap()
-    .unwrap();
-    assert_eq!(completed.state, InvocationState::Succeeded);
+    let waiters = (0..64)
+        .map(|_| {
+            let service = service.clone();
+            tokio::spawn(async move { service.wait(id, CancellationToken::new()).await })
+        })
+        .collect::<Vec<_>>();
+    for waiter in waiters {
+        let completed = tokio::time::timeout(Duration::from_secs(3), waiter)
+            .await
+            .unwrap()
+            .unwrap()
+            .unwrap();
+        assert_eq!(completed.state, InvocationState::Succeeded);
+    }
     assert_eq!(
         tokio::fs::read_to_string(&launches)
             .await
@@ -1325,6 +1331,41 @@ async fn deferred_submission_commits_before_completion_and_survives_wait_cancell
             .await
             .is_err()
     );
+}
+
+#[tokio::test]
+async fn wait_uses_durable_recovery_when_no_live_publisher_exists() {
+    let root = tempfile::tempdir().unwrap();
+    let store_root = root.path().join("store");
+    let request = InvocationRequest::new(
+        root.path().join("workspace"),
+        BazelCommand::Build,
+        vec!["//:recovered".into()],
+    );
+    let id = request.id;
+    {
+        let store = Store::open(&store_root).await.unwrap();
+        store
+            .create_invocation(&InvocationRecord::queued(request))
+            .await
+            .unwrap();
+    }
+
+    let service = InvocationService::new(
+        Store::open(&store_root).await.unwrap(),
+        RunnerConfig::default(),
+    )
+    .unwrap();
+    let recovered = tokio::time::timeout(
+        Duration::from_secs(1),
+        service.wait(id, CancellationToken::new()),
+    )
+    .await
+    .unwrap()
+    .unwrap();
+
+    assert_eq!(recovered.state, InvocationState::Interrupted);
+    assert_eq!(service.active_invocation_count().await, 0);
 }
 
 #[tokio::test]

--- a/crates/bazel-mcp-server/src/lib.rs
+++ b/crates/bazel-mcp-server/src/lib.rs
@@ -87,11 +87,14 @@ pub async fn serve(config: ValidatedServerConfig) -> anyhow::Result<()> {
                 "received shutdown signal; cancelling active Bazel invocations"
             );
             service_cancellation.cancel();
-            let deadline = tokio::time::Instant::now() + shutdown_wait;
-            while shutdown_runner.active_invocation_count().await > 0
-                && tokio::time::Instant::now() < deadline
+            if tokio::time::timeout(shutdown_wait, shutdown_runner.wait_until_idle())
+                .await
+                .is_err()
             {
-                tokio::time::sleep(std::time::Duration::from_millis(25)).await;
+                tracing::warn!(
+                    active = shutdown_runner.active_invocation_count().await,
+                    "timed out waiting for active Bazel invocations during shutdown"
+                );
             }
             tracing::info!(
                 active = shutdown_runner.active_invocation_count().await,


### PR DESCRIPTION
## Summary

- replace 25 ms per-waiter lifecycle polling with `tokio::sync::watch` notifications owned by the invocation scheduler
- centralize durable lifecycle transitions so store commits complete before in-process state publication
- wake graceful shutdown from active-invocation count changes instead of polling
- retain a 250 ms durable-store recovery path only when no in-process publisher exists, including restart and cross-process ownership cases
- cover 64 concurrent waiters, notification-driven idle shutdown, and durable restart recovery

## Why

The prior wait and shutdown paths repeatedly read durable state even when the same process already knew about every lifecycle transition. That work scaled with waiter count and invocation duration. The new path gives live waiters an event-driven signal while preserving the store as the authority: state is committed durably first, then published synchronously.

## Benchmark

Five samples of the same deferred process test with 64 concurrent waiters, comparing current `main` to this branch in isolated targets:

| Metric (median) | `main` polling | notifications | Change |
| --- | ---: | ---: | ---: |
| Wall time | 0.58 s | 0.55 s | -5% |
| Instructions retired | 230.3 M | 188.6 M | -18% |
| CPU cycles | 96.8 M | 75.4 M | -22% |

## Validation

- `make test`
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo shear`
- `make mcp-conformance` plus three additional consecutive conformance runs
- Bazel MCP: `//crates/bazel-mcp-runner:unit_test` and `//crates/bazel-mcp-server:unit_test` (2/2 passed)

`make check` completed formatting and clippy; its Nix-wrapped `cargo shear` step could not start because Nix is unavailable locally, so `cargo shear` was run directly and passed.
