### PR TITLE
refactor(server): type inspection and task boundaries

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -405,6 +405,7 @@ name = "bazel-mcp-types"
 version = "0.5.0"
 dependencies = [
  "serde",
+ "serde_json",
  "thiserror",
  "uuid",
 ]

--- a/crates/bazel-mcp-benchmark/src/bin/storage-benchmark.rs
+++ b/crates/bazel-mcp-benchmark/src/bin/storage-benchmark.rs
@@ -676,14 +676,14 @@ async fn benchmark_query(args: &Args) -> anyhow::Result<(QueryMetrics, f64)> {
     let stdout_bytes = std::fs::metadata(&paths.stdout)?.len();
 
     let postprocess_started = Instant::now();
-    let (sample, total, _) = store
+    let total = store.count_query_rows(id).await?;
+    let sample = store
         .page_query_rows(
             id,
             None,
             PageRequest {
-                cursor: None,
-                limit: 3,
-                max_bytes: None,
+                scan_limit: 3,
+                ..PageRequest::new(None, 3)
             },
         )
         .await?;
@@ -706,35 +706,19 @@ async fn benchmark_query(args: &Args) -> anyhow::Result<(QueryMetrics, f64)> {
     let terminal_ms = millis(postprocess_started.elapsed());
 
     let page_started = Instant::now();
-    let (page, total, filtered) = store
-        .page_query_rows(
-            id,
-            None,
-            PageRequest {
-                cursor: None,
-                limit: 100,
-                max_bytes: None,
-            },
-        )
+    let page = store
+        .page_query_rows(id, None, PageRequest::new(None, 100))
         .await?;
     let unfiltered_page_ms = millis(page_started.elapsed());
     anyhow::ensure!(page.items.len() == 100, "unexpected query page length");
     anyhow::ensure!(
-        total == args.query_rows && filtered == total,
+        page.total_count == Some(args.query_rows) && page.filtered_count == page.total_count,
         "wrong query counts"
     );
 
     let continuation_started = Instant::now();
-    let (continued, total, filtered) = store
-        .page_query_rows(
-            id,
-            None,
-            PageRequest {
-                cursor: page.next_cursor,
-                limit: 100,
-                max_bytes: None,
-            },
-        )
+    let continued = store
+        .page_query_rows(id, None, PageRequest::new(page.next_cursor, 100))
         .await?;
     let continuation_page_ms = millis(continuation_started.elapsed());
     anyhow::ensure!(
@@ -742,26 +726,26 @@ async fn benchmark_query(args: &Args) -> anyhow::Result<(QueryMetrics, f64)> {
         "unexpected continuation length"
     );
     anyhow::ensure!(
-        total == args.query_rows && filtered == total,
+        continued.total_count == Some(args.query_rows)
+            && continued.filtered_count == continued.total_count,
         "wrong continuation counts"
     );
 
     let last_value = format!("//benchmark/package:target_{:012}", args.query_rows - 1);
     let filtered_started = Instant::now();
-    let (page, _, filtered) = store
+    let page = store
         .page_query_rows(
             id,
             Some(&last_value),
             PageRequest {
-                cursor: None,
-                limit: 100,
-                max_bytes: None,
+                scan_limit: u32::MAX,
+                ..PageRequest::new(None, 100)
             },
         )
         .await?;
     let filtered_page_ms = millis(filtered_started.elapsed());
     anyhow::ensure!(
-        page.items.len() == 1 && filtered == 1,
+        page.items.len() == 1 && page.filtered_count == Some(1),
         "filtered query mismatch"
     );
 

--- a/crates/bazel-mcp-reducer-cases/src/replay.rs
+++ b/crates/bazel-mcp-reducer-cases/src/replay.rs
@@ -8,7 +8,8 @@ use bazel_mcp_reducer::{
     normalize_terminal_text, parse_go_diagnostic, reduce_artifacts, reduce_invocation,
 };
 use bazel_mcp_types::{
-    Artifact, Diagnostic, DiagnosticCategory, DiagnosticLocation, InvocationSummary, Severity,
+    Artifact, Diagnostic, DiagnosticCategory, DiagnosticLocation, InspectHint, InvocationSummary,
+    Severity,
 };
 use serde::{Deserialize, Serialize};
 
@@ -226,7 +227,7 @@ pub fn replay_with_evidence(case: &LoadedCase, evidence: &EvidenceSpec) -> Resul
         }
         finalize_diagnostics(&mut summary, budget);
         if !summary.success && summary.inspect_hint.is_none() {
-            summary.inspect_hint = Some("test_log".to_owned());
+            summary.inspect_hint = Some(InspectHint::TestLog);
         }
     }
 

--- a/crates/bazel-mcp-reducer-cases/src/semantics.rs
+++ b/crates/bazel-mcp-reducer-cases/src/semantics.rs
@@ -41,7 +41,10 @@ pub fn observe_replay(output: &ReplayOutput, exit_code: i32, raw_text: String) -
         },
         exit_code: Some(exit_code),
         headline: output.summary.headline.clone(),
-        inspect_hint: output.summary.inspect_hint.clone(),
+        inspect_hint: output
+            .summary
+            .inspect_hint
+            .map(|hint| hint.as_str().to_owned()),
         diagnostics: output.summary.diagnostics.clone(),
         artifacts: output.artifacts.clone(),
         visible_bytes,

--- a/crates/bazel-mcp-reducer/src/build.rs
+++ b/crates/bazel-mcp-reducer/src/build.rs
@@ -3,8 +3,8 @@ use bazel_mcp_bep::{
     view::{BuildEventIdView, FileView, NamedSetOfFilesView, build_event, build_event_id, file},
 };
 use bazel_mcp_types::{
-    Artifact, ArtifactKind, Diagnostic, DiagnosticCategory, InvocationSummary, Severity,
-    TargetCounts, TargetResult, TestCounts, TestResult, TestStatus,
+    Artifact, ArtifactKind, Diagnostic, DiagnosticCategory, InspectHint, InvocationSummary,
+    Severity, TargetCounts, TargetResult, TestCounts, TestResult, TestStatus,
 };
 use std::collections::{BTreeMap, BTreeSet};
 
@@ -318,7 +318,7 @@ impl BepAccumulator {
             query_result_count: None,
             elapsed_ms,
             truncated: self.truncated,
-            inspect_hint: self.truncated.then(|| "diagnostics".to_owned()),
+            inspect_hint: self.truncated.then_some(InspectHint::Diagnostics),
         };
         finalize_diagnostics(&mut summary, budget);
         StreamReductionOutput {
@@ -655,7 +655,7 @@ pub fn finalize_diagnostics(summary: &mut InvocationSummary, budget: Budget) {
     summary.diagnostics = diagnostics;
     summary.truncated |= truncated;
     if summary.truncated {
-        summary.inspect_hint = Some("diagnostics".to_owned());
+        summary.inspect_hint = Some(InspectHint::Diagnostics);
     }
     if !summary.success
         && let Some(first) = summary.diagnostics.first()

--- a/crates/bazel-mcp-reducer/src/extension.rs
+++ b/crates/bazel-mcp-reducer/src/extension.rs
@@ -1,6 +1,6 @@
 use std::{cmp::Reverse, collections::BTreeSet, sync::Arc};
 
-use bazel_mcp_types::{Diagnostic, InvocationSummary};
+use bazel_mcp_types::{Diagnostic, InspectHint, InvocationSummary};
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
@@ -261,7 +261,7 @@ impl ReducerPipeline {
         }
         if !report.applied.is_empty() && context.input_truncated {
             summary.truncated = true;
-            summary.inspect_hint = Some("log".to_owned());
+            summary.inspect_hint = Some(InspectHint::Log);
         }
         report
     }

--- a/crates/bazel-mcp-reducer/src/starlark.rs
+++ b/crates/bazel-mcp-reducer/src/starlark.rs
@@ -489,7 +489,7 @@ fn alloc_invocation_summary<'v>(heap: Heap<'v>, summary: &InvocationSummary) -> 
         ("truncated", heap.alloc(summary.truncated)),
         (
             "inspect_hint",
-            alloc_optional_str(heap, summary.inspect_hint.as_deref()),
+            alloc_optional_str(heap, summary.inspect_hint.map(|hint| hint.as_str())),
         ),
     ]))
 }
@@ -1244,7 +1244,7 @@ def reduce(ctx):
         baseline["coverage"]["coverage_percent"] != 75.0 or
         baseline["query_sample"][0]["ordinal"] != 7 or
         baseline["query_result_count"] != 9 or
-        baseline["inspect_hint"] != "inspect hint"
+        baseline["inspect_hint"] != "log"
     ):
         return patch([diagnostic("context mismatch")])
     return patch([
@@ -1349,7 +1349,7 @@ def reduce(ctx):
                 query_result_count: Some(9),
                 elapsed_ms: 41,
                 truncated: false,
-                inspect_hint: Some("inspect hint".to_owned()),
+                inspect_hint: Some(bazel_mcp_types::InspectHint::Log),
             },
         };
         let mut summary = InvocationSummary::default();

--- a/crates/bazel-mcp-runner/src/execution.rs
+++ b/crates/bazel-mcp-runner/src/execution.rs
@@ -18,9 +18,9 @@ use bazel_mcp_reducer::{
 };
 use bazel_mcp_store::{InvocationCompletion, InvocationPaths, StoreError};
 use bazel_mcp_types::{
-    BazelCommand, CommandClass, Diagnostic, DiagnosticCategory, InvocationId, InvocationMetrics,
-    InvocationRecord, InvocationRequest, InvocationState, PageRequest, Severity, Termination,
-    TestStatus,
+    BazelCommand, CommandClass, Diagnostic, DiagnosticCategory, InspectHint, InvocationId,
+    InvocationMetrics, InvocationRecord, InvocationRequest, InvocationState, PageRequest, Severity,
+    Termination, TestStatus,
 };
 use tokio::{process::Command, task};
 use tokio_util::sync::CancellationToken;
@@ -287,7 +287,7 @@ impl InvocationService {
                     success: false,
                     headline: format!("Could not record Bazel execution state: {message}"),
                     truncated: true,
-                    inspect_hint: Some("log".to_owned()),
+                    inspect_hint: Some(InspectHint::Log),
                     ..Default::default()
                 };
                 let _ = self
@@ -381,23 +381,23 @@ impl InvocationService {
             };
             let (query_row_count, query_sample) =
                 if queued.request.command.class() == CommandClass::Query {
+                    let query_row_count = self.store.count_query_rows(queued.request.id).await?;
                     let redactor = self.redactor.clone();
-                    let (page, total, _) = self
+                    let page = self
                         .store
                         .page_query_rows_mapped_into(
                             queued.request.id,
                             None,
                             PageRequest {
-                                cursor: None,
-                                limit: 3,
-                                max_bytes: None,
+                                scan_limit: 3,
+                                ..PageRequest::new(None, 3)
                             },
                             move |value, output| {
                                 redactor.redact_bounded_into(value, 4 * 1024, output);
                             },
                         )
                         .await?;
-                    (total, page.items)
+                    (query_row_count, page.items)
                 } else {
                     (0, Vec::new())
                 };
@@ -480,7 +480,8 @@ impl InvocationService {
             }
             if queued.request.command.class() == CommandClass::Query && exit_code == Some(0) {
                 summary.headline = format!("Bazel query returned {query_row_count} rows");
-                summary.inspect_hint = (query_row_count > 0).then(|| "query_results".to_owned());
+                summary.inspect_hint =
+                    (query_row_count > 0).then_some(InspectHint::QueryResults);
                 summary.query_result_count = Some(query_row_count);
                 summary.query_sample = query_sample;
             } else if matches!(
@@ -494,7 +495,7 @@ impl InvocationService {
                     summary.headline = bounded_text(&excerpt, 1_000);
                     if excerpt.len() > 1_000 {
                         summary.truncated = true;
-                        summary.inspect_hint = Some("log".to_owned());
+                        summary.inspect_hint = Some(InspectHint::Log);
                     }
                 }
             }
@@ -558,16 +559,16 @@ impl InvocationService {
                 summary.headline = headline;
             }
             if !summary.success && summary.inspect_hint.is_none() {
-                let view = if summary
+                let hint = if summary
                     .tests
                     .iter()
                     .any(|test| test.status != TestStatus::Passed && test.test_log_available)
                 {
-                    "test_log"
+                    InspectHint::TestLog
                 } else {
-                    "log"
+                    InspectHint::Log
                 };
-                summary.inspect_hint = Some(view.to_owned());
+                summary.inspect_hint = Some(hint);
             }
             self.sanitize_summary(queued.request.id, &queued.request.workspace, &mut summary);
             let metrics = InvocationMetrics {
@@ -625,7 +626,7 @@ impl InvocationService {
                     headline: format!("Could not finish processing Bazel results: {message}"),
                     elapsed_ms: bazel_wall_ms,
                     truncated: true,
-                    inspect_hint: Some("log".to_owned()),
+                    inspect_hint: Some(InspectHint::Log),
                     ..Default::default()
                 };
                 let _ = self
@@ -939,7 +940,7 @@ pub(crate) fn finalize_with_custom_notices(
     summary.diagnostics.extend(notices);
     if notice_summary.truncated {
         summary.truncated = true;
-        summary.inspect_hint = Some("diagnostics".to_owned());
+        summary.inspect_hint = Some(InspectHint::Diagnostics);
     }
 }
 
@@ -1021,7 +1022,7 @@ pub(crate) fn fallback_summary(
         diagnostics,
         elapsed_ms,
         truncated: true,
-        inspect_hint: Some("log".to_owned()),
+        inspect_hint: Some(InspectHint::Log),
         ..Default::default()
     }
 }

--- a/crates/bazel-mcp-runner/src/inspection.rs
+++ b/crates/bazel-mcp-runner/src/inspection.rs
@@ -10,8 +10,9 @@ use base64::{Engine, engine::general_purpose::URL_SAFE_NO_PAD};
 use bazel_mcp_reducer::normalize_terminal_text;
 use bazel_mcp_store::{InvocationHeader, InvocationPaths, StoreError};
 use bazel_mcp_types::{
-    ArtifactKind, BazelCommand, CommandClass, InvocationId, InvocationState, PageRequest,
-    Termination,
+    ArtifactKind, BazelCommand, CommandClass, InspectCoverageItem, InspectCoverageSummary,
+    InspectCoverageUnavailable, InspectMetrics, InspectPayload, InspectResult, InspectSummary,
+    InspectView, InvocationId, InvocationLedgerEntry, InvocationState, PageRequest, Termination,
 };
 use serde::{Deserialize, Serialize};
 use tokio::io::{AsyncBufReadExt, BufReader};
@@ -22,21 +23,6 @@ use crate::{
     service::{InvocationService, RunnerError, bounded_text},
 };
 
-#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]
-#[serde(rename_all = "snake_case")]
-pub enum InspectView {
-    Summary,
-    Metrics,
-    Diagnostics,
-    Tests,
-    TestLog,
-    Coverage,
-    Artifacts,
-    QueryResults,
-    Log,
-    Invocations,
-}
-
 #[derive(Clone, Debug)]
 pub struct InspectRequest {
     pub invocation_id: Option<InvocationId>,
@@ -46,8 +32,8 @@ pub struct InspectRequest {
     pub view: InspectView,
     pub cursor: Option<String>,
     pub filter: Option<String>,
-    pub limit: u32,
-    pub max_bytes: usize,
+    pub item_limit: u32,
+    pub scan_limit: u32,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -63,6 +49,13 @@ pub(crate) struct EvidenceRecord {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub(crate) label: Option<String>,
     pub(crate) text: String,
+}
+
+pub(crate) struct EvidencePage {
+    pub(crate) items: Vec<String>,
+    pub(crate) item_cursors: Vec<String>,
+    pub(crate) truncated: bool,
+    pub(crate) next_cursor: Option<String>,
 }
 
 impl LogCursor {
@@ -94,84 +87,68 @@ impl LogCursor {
     }
 }
 
-#[derive(Clone, Debug, Serialize)]
-pub struct InspectResult {
-    pub invocation_id: Option<InvocationId>,
-    pub view: InspectView,
-    pub items: serde_json::Value,
-    pub total_count: Option<u64>,
-    pub filtered_count: Option<u64>,
-    pub next_cursor: Option<String>,
-    pub truncated: bool,
-}
-
 impl InvocationService {
     pub async fn inspect(&self, request: InspectRequest) -> Result<InspectResult, RunnerError> {
         if request.view == InspectView::Invocations {
-            let mut limit = request.limit.clamp(1, 100);
-            loop {
-                let page = self
-                    .store
-                    .list_invocations(
-                        request.workspace.as_deref(),
-                        request.state,
-                        request.command.as_ref(),
-                        PageRequest {
-                            cursor: request.cursor.clone(),
-                            limit,
-                            max_bytes: None,
-                        },
-                    )
-                    .await?;
-                let result = InspectResult {
-                    invocation_id: None,
-                    view: request.view,
-                    items: serde_json::Value::Array(
-                        page.items.iter().map(invocation_ledger_row).collect(),
-                    ),
-                    total_count: None,
-                    filtered_count: None,
-                    next_cursor: page.next_cursor,
-                    truncated: page.truncated,
-                };
-                if serialized_len(&result)? <= request.max_bytes || limit == 1 {
-                    return enforce_inspect_budget(result, request.max_bytes);
-                }
-                limit = (limit / 2).max(1);
-            }
+            let page = self
+                .store
+                .list_invocations(
+                    request.workspace.as_deref(),
+                    request.state,
+                    request.command.as_ref(),
+                    PageRequest {
+                        cursor: request.cursor.clone(),
+                        item_limit: request.item_limit.clamp(1, 100),
+                        scan_limit: request.scan_limit,
+                    },
+                )
+                .await?;
+            return Ok(InspectResult::new(
+                None,
+                InspectPayload::Invocations(page.items.iter().map(invocation_ledger_row).collect()),
+                page.total_count,
+                page.filtered_count,
+                page.next_cursor,
+                page.truncated,
+                page.item_cursors,
+            )
+            .with_start_cursor(request.cursor));
         }
 
         let id = request.invocation_id.ok_or(StoreError::InvalidCursor)?;
         let record = self.store.get_invocation(id).await?;
         let page_request = PageRequest {
             cursor: request.cursor.clone(),
-            limit: request.limit.clamp(1, 100),
-            max_bytes: Some(request.max_bytes.saturating_sub(512)),
+            item_limit: request.item_limit.clamp(1, 100),
+            scan_limit: request.scan_limit,
         };
         let paths = self.store.paths_for(&record);
-        let (items, total_count, filtered_count, next_cursor, truncated) = match request.view {
+        let result = match request.view {
             InspectView::Summary => {
                 let items = record.summary.as_ref().map_or_else(Vec::new, |summary| {
-                    vec![serde_json::json!({
-                        "success": summary.success,
-                        "headline": summary.headline,
-                        "targets": summary.target_counts,
-                        "tests": summary.test_counts,
-                        "diagnostics": summary.diagnostics,
-                        "coverage": summary.coverage.as_ref().map(|coverage| serde_json::json!({
-                            "lines_found": coverage.lines_found,
-                            "lines_hit": coverage.lines_hit,
-                            "coverage_percent": coverage.coverage_percent,
-                        })),
-                        "query_result_count": summary.query_result_count,
-                        "query_sample": summary.query_sample,
-                        "elapsed_ms": summary.elapsed_ms,
-                        "truncated": summary.truncated,
-                        "inspect_hint": summary.inspect_hint,
-                    })]
+                    vec![InspectSummary {
+                        success: summary.success,
+                        headline: summary.headline.clone(),
+                        targets: summary.target_counts.clone(),
+                        tests: summary.test_counts.clone(),
+                        diagnostics: summary.diagnostics.clone(),
+                        coverage: summary.coverage.as_ref().map(|coverage| {
+                            InspectCoverageSummary {
+                                lines_found: coverage.lines_found,
+                                lines_hit: coverage.lines_hit,
+                                coverage_percent: coverage.coverage_percent,
+                            }
+                        }),
+                        query_result_count: summary.query_result_count,
+                        query_sample: summary.query_sample.clone(),
+                        elapsed_ms: summary.elapsed_ms,
+                        truncated: summary.truncated,
+                        inspect_hint: summary.inspect_hint,
+                    }]
                 });
-                (
-                    serde_json::to_value(items)?,
+                InspectResult::new(
+                    Some(id),
+                    InspectPayload::Summary(items),
                     Some(u64::from(record.summary.is_some())),
                     Some(u64::from(record.summary.is_some())),
                     None,
@@ -179,61 +156,73 @@ impl InvocationService {
                         .summary
                         .as_ref()
                         .is_some_and(|summary| summary.truncated),
+                    Vec::new(),
                 )
             }
-            InspectView::Metrics => {
-                let items = vec![serde_json::json!({
-                    "state": record.state,
-                    "requested_at_ms": record.request.requested_at_ms,
-                    "started_at_ms": record.started_at_ms,
-                    "finished_at_ms": record.finished_at_ms,
-                    "termination": record.termination,
-                    "metrics": record.metrics,
-                })];
-                (serde_json::to_value(items)?, Some(1), Some(1), None, false)
-            }
+            InspectView::Metrics => InspectResult::new(
+                Some(id),
+                InspectPayload::Metrics(vec![InspectMetrics {
+                    state: record.state,
+                    requested_at_ms: record.request.requested_at_ms,
+                    started_at_ms: record.started_at_ms,
+                    finished_at_ms: record.finished_at_ms,
+                    termination: record.termination.clone(),
+                    metrics: record.metrics.clone(),
+                }]),
+                Some(1),
+                Some(1),
+                None,
+                false,
+                Vec::new(),
+            ),
             InspectView::Diagnostics => {
-                let (page, total, filtered) = self
+                let page = self
                     .store
                     .page_diagnostics(id, request.filter.as_deref(), page_request)
                     .await?;
-                (
-                    serde_json::to_value(page.items)?,
-                    Some(total),
-                    Some(filtered),
+                InspectResult::new(
+                    Some(id),
+                    InspectPayload::Diagnostics(page.items),
+                    page.total_count,
+                    page.filtered_count,
                     page.next_cursor,
                     page.truncated,
+                    page.item_cursors,
                 )
             }
             InspectView::Tests => {
-                let (page, total, filtered) = self
+                let page = self
                     .store
                     .page_tests(id, request.filter.as_deref(), page_request)
                     .await?;
-                (
-                    serde_json::to_value(page.items)?,
-                    Some(total),
-                    Some(filtered),
+                InspectResult::new(
+                    Some(id),
+                    InspectPayload::Tests(page.items),
+                    page.total_count,
+                    page.filtered_count,
                     page.next_cursor,
                     page.truncated,
+                    page.item_cursors,
                 )
             }
             InspectView::Artifacts => {
-                let (page, total, filtered) = self
+                let page = self
                     .store
                     .page_artifacts(id, request.filter.as_deref(), page_request)
                     .await?;
-                (
-                    serde_json::to_value(page.items)?,
-                    Some(total),
-                    Some(filtered),
+                InspectResult::new(
+                    Some(id),
+                    InspectPayload::Artifacts(page.items),
+                    page.total_count,
+                    page.filtered_count,
                     page.next_cursor,
                     page.truncated,
+                    page.item_cursors,
                 )
             }
             InspectView::QueryResults => {
                 let redactor = self.redactor.clone();
-                let (page, total, filtered) = self
+                let page = self
                     .store
                     .page_query_rows_mapped_into(
                         id,
@@ -244,108 +233,116 @@ impl InvocationService {
                         },
                     )
                     .await?;
-                (
-                    serde_json::to_value(page.items)?,
-                    Some(total),
-                    Some(filtered),
+                InspectResult::new(
+                    Some(id),
+                    InspectPayload::QueryResults(page.items),
+                    page.total_count,
+                    page.filtered_count,
                     page.next_cursor,
                     page.truncated,
+                    page.item_cursors,
                 )
             }
             InspectView::Coverage => {
-                let (page, total, filtered) = self
+                let page = self
                     .store
                     .page_coverage(id, request.filter.as_deref(), page_request)
                     .await?;
-                let mut items = serde_json::to_value(page.items)?;
-                let mut total = total;
-                let mut filtered = filtered;
-                if items.as_array().is_some_and(Vec::is_empty) {
-                    let (artifacts, _, _) = self
+                let mut items = page
+                    .items
+                    .into_iter()
+                    .map(InspectCoverageItem::File)
+                    .collect::<Vec<_>>();
+                let mut total_count = page.total_count;
+                let mut filtered_count = page.filtered_count;
+                let mut next_cursor = page.next_cursor;
+                let mut truncated = page.truncated;
+                let mut item_cursors = page.item_cursors;
+                if items.is_empty() {
+                    let artifacts = self
                         .store
                         .page_artifacts(
                             id,
                             request.filter.as_deref(),
                             PageRequest {
                                 cursor: None,
-                                limit: request.limit,
-                                max_bytes: Some(request.max_bytes.saturating_sub(512)),
+                                item_limit: request.item_limit,
+                                scan_limit: request.scan_limit,
                             },
                         )
                         .await?;
-                    let unavailable = artifacts
-                        .items
-                        .into_iter()
-                        .filter(|artifact| {
-                            artifact.kind == ArtifactKind::Coverage && !artifact.locally_available
-                        })
-                        .map(|artifact| {
-                            serde_json::json!({
-                                "availability_reason": "remote_artifact_unavailable",
-                                "artifact": artifact,
-                            })
-                        })
-                        .collect::<Vec<_>>();
-                    let unavailable = if unavailable.is_empty() {
-                        vec![serde_json::json!({
-                            "availability_reason": "coverage_artifact_not_found",
-                        })]
-                    } else {
-                        unavailable
-                    };
-                    total = unavailable.len() as u64;
-                    filtered = total;
-                    items = serde_json::Value::Array(unavailable);
+                    items.clear();
+                    item_cursors.clear();
+                    for (artifact, cursor) in
+                        artifacts.items.into_iter().zip(artifacts.item_cursors)
+                    {
+                        if artifact.kind == ArtifactKind::Coverage && !artifact.locally_available {
+                            items.push(InspectCoverageItem::Unavailable(
+                                InspectCoverageUnavailable {
+                                    availability_reason: "remote_artifact_unavailable",
+                                    artifact: Some(artifact),
+                                },
+                            ));
+                            item_cursors.push(cursor);
+                        }
+                    }
+                    if items.is_empty() {
+                        items.push(InspectCoverageItem::Unavailable(
+                            InspectCoverageUnavailable {
+                                availability_reason: "coverage_artifact_not_found",
+                                artifact: None,
+                            },
+                        ));
+                    }
+                    total_count = Some(items.len() as u64);
+                    filtered_count = total_count;
+                    next_cursor = artifacts.next_cursor;
+                    truncated = artifacts.truncated;
                 }
-                (
-                    items,
-                    Some(total),
-                    Some(filtered),
-                    page.next_cursor,
-                    page.truncated,
+                InspectResult::new(
+                    Some(id),
+                    InspectPayload::Coverage(items),
+                    total_count,
+                    filtered_count,
+                    next_cursor,
+                    truncated,
+                    item_cursors,
                 )
             }
             InspectView::Log => {
-                let (items, truncated, next_cursor) = self
+                let page = self
                     .read_evidence_page(&paths.evidence, &paths, &request)
                     .await?;
-                (
-                    serde_json::to_value(items)?,
+                InspectResult::new(
+                    Some(id),
+                    InspectPayload::Log(page.items),
                     None,
                     None,
-                    next_cursor,
-                    truncated,
+                    page.next_cursor,
+                    page.truncated,
+                    page.item_cursors,
                 )
             }
             InspectView::TestLog => {
-                let (items, truncated, next_cursor) = if paths.test_log_evidence.exists() {
+                let page = if paths.test_log_evidence.exists() {
                     self.read_evidence_page(&paths.test_log_evidence, &paths, &request)
                         .await?
                 } else {
                     self.read_test_log_unavailable_page(id, &request).await?
                 };
-                (
-                    serde_json::to_value(items)?,
+                InspectResult::new(
+                    Some(id),
+                    InspectPayload::TestLog(page.items),
                     None,
                     None,
-                    next_cursor,
-                    truncated,
+                    page.next_cursor,
+                    page.truncated,
+                    page.item_cursors,
                 )
             }
             InspectView::Invocations => unreachable!("handled above"),
         };
-        enforce_inspect_budget(
-            InspectResult {
-                invocation_id: Some(id),
-                view: request.view,
-                items,
-                total_count,
-                filtered_count,
-                next_cursor,
-                truncated,
-            },
-            request.max_bytes,
-        )
+        Ok(result.with_start_cursor(request.cursor))
     }
 
     pub(crate) async fn persist_failure_evidence(
@@ -377,7 +374,7 @@ impl InvocationService {
         path: &Path,
         paths: &InvocationPaths,
         request: &InspectRequest,
-    ) -> Result<(Vec<String>, bool, Option<String>), RunnerError> {
+    ) -> Result<EvidencePage, RunnerError> {
         let invocation_id = request.invocation_id.ok_or(StoreError::InvalidCursor)?;
         let start = request
             .cursor
@@ -421,7 +418,7 @@ impl InvocationService {
         &self,
         invocation_id: InvocationId,
         request: &InspectRequest,
-    ) -> Result<(Vec<String>, bool, Option<String>), RunnerError> {
+    ) -> Result<EvidencePage, RunnerError> {
         let start = request
             .cursor
             .as_deref()
@@ -435,26 +432,22 @@ impl InvocationService {
             })
             .transpose()?
             .map_or(0, |cursor| cursor.next_record);
-        let maximum_bytes = request.max_bytes.saturating_sub(512).max(1);
-        let maximum_items = usize::try_from(request.limit.clamp(1, 100)).unwrap_or(100);
+        let maximum_items = usize::try_from(request.item_limit.clamp(1, 100)).unwrap_or(100);
+        let maximum_scanned =
+            usize::try_from(request.scan_limit.clamp(request.item_limit.max(1), 10_000))
+                .unwrap_or(10_000);
         let filter = request.filter.as_deref().map(str::to_ascii_lowercase);
         let mut items = Vec::new();
-        let mut used_bytes = 2_usize;
+        let mut item_cursors = Vec::new();
         let mut reason_index = 0_u64;
+        let mut next_record = start;
+        let mut scanned = 0_usize;
         let mut storage_cursor = None;
 
         loop {
-            let (page, _, _) = self
+            let page = self
                 .store
-                .page_tests(
-                    invocation_id,
-                    None,
-                    PageRequest {
-                        cursor: storage_cursor,
-                        limit: 100,
-                        max_bytes: Some(128 * 1024),
-                    },
-                )
+                .page_tests(invocation_id, None, PageRequest::new(storage_cursor, 100))
                 .await?;
             for test in page.items {
                 let Some(reason) = test.test_log_unavailable_reason else {
@@ -465,24 +458,28 @@ impl InvocationService {
                 if index < start {
                     continue;
                 }
+                if scanned == maximum_scanned {
+                    let next_cursor = LogCursor {
+                        invocation_id,
+                        view: request.view,
+                        next_record,
+                        filter: request.filter.clone(),
+                    }
+                    .encode()?;
+                    return Ok(EvidencePage {
+                        items,
+                        item_cursors,
+                        truncated: true,
+                        next_cursor: Some(next_cursor),
+                    });
+                }
                 let text = self
                     .redactor
                     .redact_bounded(&format!("{}: {reason}", test.label), 4 * 1024);
-                if !filter
+                let matches = filter
                     .as_ref()
-                    .is_none_or(|filter| text.to_ascii_lowercase().contains(filter))
-                {
-                    continue;
-                }
-                let item_bytes = serde_json::to_vec(&text)?.len();
-                let separator = usize::from(!items.is_empty());
-                if items.len() == maximum_items
-                    || (!items.is_empty()
-                        && used_bytes
-                            .saturating_add(separator)
-                            .saturating_add(item_bytes)
-                            > maximum_bytes)
-                {
+                    .is_none_or(|filter| text.to_ascii_lowercase().contains(filter));
+                if matches && items.len() == maximum_items {
                     let next_cursor = LogCursor {
                         invocation_id,
                         view: request.view,
@@ -490,15 +487,34 @@ impl InvocationService {
                         filter: request.filter.clone(),
                     }
                     .encode()?;
-                    return Ok((items, true, Some(next_cursor)));
+                    return Ok(EvidencePage {
+                        items,
+                        item_cursors,
+                        truncated: true,
+                        next_cursor: Some(next_cursor),
+                    });
                 }
-                used_bytes = used_bytes
-                    .saturating_add(separator)
-                    .saturating_add(item_bytes);
-                items.push(text);
+                scanned = scanned.saturating_add(1);
+                next_record = index.saturating_add(1);
+                if matches {
+                    let cursor = LogCursor {
+                        invocation_id,
+                        view: request.view,
+                        next_record,
+                        filter: request.filter.clone(),
+                    }
+                    .encode()?;
+                    items.push(text);
+                    item_cursors.push(cursor);
+                }
             }
             if !page.truncated {
-                return Ok((items, false, None));
+                return Ok(EvidencePage {
+                    items,
+                    item_cursors,
+                    truncated: false,
+                    next_cursor: None,
+                });
             }
             storage_cursor = page.next_cursor;
         }
@@ -510,18 +526,25 @@ pub(crate) fn page_evidence_records(
     start: u64,
     request: &InspectRequest,
     invocation_id: InvocationId,
-) -> Result<(Vec<String>, bool, Option<String>), RunnerError> {
-    let maximum_bytes = request.max_bytes.saturating_sub(512).max(1);
-    let maximum_items = usize::try_from(request.limit.clamp(1, 100)).unwrap_or(100);
+) -> Result<EvidencePage, RunnerError> {
+    let maximum_items = usize::try_from(request.item_limit.clamp(1, 100)).unwrap_or(100);
+    let maximum_scanned =
+        usize::try_from(request.scan_limit.clamp(request.item_limit.max(1), 10_000))
+            .unwrap_or(10_000);
     let filter = request.filter.as_deref().map(str::to_ascii_lowercase);
     let mut items = Vec::new();
-    let mut used_bytes = 2_usize;
+    let mut item_cursors = Vec::new();
     let mut next_record = start;
+    let mut scanned = 0_usize;
     let mut truncated = false;
     for (index, record) in records.enumerate() {
         let index = u64::try_from(index).unwrap_or(u64::MAX);
         if index < start {
             continue;
+        }
+        if scanned == maximum_scanned {
+            truncated = true;
+            break;
         }
         let matches = filter.as_ref().is_none_or(|filter| {
             record.text.to_ascii_lowercase().contains(filter)
@@ -530,28 +553,24 @@ pub(crate) fn page_evidence_records(
                     .as_deref()
                     .is_some_and(|label| label.to_ascii_lowercase().contains(filter))
         });
-        if !matches {
-            next_record = index.saturating_add(1);
-            continue;
-        }
-        let item_bytes = serde_json::to_vec(&record.text)?.len();
-        let separator = usize::from(!items.is_empty());
-        if items.len() == maximum_items
-            || (!items.is_empty()
-                && used_bytes
-                    .saturating_add(separator)
-                    .saturating_add(item_bytes)
-                    > maximum_bytes)
-        {
+        if matches && items.len() == maximum_items {
             next_record = index;
             truncated = true;
             break;
         }
-        used_bytes = used_bytes
-            .saturating_add(separator)
-            .saturating_add(item_bytes);
-        items.push(record.text);
+        scanned = scanned.saturating_add(1);
         next_record = index.saturating_add(1);
+        if matches {
+            let cursor = LogCursor {
+                invocation_id,
+                view: request.view,
+                next_record,
+                filter: request.filter.clone(),
+            }
+            .encode()?;
+            items.push(record.text);
+            item_cursors.push(cursor);
+        }
     }
     let next_cursor = truncated
         .then_some(LogCursor {
@@ -562,7 +581,12 @@ pub(crate) fn page_evidence_records(
         })
         .map(|cursor| cursor.encode())
         .transpose()?;
-    Ok((items, truncated, next_cursor))
+    Ok(EvidencePage {
+        items,
+        item_cursors,
+        truncated,
+        next_cursor,
+    })
 }
 
 pub(crate) fn should_persist_failure_evidence(command: &BazelCommand, failed: bool) -> bool {
@@ -663,7 +687,7 @@ fn failure_evidence_priority(line: &str) -> Option<u8> {
     }
 }
 
-fn invocation_ledger_row(record: &InvocationHeader) -> serde_json::Value {
+fn invocation_ledger_row(record: &InvocationHeader) -> InvocationLedgerEntry {
     let arguments = record
         .request
         .arguments
@@ -675,114 +699,31 @@ fn invocation_ledger_row(record: &InvocationHeader) -> serde_json::Value {
         Some(Termination::Exit { code }) => Some(code),
         _ => None,
     };
-    serde_json::json!({
-        "invocation_id": record.request.id,
-        "workspace": bounded_text(&record.request.workspace.to_string_lossy(), 256),
-        "state": record.state,
-        "command": record.request.command,
-        "arguments": arguments,
-        "arguments_truncated": record.request.arguments.len() > 3,
-        "requested_at_ms": record.request.requested_at_ms,
-        "finished_at_ms": record.finished_at_ms,
-        "exit_code": exit_code,
-        "duration_ms": record.metrics.bazel_wall_ms,
-        "headline": record
+    InvocationLedgerEntry {
+        invocation_id: record.request.id,
+        workspace: bounded_text(&record.request.workspace.to_string_lossy(), 256),
+        state: record.state,
+        command: record.request.command.clone(),
+        arguments,
+        arguments_truncated: record.request.arguments.len() > 3,
+        requested_at_ms: record.request.requested_at_ms,
+        finished_at_ms: record.finished_at_ms,
+        exit_code,
+        duration_ms: record.metrics.bazel_wall_ms,
+        headline: record
             .summary
             .as_ref()
             .map(|summary| bounded_text(&summary.headline, 256)),
-        "targets": record.summary.as_ref().map(|summary| &summary.target_counts),
-        "tests": record.summary.as_ref().map(|summary| &summary.test_counts),
-        "raw_output_bytes": record.metrics.raw_output_bytes,
-        "model_visible_bytes": record.metrics.model_visible_bytes,
-        "inspect_calls": record.metrics.inspect_calls,
-    })
-}
-
-fn enforce_inspect_budget(
-    mut result: InspectResult,
-    requested_bytes: usize,
-) -> Result<InspectResult, RunnerError> {
-    let hard_limit = requested_bytes.min(32 * 1024);
-    if serialized_len(&result)? <= hard_limit {
-        return Ok(result);
-    }
-    result.truncated = true;
-
-    match result.view {
-        InspectView::Summary => {
-            while serialized_len(&result)? > hard_limit {
-                let Some(summary) = result
-                    .items
-                    .as_array_mut()
-                    .and_then(|items| items.first_mut())
-                else {
-                    break;
-                };
-                let Some(diagnostics) = summary
-                    .get_mut("diagnostics")
-                    .and_then(serde_json::Value::as_array_mut)
-                else {
-                    break;
-                };
-                if diagnostics.pop().is_none() {
-                    break;
-                }
-                summary["truncated"] = serde_json::Value::Bool(true);
-            }
-        }
-        InspectView::Tests => {
-            while serialized_len(&result)? > hard_limit {
-                let Some(tests) = result.items.as_array_mut() else {
-                    break;
-                };
-                let Some(cases) = tests.iter_mut().rev().find_map(|test| {
-                    test.get_mut("cases")
-                        .and_then(serde_json::Value::as_array_mut)
-                        .filter(|cases| !cases.is_empty())
-                }) else {
-                    break;
-                };
-                cases.pop();
-            }
-        }
-        _ => {}
-    }
-
-    for string_limit in [1_000, 512, 256, 64, 0] {
-        if serialized_len(&result)? <= hard_limit {
-            return Ok(result);
-        }
-        bound_json_strings(&mut result.items, string_limit);
-    }
-    if serialized_len(&result)? > hard_limit {
-        return Err(RunnerError::ResponseTooLarge(hard_limit));
-    }
-    Ok(result)
-}
-
-fn serialized_len(result: &InspectResult) -> Result<usize, RunnerError> {
-    Ok(serde_json::to_vec(result)?.len())
-}
-
-fn bound_json_strings(value: &mut serde_json::Value, maximum_bytes: usize) {
-    match value {
-        serde_json::Value::String(text) => {
-            if maximum_bytes == 0 {
-                text.clear();
-            } else if text.len() > maximum_bytes {
-                *text = bounded_text(text, maximum_bytes);
-            }
-        }
-        serde_json::Value::Array(items) => {
-            for item in items {
-                bound_json_strings(item, maximum_bytes);
-            }
-        }
-        serde_json::Value::Object(fields) => {
-            for value in fields.values_mut() {
-                bound_json_strings(value, maximum_bytes);
-            }
-        }
-        serde_json::Value::Null | serde_json::Value::Bool(_) | serde_json::Value::Number(_) => {}
+        targets: record
+            .summary
+            .as_ref()
+            .map(|summary| summary.target_counts.clone()),
+        tests: record
+            .summary
+            .as_ref()
+            .map(|summary| summary.test_counts.clone()),
+        raw_output_bytes: record.metrics.raw_output_bytes,
+        model_visible_bytes: record.metrics.model_visible_bytes,
+        inspect_calls: record.metrics.inspect_calls,
     }
 }

--- a/crates/bazel-mcp-runner/src/lib.rs
+++ b/crates/bazel-mcp-runner/src/lib.rs
@@ -13,7 +13,8 @@ mod test_evidence;
 mod version;
 
 pub use bazel_mcp_reducer::{StarlarkLimits, StarlarkReducerConfig};
-pub use inspection::{InspectRequest, InspectResult, InspectView};
+pub use bazel_mcp_types::{InspectResult, InspectView};
+pub use inspection::InspectRequest;
 #[doc(hidden)]
 pub use service::RunnerTestSupport;
 pub use service::{

--- a/crates/bazel-mcp-runner/src/service.rs
+++ b/crates/bazel-mcp-runner/src/service.rs
@@ -36,15 +36,15 @@ use crate::{
 
 #[cfg(test)]
 use crate::inspection::{
-    EvidenceRecord, InspectRequest, InspectView, LogCursor, failure_evidence_records,
-    page_evidence_records, should_persist_failure_evidence,
+    EvidenceRecord, InspectRequest, LogCursor, failure_evidence_records, page_evidence_records,
+    should_persist_failure_evidence,
 };
 
 #[cfg(test)]
 use crate::{artifacts::local_artifact_path, test_evidence::artifact_matches_test};
 
 #[cfg(test)]
-use bazel_mcp_types::{ArtifactKind, BazelCommand};
+use bazel_mcp_types::{ArtifactKind, BazelCommand, InspectView};
 
 pub(crate) const COMPLETE_BEP_LOG_LIMIT: usize = 2 * 1024 * 1024;
 pub(crate) const FALLBACK_LOG_LIMIT: usize = 8 * 1024 * 1024;
@@ -1141,8 +1141,8 @@ mod tests {
             view: InspectView::Log,
             cursor: None,
             filter: None,
-            limit: 2,
-            max_bytes: 8 * 1024,
+            item_limit: 2,
+            scan_limit: 100,
         };
         let mut observed = Vec::new();
         loop {
@@ -1151,11 +1151,11 @@ mod tests {
                 .as_deref()
                 .map(|cursor| LogCursor::decode_for(cursor, id, InspectView::Log, None).unwrap())
                 .map_or(0, |cursor| cursor.next_record);
-            let (items, truncated, cursor) =
+            let page =
                 page_evidence_records(records.clone().into_iter(), start, &request, id).unwrap();
-            observed.extend(items);
-            request.cursor = cursor;
-            if !truncated {
+            observed.extend(page.items);
+            request.cursor = page.next_cursor;
+            if !page.truncated {
                 break;
             }
         }

--- a/crates/bazel-mcp-runner/tests/process.rs
+++ b/crates/bazel-mcp-runner/tests/process.rs
@@ -19,8 +19,8 @@ use bazel_mcp_runner::{
 use bazel_mcp_store::Store;
 use bazel_mcp_types::{
     Artifact, ArtifactKind, BazelCommand, DeferredRetrieval, Diagnostic, DiagnosticCategory,
-    InvocationRecord, InvocationRequest, InvocationState, InvocationSummary, ResultDisposition,
-    Severity, Termination, TestCase, TestResult, TestStatus,
+    InspectHint, InspectPayload, InvocationRecord, InvocationRequest, InvocationState,
+    InvocationSummary, ResultDisposition, Severity, Termination, TestCase, TestResult, TestStatus,
 };
 use tempfile::TempDir;
 use tokio_util::sync::CancellationToken;
@@ -386,8 +386,8 @@ async fn redacts_secrets_from_metadata_normalized_rows_and_log_inspection() {
                 view,
                 cursor: None,
                 filter: None,
-                limit: 20,
-                max_bytes: 8 * 1024,
+                item_limit: 20,
+                scan_limit: 10_000,
             })
             .await
             .unwrap();
@@ -402,12 +402,12 @@ async fn redacts_secrets_from_metadata_normalized_rows_and_log_inspection() {
             view: InspectView::Log,
             cursor: None,
             filter: Some("SUPERSECRET".into()),
-            limit: 20,
-            max_bytes: 8 * 1024,
+            item_limit: 20,
+            scan_limit: 10_000,
         })
         .await
         .unwrap();
-    assert!(secret_filter.items.as_array().unwrap().is_empty());
+    assert!(secret_filter.items.is_empty());
 
     service
         .test_support()
@@ -432,8 +432,8 @@ async fn redacts_secrets_from_metadata_normalized_rows_and_log_inspection() {
             view: InspectView::Coverage,
             cursor: None,
             filter: None,
-            limit: 20,
-            max_bytes: 8 * 1024,
+            item_limit: 20,
+            scan_limit: 10_000,
         })
         .await
         .unwrap();
@@ -500,8 +500,8 @@ async fn preserves_raw_bep_before_redacting_every_persisted_and_visible_projecti
             view: InspectView::Diagnostics,
             cursor: None,
             filter: None,
-            limit: 20,
-            max_bytes: 8 * 1024,
+            item_limit: 20,
+            scan_limit: 10_000,
         })
         .await
         .unwrap();
@@ -596,8 +596,8 @@ async fn log_inspection_uses_bounded_opaque_cursors() {
             view: InspectView::Log,
             cursor: None,
             filter: None,
-            limit: 20,
-            max_bytes: 1024,
+            item_limit: 20,
+            scan_limit: 10_000,
         })
         .await
         .unwrap();
@@ -614,8 +614,8 @@ async fn log_inspection_uses_bounded_opaque_cursors() {
             view: InspectView::Log,
             cursor: Some(cursor.clone()),
             filter: None,
-            limit: 20,
-            max_bytes: 1024,
+            item_limit: 20,
+            scan_limit: 10_000,
         })
         .await
         .unwrap();
@@ -635,8 +635,8 @@ async fn log_inspection_uses_bounded_opaque_cursors() {
                 view: InspectView::Log,
                 cursor: Some(cursor),
                 filter: None,
-                limit: 20,
-                max_bytes: 1024,
+                item_limit: 20,
+                scan_limit: 10_000,
             })
             .await
             .is_err()
@@ -651,8 +651,8 @@ async fn log_inspection_uses_bounded_opaque_cursors() {
             view: InspectView::Log,
             cursor: Some("512".into()),
             filter: None,
-            limit: 20,
-            max_bytes: 1024,
+            item_limit: 20,
+            scan_limit: 10_000,
         })
         .await;
     assert!(invalid.is_err());
@@ -666,13 +666,16 @@ async fn log_inspection_uses_bounded_opaque_cursors() {
             view: InspectView::Log,
             cursor: None,
             filter: Some("LINE-150".into()),
-            limit: 20,
-            max_bytes: 1024,
+            item_limit: 20,
+            scan_limit: 10_000,
         })
         .await
         .unwrap();
-    assert_eq!(filtered.items.as_array().unwrap().len(), 1);
-    assert!(filtered.items[0].as_str().unwrap().contains("line-150"));
+    let InspectPayload::Log(filtered_items) = filtered.items else {
+        panic!("log inspection returned a different payload type");
+    };
+    assert_eq!(filtered_items.len(), 1);
+    assert!(filtered_items[0].contains("line-150"));
 
     let unmatched = service
         .inspect(InspectRequest {
@@ -683,12 +686,12 @@ async fn log_inspection_uses_bounded_opaque_cursors() {
             view: InspectView::Log,
             cursor: None,
             filter: Some("not-present".into()),
-            limit: 20,
-            max_bytes: 1024,
+            item_limit: 20,
+            scan_limit: 10_000,
         })
         .await
         .unwrap();
-    assert!(unmatched.items.as_array().unwrap().is_empty());
+    assert!(unmatched.items.is_empty());
 }
 
 #[tokio::test]
@@ -743,7 +746,7 @@ async fn failed_test_logs_are_snapshotted_and_retrieved_without_a_public_uri() {
     assert!(flag_marker.exists());
     let summary = failed.summary.as_ref().unwrap();
     assert!(summary.headline.contains("got 1, want 2"));
-    assert_eq!(summary.inspect_hint.as_deref(), Some("test_log"));
+    assert_eq!(summary.inspect_hint, Some(InspectHint::TestLog));
     let diagnostic = summary
         .diagnostics
         .iter()
@@ -776,18 +779,15 @@ async fn failed_test_logs_are_snapshotted_and_retrieved_without_a_public_uri() {
             view: InspectView::TestLog,
             cursor: None,
             filter: Some("//PKG:FAILING".into()),
-            limit: 20,
-            max_bytes: 8 * 1024,
+            item_limit: 20,
+            scan_limit: 10_000,
         })
         .await
         .unwrap();
-    let items = inspected.items.as_array().unwrap();
-    assert!(items.iter().all(serde_json::Value::is_string));
-    assert!(
-        items
-            .iter()
-            .any(|item| item.as_str().unwrap().contains("got 1, want 2"))
-    );
+    let InspectPayload::TestLog(items) = inspected.items else {
+        panic!("test-log inspection returned a different payload type");
+    };
+    assert!(items.iter().any(|item| item.contains("got 1, want 2")));
 
     let failed_paths = service.test_support().paths_for(&failed);
     let retained_before = tokio::fs::read(&failed_paths.test_logs_raw).await.unwrap();
@@ -861,7 +861,7 @@ FAILED (failures=1)
         .await
         .unwrap();
     let summary = failed.summary.as_ref().unwrap();
-    assert_eq!(summary.inspect_hint.as_deref(), Some("test_log"));
+    assert_eq!(summary.inspect_hint, Some(InspectHint::TestLog));
     assert!(
         summary
             .headline
@@ -936,7 +936,7 @@ async fn failed_java_test_logs_promote_the_located_application_frame() {
         .await
         .unwrap();
     let summary = failed.summary.as_ref().unwrap();
-    assert_eq!(summary.inspect_hint.as_deref(), Some("test_log"));
+    assert_eq!(summary.inspect_hint, Some(InspectHint::TestLog));
     let matching = summary
         .diagnostics
         .iter()
@@ -1009,7 +1009,7 @@ TypeError: Cannot read properties of undefined (reading 'lines')
         .await
         .unwrap();
     let summary = failed.summary.as_ref().unwrap();
-    assert_eq!(summary.inspect_hint.as_deref(), Some("test_log"));
+    assert_eq!(summary.inspect_hint, Some(InspectHint::TestLog));
     let matching = summary
         .diagnostics
         .iter()
@@ -1081,7 +1081,7 @@ invoice total should include the service fee
         .await
         .unwrap();
     let summary = failed.summary.as_ref().unwrap();
-    assert_eq!(summary.inspect_hint.as_deref(), Some("test_log"));
+    assert_eq!(summary.inspect_hint, Some(InspectHint::TestLog));
     let matching = summary
         .diagnostics
         .iter()
@@ -2195,7 +2195,7 @@ async fn query_and_informational_commands_return_bounded_initial_evidence() {
     let query_summary = query.summary.unwrap();
     assert_eq!(query_summary.query_result_count, Some(4));
     assert_eq!(query_summary.query_sample.len(), 3);
-    assert!(query_summary.inspect_hint.as_deref() == Some("query_results"));
+    assert_eq!(query_summary.inspect_hint, Some(InspectHint::QueryResults));
 
     let informational = service
         .run(InvocationRequest::new(
@@ -2216,7 +2216,7 @@ async fn query_and_informational_commands_return_bounded_initial_evidence() {
 }
 
 #[tokio::test]
-async fn inspect_shrinks_nested_results_to_the_hard_byte_budget() {
+async fn inspect_preserves_typed_nested_results_for_server_encoding() {
     let root = tempfile::tempdir().unwrap();
     let workspace = root.path().join("workspace");
     tokio::fs::create_dir(&workspace).await.unwrap();
@@ -2292,13 +2292,13 @@ async fn inspect_shrinks_nested_results_to_the_hard_byte_budget() {
                 view,
                 cursor: None,
                 filter: None,
-                limit: 20,
-                max_bytes: 8 * 1024,
+                item_limit: 20,
+                scan_limit: 10_000,
             })
             .await
             .unwrap();
-        assert!(result.truncated);
-        assert!(serde_json::to_vec(&result).unwrap().len() <= 8 * 1024);
+        assert!(!result.truncated);
+        assert!(serde_json::to_vec(&result).unwrap().len() > 8 * 1024);
     }
     let unavailable = service
         .inspect(InspectRequest {
@@ -2309,14 +2309,14 @@ async fn inspect_shrinks_nested_results_to_the_hard_byte_budget() {
             view: InspectView::TestLog,
             cursor: None,
             filter: Some("//PKG:TEST".into()),
-            limit: 20,
-            max_bytes: 8 * 1024,
+            item_limit: 20,
+            scan_limit: 10_000,
         })
         .await
         .unwrap();
     assert_eq!(
         unavailable.items,
-        serde_json::json!(["//pkg:test: test_log_not_found"])
+        InspectPayload::TestLog(vec!["//pkg:test: test_log_not_found".to_owned()])
     );
 }
 

--- a/crates/bazel-mcp-server/src/handler.rs
+++ b/crates/bazel-mcp-server/src/handler.rs
@@ -1,10 +1,9 @@
-use std::{collections::BTreeMap, path::PathBuf, str::FromStr, time::Duration};
+use std::{path::PathBuf, str::FromStr, time::Duration};
 
 use bazel_mcp_runner::{InspectRequest, InspectView, InvocationService};
 use bazel_mcp_types::{
-    BazelCommand, DeferredResultView, DeferredRetrieval, DeferredTerminalState, Diagnostic,
-    InvocationId, InvocationRecord, InvocationRequest, InvocationState, PageRequest, QueryRow,
-    ResultDisposition, TargetCounts, Termination, TestCounts,
+    BazelCommand, DeferredResultView, DeferredRetrieval, DeferredTerminalState, InvocationId,
+    InvocationRecord, InvocationRequest, InvocationState, PageRequest, ResultDisposition,
 };
 use rmcp::{
     ErrorData, RoleServer,
@@ -17,15 +16,21 @@ use rmcp::{
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
-use crate::{McpExecutionPolicy, ResultEncoding};
-
-const TASKS_EXTENSION: &str = "io.modelcontextprotocol/tasks";
-const IMMEDIATE_RESPONSE: &str = "io.modelcontextprotocol/model-immediate-response";
+use crate::{
+    McpExecutionPolicy, ResultEncoding,
+    protocol::{
+        IMMEDIATE_RESPONSE, LegacyTasksAdapter, ProtocolAdapter, ProtocolFamily, TASKS_EXTENSION,
+        TasksExtensionAdapter,
+    },
+    result::{EncodedResult, ExecutionResult, ResultEncoder, RunResultBuilder},
+    tasks::{TaskResultState, TaskSnapshot},
+};
 
 #[derive(Clone)]
 pub struct BazelMcpServer {
     runner: InvocationService,
-    result_encoding: ResultEncoding,
+    result_encoder: ResultEncoder,
+    run_result_builder: RunResultBuilder,
     progress_initial_delay: std::time::Duration,
     progress_interval: std::time::Duration,
     execution_policy: McpExecutionPolicy,
@@ -88,32 +93,14 @@ pub struct CancelParams {
     pub reason: Option<String>,
 }
 
-#[derive(Debug, Serialize)]
-struct RunResult<'a> {
-    invocation_id: String,
-    state: bazel_mcp_types::InvocationState,
-    command: &'a str,
-    exit_code: Option<i32>,
-    duration_ms: u64,
-    headline: &'a str,
-    targets: TargetCounts,
-    tests: TestCounts,
-    diagnostics: &'a [Diagnostic],
-    query_result_count: Option<u64>,
-    query_sample: Option<&'a [QueryRow]>,
-    truncated: bool,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    inspect_hint: Option<&'a str>,
-    available_views: &'static [&'static str],
-    more_available: bool,
-}
-
 impl BazelMcpServer {
     #[must_use]
     pub fn new(runner: InvocationService, result_encoding: ResultEncoding) -> Self {
+        let result_encoder = ResultEncoder::new(result_encoding);
         Self {
             runner,
-            result_encoding,
+            result_encoder: result_encoder.clone(),
+            run_result_builder: RunResultBuilder::new(result_encoder),
             progress_initial_delay: std::time::Duration::from_secs(30),
             progress_interval: std::time::Duration::from_secs(60),
             execution_policy: McpExecutionPolicy::Auto,
@@ -239,19 +226,8 @@ impl BazelMcpServer {
         &self,
         Parameters(params): Parameters<InspectParams>,
     ) -> Result<CallToolResult, String> {
-        let view = match params.view.as_str() {
-            "summary" => InspectView::Summary,
-            "metrics" => InspectView::Metrics,
-            "diagnostics" => InspectView::Diagnostics,
-            "tests" => InspectView::Tests,
-            "log" => InspectView::Log,
-            "test_log" => InspectView::TestLog,
-            "coverage" => InspectView::Coverage,
-            "artifacts" => InspectView::Artifacts,
-            "query_results" => InspectView::QueryResults,
-            "invocations" => InspectView::Invocations,
-            other => return Err(format!("unsupported inspection view: {other}")),
-        };
+        let view = InspectView::parse(&params.view)
+            .ok_or_else(|| format!("unsupported inspection view: {}", params.view))?;
         let id = if view == InspectView::Invocations {
             if params.invocation_id.is_some() {
                 return Err("invocation_id is not supported for the invocations view".into());
@@ -287,55 +263,36 @@ impl BazelMcpServer {
             return Err("command is supported only for the invocations view".into());
         }
         let visible_budget = inspect_visible_budget(params.max_bytes);
-        let mut representation_budget = self.single_representation_budget(visible_budget);
-        loop {
-            let result = self
+        let item_limit = params.limit.unwrap_or(20).clamp(1, 100);
+        let result = self
+            .runner
+            .inspect(InspectRequest {
+                invocation_id: id,
+                workspace,
+                state,
+                command,
+                view,
+                cursor: params.cursor,
+                filter: params.filter,
+                item_limit,
+                scan_limit: item_limit.saturating_mul(20).clamp(1_000, 10_000),
+            })
+            .await
+            .map_err(|error| error.to_string())?;
+        let encoded = self.result_encoder.encode_inspect(result, visible_budget)?;
+        if let Some(id) = id
+            && let Err(error) = self
                 .runner
-                .inspect(InspectRequest {
-                    invocation_id: id,
-                    workspace: workspace.clone(),
-                    state,
-                    command: command.clone(),
-                    view,
-                    cursor: params.cursor.clone(),
-                    filter: params.filter.clone(),
-                    limit: params.limit.unwrap_or(20).clamp(1, 100),
-                    max_bytes: representation_budget,
-                })
+                .record_model_visible_result(id, encoded.visible_bytes, true)
                 .await
-                .map_err(|error| error.to_string())?;
-            let value = serde_json::to_value(result).map_err(|error| error.to_string())?;
-            let (encoded, bytes) = self.encode_with_size(value)?;
-            if bytes > visible_budget {
-                let proportional_budget = representation_budget
-                    .saturating_mul(visible_budget)
-                    .checked_div(bytes)
-                    .unwrap_or_default();
-                let headroom = (proportional_budget / 20).max(1);
-                representation_budget = proportional_budget
-                    .saturating_sub(headroom)
-                    .min(representation_budget.saturating_sub(1));
-                if representation_budget == 0 {
-                    return Err(
-                        "bounded bazel.inspect response could not fit its hard byte limit".into(),
-                    );
-                }
-                continue;
-            }
-            if let Some(id) = id
-                && let Err(error) = self
-                    .runner
-                    .record_model_visible_result(id, bytes, true)
-                    .await
-            {
-                tracing::warn!(
-                    invocation_id = %id,
-                    %error,
-                    "could not persist model-visible inspection metrics"
-                );
-            }
-            return Ok(encoded);
+        {
+            tracing::warn!(
+                invocation_id = %id,
+                %error,
+                "could not persist model-visible inspection metrics"
+            );
         }
+        Ok(encoded.result)
     }
 
     #[tool(
@@ -352,7 +309,9 @@ impl BazelMcpServer {
             .cancel_with_reason(id, params.reason.as_deref())
             .await
             .map_err(|error| error.to_string())?;
-        self.encode(serde_json::to_value(result).map_err(|error| error.to_string())?)
+        self.result_encoder
+            .encode(&result)
+            .map(|encoded| encoded.result)
     }
 }
 
@@ -362,197 +321,54 @@ impl BazelMcpServer {
         record: &InvocationRecord,
         tool_error: bool,
     ) -> Result<CallToolResult, String> {
-        let exit_code = match &record.termination {
-            Some(Termination::Exit { code }) => Some(*code),
-            _ => None,
-        };
-        let summary = record
-            .summary
-            .as_ref()
-            .ok_or_else(|| "completed invocation has no summary".to_owned())?;
-        let mut diagnostic_count = summary.diagnostics.len();
-        let mut query_sample_count = summary.query_sample.len();
-        loop {
-            let result = RunResult {
-                invocation_id: record.request.id.to_string(),
-                state: record.state,
-                command: record.request.command.as_str(),
-                exit_code,
-                duration_ms: record.metrics.bazel_wall_ms,
-                headline: &summary.headline,
-                targets: summary.target_counts.clone(),
-                tests: summary.test_counts.clone(),
-                diagnostics: &summary.diagnostics[..diagnostic_count],
-                query_result_count: summary.query_result_count,
-                query_sample: (query_sample_count > 0)
-                    .then_some(&summary.query_sample[..query_sample_count]),
-                truncated: summary.truncated
-                    || diagnostic_count < summary.diagnostics.len()
-                    || query_sample_count < summary.query_sample.len(),
-                inspect_hint: summary.inspect_hint.as_deref(),
-                available_views: &[
-                    "summary",
-                    "metrics",
-                    "diagnostics",
-                    "tests",
-                    "test_log",
-                    "coverage",
-                    "artifacts",
-                    "query_results",
-                    "log",
-                ],
-                more_available: summary.truncated
-                    || diagnostic_count < summary.diagnostics.len()
-                    || query_sample_count < summary.query_sample.len()
-                    || !summary.targets.is_empty()
-                    || !summary.tests.is_empty()
-                    || summary.inspect_hint.is_some(),
-            };
-            let value = serde_json::to_value(&result).map_err(|error| error.to_string())?;
-            let limit = if summary.success { 2 * 1024 } else { 8 * 1024 };
-            let (mut encoded, bytes) = self.encode_with_size(value)?;
-            if bytes <= limit {
-                if let Err(error) = self
-                    .runner
-                    .record_model_visible_result(record.request.id, bytes, false)
-                    .await
-                {
-                    tracing::warn!(
-                        invocation_id = %record.request.id,
-                        %error,
-                        "could not persist model-visible response metrics"
-                    );
-                }
-                if tool_error {
-                    encoded.is_error = Some(true);
-                }
-                return Ok(encoded);
-            }
-            if query_sample_count > 0 {
-                query_sample_count -= 1;
-            } else if diagnostic_count > 0 {
-                diagnostic_count -= 1;
-            } else {
-                return Err("bounded bazel.run response could not fit its hard byte limit".into());
-            }
+        let EncodedResult {
+            result,
+            visible_bytes,
+        } = self
+            .run_result_builder
+            .build(ExecutionResult::new(record, tool_error))?;
+        if let Err(error) = self
+            .runner
+            .record_model_visible_result(record.request.id, visible_bytes, false)
+            .await
+        {
+            tracing::warn!(
+                invocation_id = %record.request.id,
+                %error,
+                "could not persist model-visible response metrics"
+            );
         }
-    }
-
-    fn single_representation_budget(&self, visible_budget: usize) -> usize {
-        match self.result_encoding {
-            ResultEncoding::Text | ResultEncoding::Toon | ResultEncoding::Structured => {
-                visible_budget
-            }
-            ResultEncoding::Both => visible_budget / 2,
-        }
+        Ok(result)
     }
 
     #[cfg(test)]
     fn model_visible_bytes(&self, value: &serde_json::Value) -> Result<usize, String> {
-        self.encode_with_size(value.clone()).map(|(_, bytes)| bytes)
+        self.result_encoder
+            .encode_value(value.clone())
+            .map(|encoded| encoded.visible_bytes)
     }
 
+    #[cfg(test)]
     fn encode(&self, value: serde_json::Value) -> Result<CallToolResult, String> {
-        self.encode_with_size(value).map(|(result, _)| result)
+        self.result_encoder
+            .encode_value(value)
+            .map(|encoded| encoded.result)
     }
 
-    fn encode_with_size(
-        &self,
-        value: serde_json::Value,
-    ) -> Result<(CallToolResult, usize), String> {
-        Ok(match self.result_encoding {
-            ResultEncoding::Text => {
-                let text = serde_json::to_string(&value).map_err(|error| error.to_string())?;
-                let bytes = text.len();
-                (
-                    CallToolResult::success(vec![ContentBlock::text(text)]),
-                    bytes,
-                )
-            }
-            ResultEncoding::Toon => {
-                let text = Self::encode_toon(&value)?;
-                let bytes = text.len();
-                (
-                    CallToolResult::success(vec![ContentBlock::text(text)]),
-                    bytes,
-                )
-            }
-            ResultEncoding::Structured => {
-                let bytes = serde_json::to_vec(&value)
-                    .map_err(|error| error.to_string())?
-                    .len();
-                let mut result = CallToolResult::default();
-                result.structured_content = Some(value);
-                result.is_error = Some(false);
-                (result, bytes)
-            }
-            ResultEncoding::Both => {
-                let text = serde_json::to_string(&value).map_err(|error| error.to_string())?;
-                let bytes = text.len().saturating_mul(2);
-                let mut result = CallToolResult::success(vec![ContentBlock::text(text)]);
-                result.structured_content = Some(value);
-                (result, bytes)
-            }
-        })
-    }
-
+    #[cfg(test)]
     fn encode_toon(value: &serde_json::Value) -> Result<String, String> {
         toon_format::encode_default(value).map_err(|error| format!("encode TOON result: {error}"))
     }
 }
 
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-enum ProtocolFamily {
-    Earlier,
-    LegacyTasks,
-    TasksExtension,
-}
-
-impl ProtocolFamily {
-    const fn as_str(self) -> &'static str {
-        match self {
-            Self::Earlier => "synchronous",
-            Self::LegacyTasks => "legacy_tasks",
-            Self::TasksExtension => "tasks_extension",
-        }
-    }
-}
-
 impl BazelMcpServer {
     fn protocol_family(version: Option<&ProtocolVersion>) -> ProtocolFamily {
-        match version {
-            Some(version) if version == &ProtocolVersion::V_2025_11_25 => {
-                ProtocolFamily::LegacyTasks
-            }
-            Some(version) if version.as_str() >= "2026-06-30" => ProtocolFamily::TasksExtension,
-            _ => ProtocolFamily::Earlier,
-        }
+        ProtocolAdapter::negotiate(version).family()
     }
 
     fn initialize_result(&self, version: ProtocolVersion) -> InitializeResult {
-        let family = Self::protocol_family(Some(&version));
-        let mut capabilities = ServerCapabilities::default();
-        capabilities.tools = Some(ToolsCapability::default());
-        match family {
-            ProtocolFamily::LegacyTasks => {
-                let tasks = if self.execution_policy == McpExecutionPolicy::SyncOnly {
-                    let mut tasks = TasksCapability::default();
-                    tasks.list = Some(JsonObject::new());
-                    tasks.cancel = Some(JsonObject::new());
-                    tasks
-                } else {
-                    TasksCapability::server_default()
-                };
-                capabilities.tasks = Some(tasks);
-            }
-            ProtocolFamily::TasksExtension => {
-                capabilities.extensions = Some(BTreeMap::from([(
-                    TASKS_EXTENSION.to_owned(),
-                    JsonObject::new(),
-                )]));
-            }
-            ProtocolFamily::Earlier => {}
-        }
+        let adapter = ProtocolAdapter::negotiate(Some(&version));
+        let capabilities = adapter.capabilities(self.execution_policy);
         let mut result = InitializeResult::new(capabilities)
             .with_server_info(Implementation::new("bazel-mcp", env!("CARGO_PKG_VERSION")))
             .with_instructions(
@@ -564,21 +380,14 @@ impl BazelMcpServer {
 
     fn tools_for(&self, family: ProtocolFamily) -> Vec<Tool> {
         let mut tools = self.tool_router.list_all();
-        if family == ProtocolFamily::LegacyTasks {
-            for tool in &mut tools {
-                if tool.name == "bazel.run" {
-                    tool.execution = match self.execution_policy {
-                        McpExecutionPolicy::Auto => {
-                            Some(ToolExecution::new().with_task_support(TaskSupport::Optional))
-                        }
-                        McpExecutionPolicy::SyncOnly => None,
-                        McpExecutionPolicy::TasksRequired => {
-                            Some(ToolExecution::new().with_task_support(TaskSupport::Required))
-                        }
-                    };
-                }
+        let adapter = match family {
+            ProtocolFamily::Earlier => ProtocolAdapter::negotiate(None),
+            ProtocolFamily::LegacyTasks => {
+                ProtocolAdapter::negotiate(Some(&ProtocolVersion::V_2025_11_25))
             }
-        }
+            ProtocolFamily::TasksExtension => ProtocolAdapter::Extension(TasksExtensionAdapter),
+        };
+        adapter.adapt_tools(&mut tools, self.execution_policy);
         tools
     }
 
@@ -721,107 +530,37 @@ impl BazelMcpServer {
     }
 
     fn legacy_task(&self, view: &DeferredResultView) -> Task {
-        let status = if view.deferred.terminal_override == Some(DeferredTerminalState::Cancelled) {
-            TaskStatus::Cancelled
-        } else if view.deferred.failure.is_some() {
-            TaskStatus::Failed
-        } else if view.invocation.state.is_terminal() {
-            TaskStatus::Completed
-        } else {
-            TaskStatus::Working
-        };
-        self.task_object(view, status)
-    }
-
-    fn extension_status(&self, view: &DeferredResultView) -> TaskStatus {
-        if view
-            .deferred
-            .failure
-            .as_ref()
-            .is_some_and(|failure| failure.kind == bazel_mcp_types::DeferredFailureKind::Internal)
-        {
-            TaskStatus::Failed
-        } else if view.invocation.state == InvocationState::Cancelled {
-            TaskStatus::Cancelled
-        } else if view.invocation.state.is_terminal() {
-            TaskStatus::Completed
-        } else {
-            TaskStatus::Working
-        }
-    }
-
-    fn task_object(&self, view: &DeferredResultView, status: TaskStatus) -> Task {
-        let elapsed_ms = bazel_mcp_types::unix_timestamp_ms()
-            .saturating_sub(view.deferred.created_at_ms)
-            .max(0);
-        let status_name = match status {
-            TaskStatus::Working => "working",
-            TaskStatus::InputRequired => "input_required",
-            TaskStatus::Completed => "completed",
-            TaskStatus::Failed => "failed",
-            TaskStatus::Cancelled => "cancelled",
-            _ => "unknown",
-        };
-        Task::new(
-            view.deferred.invocation_id.to_string(),
-            status,
-            format_timestamp(view.deferred.created_at_ms),
-            format_timestamp(view.deferred.updated_at_ms),
-        )
-        .with_status_message(format!("state={status_name} elapsed_ms={elapsed_ms}"))
-        .with_ttl(view.deferred.advertised_ttl_ms())
-        .with_poll_interval(self.task_poll_interval_ms)
+        let snapshot = TaskSnapshot::from_view(view, self.task_poll_interval_ms);
+        LegacyTasksAdapter.task(&snapshot)
     }
 
     fn extension_task_value(&self, view: &DeferredResultView) -> serde_json::Value {
-        let status = self.extension_status(view);
-        serde_json::json!({
-            "resultType": "task",
-            "taskId": view.deferred.invocation_id.to_string(),
-            "status": task_status_name(&status),
-            "createdAt": format_timestamp(view.deferred.created_at_ms),
-            "lastUpdatedAt": format_timestamp(view.deferred.updated_at_ms),
-            "ttlMs": view.deferred.advertised_ttl_ms(),
-            "pollIntervalMs": self.task_poll_interval_ms,
-        })
+        let snapshot = TaskSnapshot::from_view(view, self.task_poll_interval_ms);
+        TasksExtensionAdapter.creation(&snapshot)
     }
 
     async fn extension_get_value(
         &self,
         view: &DeferredResultView,
     ) -> Result<serde_json::Value, ErrorData> {
-        let status = self.extension_status(view);
-        let mut value = serde_json::json!({
-            "resultType": "complete",
-            "taskId": view.deferred.invocation_id.to_string(),
-            "status": task_status_name(&status),
-            "createdAt": format_timestamp(view.deferred.created_at_ms),
-            "lastUpdatedAt": format_timestamp(view.deferred.updated_at_ms),
-            "ttlMs": view.deferred.advertised_ttl_ms(),
-            "pollIntervalMs": self.task_poll_interval_ms,
-        });
-        if status == TaskStatus::Completed {
-            let tool_error = view.deferred.failure.is_some();
-            let result = self
-                .build_run_result(&view.invocation, tool_error)
-                .await
-                .map_err(|error| ErrorData::internal_error(error, None))?;
-            value["result"] = serde_json::to_value(result)
-                .map_err(|error| ErrorData::internal_error(error.to_string(), None))?;
-        } else if status == TaskStatus::Failed {
-            let message = view
-                .deferred
-                .failure
-                .as_ref()
-                .map_or("Deferred invocation failed", |failure| {
-                    failure.redacted_message.as_str()
-                });
-            value["error"] = serde_json::json!({
-                "code": ErrorCode::INTERNAL_ERROR.0,
-                "message": message,
-            });
-        }
-        Ok(value)
+        let snapshot = TaskSnapshot::from_view(view, self.task_poll_interval_ms);
+        let (result, error) = match &snapshot.result {
+            TaskResultState::Invocation { tool_error } if snapshot.state.is_terminal() => {
+                let result = self
+                    .build_run_result(&view.invocation, *tool_error)
+                    .await
+                    .map_err(|error| ErrorData::internal_error(error, None))?;
+                (Some(result), None)
+            }
+            TaskResultState::InternalFailure { redacted_message } => {
+                (None, Some(redacted_message.as_str()))
+            }
+            TaskResultState::Pending | TaskResultState::Cancelled => (None, None),
+            TaskResultState::Invocation { .. } => (None, None),
+        };
+        TasksExtensionAdapter
+            .complete(&snapshot, result, error)
+            .map_err(|error| ErrorData::internal_error(error.to_string(), None))
     }
 
     async fn call_tool_request(
@@ -1034,7 +773,9 @@ impl BazelMcpServer {
             .deferred_result(id, DeferredRetrieval::InlineResult)
             .await
             .map_err(|_| Self::task_not_found(task_id))?;
-        let terminal = self.extension_status(&view) != TaskStatus::Working;
+        let terminal = TaskSnapshot::from_view(&view, self.task_poll_interval_ms)
+            .state
+            .is_terminal();
         let result = self
             .extension_get_value(&view)
             .await
@@ -1061,7 +802,7 @@ impl BazelMcpServer {
             .cancel(id)
             .await
             .map_err(|error| ErrorData::internal_error(error.to_string(), None))?;
-        let result = CustomResult::new(serde_json::json!({"resultType": "complete"}));
+        let result = TasksExtensionAdapter.acknowledge();
         Self::trace_task_response(ProtocolFamily::TasksExtension, "control", &result);
         Ok(result)
     }
@@ -1098,7 +839,7 @@ impl BazelMcpServer {
                     .deferred_result(id, DeferredRetrieval::InlineResult)
                     .await
                     .map_err(|_| Self::task_not_found(task_id))?;
-                let result = CustomResult::new(serde_json::json!({"resultType": "complete"}));
+                let result = TasksExtensionAdapter.acknowledge();
                 Self::trace_task_response(ProtocolFamily::TasksExtension, "control", &result);
                 Ok(ServerResult::CustomResult(result))
             }
@@ -1175,11 +916,7 @@ impl Service<RoleServer> for BazelMcpServer {
                     .runner
                     .list_deferred_results(
                         DeferredRetrieval::SeparateResult,
-                        PageRequest {
-                            cursor,
-                            limit: 100,
-                            max_bytes: None,
-                        },
+                        PageRequest::new(cursor, 100),
                     )
                     .await
                     .map_err(|error| ErrorData::invalid_params(error.to_string(), None))?;
@@ -1248,29 +985,6 @@ fn parse_task_id(value: &str) -> Result<InvocationId, ErrorData> {
     parse_id(value).map_err(|_| ErrorData::invalid_params("taskId must be a UUID", None))
 }
 
-fn task_status_name(status: &TaskStatus) -> &'static str {
-    match status {
-        TaskStatus::Working => "working",
-        TaskStatus::InputRequired => "input_required",
-        TaskStatus::Completed => "completed",
-        TaskStatus::Failed => "failed",
-        TaskStatus::Cancelled => "cancelled",
-        _ => "unknown",
-    }
-}
-
-fn format_timestamp(timestamp_ms: i64) -> String {
-    let nanos = i128::from(timestamp_ms).saturating_mul(1_000_000);
-    time::OffsetDateTime::from_unix_timestamp_nanos(nanos)
-        .ok()
-        .and_then(|timestamp| {
-            timestamp
-                .format(&time::format_description::well_known::Rfc3339)
-                .ok()
-        })
-        .unwrap_or_else(|| "1970-01-01T00:00:00Z".to_owned())
-}
-
 fn parse_id(value: &str) -> Result<InvocationId, String> {
     Uuid::parse_str(value)
         .map(InvocationId::from_uuid)
@@ -1299,6 +1013,7 @@ fn inspect_visible_budget(requested: Option<u32>) -> usize {
 mod tests {
     use bazel_mcp_runner::RunnerConfig;
     use bazel_mcp_store::Store;
+    use bazel_mcp_types::{Diagnostic, Termination};
     use tempfile::tempdir;
 
     use super::*;
@@ -1418,7 +1133,6 @@ mod tests {
 
         let text = BazelMcpServer::new(runner.clone(), ResultEncoding::Text);
         assert_eq!(text.model_visible_bytes(&value).unwrap(), one);
-        assert_eq!(text.single_representation_budget(8_192), 8_192);
         let text_result = text.encode(value.clone()).unwrap();
         let Some(ContentBlock::Text(content)) = text_result.content.first() else {
             panic!("text result did not contain one text block");
@@ -1431,7 +1145,6 @@ mod tests {
         let toon = BazelMcpServer::new(runner.clone(), ResultEncoding::Toon);
         let toon_text = BazelMcpServer::encode_toon(&value).unwrap();
         assert_eq!(toon.model_visible_bytes(&value).unwrap(), toon_text.len());
-        assert_eq!(toon.single_representation_budget(8_192), 8_192);
         let decoded: serde_json::Value = toon_format::decode_default(&toon_text).unwrap();
         assert_eq!(decoded, value);
         let result = toon.encode(value.clone()).unwrap();
@@ -1450,7 +1163,6 @@ mod tests {
 
         let both = BazelMcpServer::new(runner, ResultEncoding::Both);
         assert_eq!(both.model_visible_bytes(&value).unwrap(), one * 2);
-        assert_eq!(both.single_representation_budget(8_192), 4_096);
         assert_eq!(
             both.encode(value.clone()).unwrap().structured_content,
             Some(value)

--- a/crates/bazel-mcp-server/src/lib.rs
+++ b/crates/bazel-mcp-server/src/lib.rs
@@ -2,6 +2,9 @@
 
 mod config;
 mod handler;
+mod protocol;
+mod result;
+mod tasks;
 
 pub use bazel_mcp_runner::BepTransport;
 pub use config::{

--- a/crates/bazel-mcp-server/src/protocol.rs
+++ b/crates/bazel-mcp-server/src/protocol.rs
@@ -1,0 +1,200 @@
+//! Negotiated MCP protocol adapters.
+
+use std::collections::BTreeMap;
+
+use rmcp::model::{
+    CallToolResult, CustomResult, JsonObject, ProtocolVersion, ServerCapabilities, Task,
+    TaskStatus, TaskSupport, Tool, ToolExecution, ToolsCapability,
+};
+
+use crate::{
+    McpExecutionPolicy,
+    tasks::{TaskSnapshot, TaskState},
+};
+
+pub(crate) const TASKS_EXTENSION: &str = "io.modelcontextprotocol/tasks";
+pub(crate) const IMMEDIATE_RESPONSE: &str = "io.modelcontextprotocol/model-immediate-response";
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum ProtocolFamily {
+    Earlier,
+    LegacyTasks,
+    TasksExtension,
+}
+
+impl ProtocolFamily {
+    pub(crate) const fn as_str(self) -> &'static str {
+        match self {
+            Self::Earlier => "synchronous",
+            Self::LegacyTasks => "legacy_tasks",
+            Self::TasksExtension => "tasks_extension",
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+pub(crate) struct SyncAdapter;
+
+#[derive(Clone, Copy, Debug)]
+pub(crate) struct LegacyTasksAdapter;
+
+#[derive(Clone, Copy, Debug)]
+pub(crate) struct TasksExtensionAdapter;
+
+#[derive(Clone, Copy, Debug)]
+pub(crate) enum ProtocolAdapter {
+    Sync(SyncAdapter),
+    Legacy(LegacyTasksAdapter),
+    Extension(TasksExtensionAdapter),
+}
+
+impl ProtocolAdapter {
+    #[must_use]
+    pub(crate) fn negotiate(version: Option<&ProtocolVersion>) -> Self {
+        match version {
+            Some(version) if version == &ProtocolVersion::V_2025_11_25 => {
+                Self::Legacy(LegacyTasksAdapter)
+            }
+            Some(version) if version.as_str() >= "2026-06-30" => {
+                Self::Extension(TasksExtensionAdapter)
+            }
+            _ => Self::Sync(SyncAdapter),
+        }
+    }
+
+    pub(crate) const fn family(self) -> ProtocolFamily {
+        match self {
+            Self::Sync(_) => ProtocolFamily::Earlier,
+            Self::Legacy(_) => ProtocolFamily::LegacyTasks,
+            Self::Extension(_) => ProtocolFamily::TasksExtension,
+        }
+    }
+
+    #[must_use]
+    pub(crate) fn capabilities(self, policy: McpExecutionPolicy) -> ServerCapabilities {
+        let mut capabilities = ServerCapabilities::default();
+        capabilities.tools = Some(ToolsCapability::default());
+        match self {
+            Self::Legacy(_) => {
+                let tasks = if policy == McpExecutionPolicy::SyncOnly {
+                    let mut tasks = rmcp::model::TasksCapability::default();
+                    tasks.list = Some(JsonObject::new());
+                    tasks.cancel = Some(JsonObject::new());
+                    tasks
+                } else {
+                    rmcp::model::TasksCapability::server_default()
+                };
+                capabilities.tasks = Some(tasks);
+            }
+            Self::Extension(_) => {
+                capabilities.extensions = Some(BTreeMap::from([(
+                    TASKS_EXTENSION.to_owned(),
+                    JsonObject::new(),
+                )]));
+            }
+            Self::Sync(_) => {}
+        }
+        capabilities
+    }
+
+    pub(crate) fn adapt_tools(self, tools: &mut [Tool], policy: McpExecutionPolicy) {
+        let Self::Legacy(_) = self else {
+            return;
+        };
+        for tool in tools {
+            if tool.name == "bazel.run" {
+                tool.execution = match policy {
+                    McpExecutionPolicy::Auto => {
+                        Some(ToolExecution::new().with_task_support(TaskSupport::Optional))
+                    }
+                    McpExecutionPolicy::SyncOnly => None,
+                    McpExecutionPolicy::TasksRequired => {
+                        Some(ToolExecution::new().with_task_support(TaskSupport::Required))
+                    }
+                };
+            }
+        }
+    }
+}
+
+impl LegacyTasksAdapter {
+    #[must_use]
+    pub(crate) fn task(self, snapshot: &TaskSnapshot) -> Task {
+        Task::new(
+            snapshot.id.to_string(),
+            legacy_status(snapshot.state),
+            format_timestamp(snapshot.created_at_ms),
+            format_timestamp(snapshot.updated_at_ms),
+        )
+        .with_status_message(snapshot.status_message.clone())
+        .with_ttl(snapshot.ttl_ms)
+        .with_poll_interval(snapshot.poll_interval_ms)
+    }
+}
+
+impl TasksExtensionAdapter {
+    #[must_use]
+    pub(crate) fn creation(self, snapshot: &TaskSnapshot) -> serde_json::Value {
+        serde_json::json!({
+            "resultType": "task",
+            "taskId": snapshot.id.to_string(),
+            "status": snapshot.state.as_str(),
+            "createdAt": format_timestamp(snapshot.created_at_ms),
+            "lastUpdatedAt": format_timestamp(snapshot.updated_at_ms),
+            "ttlMs": snapshot.ttl_ms,
+            "pollIntervalMs": snapshot.poll_interval_ms,
+        })
+    }
+
+    pub(crate) fn complete(
+        self,
+        snapshot: &TaskSnapshot,
+        result: Option<CallToolResult>,
+        error: Option<&str>,
+    ) -> Result<serde_json::Value, serde_json::Error> {
+        let mut value = serde_json::json!({
+            "resultType": "complete",
+            "taskId": snapshot.id.to_string(),
+            "status": snapshot.state.as_str(),
+            "createdAt": format_timestamp(snapshot.created_at_ms),
+            "lastUpdatedAt": format_timestamp(snapshot.updated_at_ms),
+            "ttlMs": snapshot.ttl_ms,
+            "pollIntervalMs": snapshot.poll_interval_ms,
+        });
+        if let Some(result) = result {
+            value["result"] = serde_json::to_value(result)?;
+        } else if let Some(message) = error {
+            value["error"] = serde_json::json!({
+                "code": rmcp::model::ErrorCode::INTERNAL_ERROR.0,
+                "message": message,
+            });
+        }
+        Ok(value)
+    }
+
+    #[must_use]
+    pub(crate) fn acknowledge(self) -> CustomResult {
+        CustomResult::new(serde_json::json!({"resultType": "complete"}))
+    }
+}
+
+fn legacy_status(state: TaskState) -> TaskStatus {
+    match state {
+        TaskState::Working => TaskStatus::Working,
+        TaskState::Completed => TaskStatus::Completed,
+        TaskState::Failed => TaskStatus::Failed,
+        TaskState::Cancelled => TaskStatus::Cancelled,
+    }
+}
+
+fn format_timestamp(timestamp_ms: i64) -> String {
+    let nanos = i128::from(timestamp_ms).saturating_mul(1_000_000);
+    time::OffsetDateTime::from_unix_timestamp_nanos(nanos)
+        .ok()
+        .and_then(|timestamp| {
+            timestamp
+                .format(&time::format_description::well_known::Rfc3339)
+                .ok()
+        })
+        .unwrap_or_else(|| "1970-01-01T00:00:00Z".to_owned())
+}

--- a/crates/bazel-mcp-server/src/result.rs
+++ b/crates/bazel-mcp-server/src/result.rs
@@ -1,0 +1,318 @@
+//! Final MCP result encoding and byte-budget enforcement.
+
+use bazel_mcp_types::{
+    AvailableViews, Diagnostic, InspectHint, InspectPayload, InspectResult, InvocationRecord,
+    InvocationState, QueryRow, TargetCounts, Termination, TestCounts,
+};
+use rmcp::model::{CallToolResult, ContentBlock};
+use serde::Serialize;
+
+use crate::ResultEncoding;
+
+#[derive(Clone, Debug)]
+pub(crate) struct ResultEncoder {
+    encoding: ResultEncoding,
+}
+
+#[derive(Clone, Debug)]
+pub(crate) struct RunResultBuilder {
+    encoder: ResultEncoder,
+}
+
+#[derive(Debug)]
+pub(crate) struct EncodedResult {
+    pub(crate) result: CallToolResult,
+    pub(crate) visible_bytes: usize,
+}
+
+#[derive(Clone, Copy, Debug)]
+pub(crate) struct ExecutionResult<'a> {
+    pub(crate) record: &'a InvocationRecord,
+    pub(crate) tool_error: bool,
+}
+
+impl<'a> ExecutionResult<'a> {
+    #[must_use]
+    pub(crate) const fn new(record: &'a InvocationRecord, tool_error: bool) -> Self {
+        Self { record, tool_error }
+    }
+}
+
+#[derive(Clone, Debug, Serialize)]
+struct RunResult {
+    invocation_id: String,
+    state: InvocationState,
+    command: String,
+    exit_code: Option<i32>,
+    duration_ms: u64,
+    headline: String,
+    targets: TargetCounts,
+    tests: TestCounts,
+    diagnostics: Vec<Diagnostic>,
+    query_result_count: Option<u64>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    query_sample: Vec<QueryRow>,
+    truncated: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    inspect_hint: Option<InspectHint>,
+    available_views: AvailableViews,
+    more_available: bool,
+}
+
+impl ResultEncoder {
+    #[must_use]
+    pub(crate) const fn new(encoding: ResultEncoding) -> Self {
+        Self { encoding }
+    }
+
+    pub(crate) fn encode<T: Serialize>(&self, value: &T) -> Result<EncodedResult, String> {
+        let value = serde_json::to_value(value).map_err(|error| error.to_string())?;
+        self.encode_value(value)
+    }
+
+    pub(crate) fn encode_value(&self, value: serde_json::Value) -> Result<EncodedResult, String> {
+        let (result, visible_bytes) = match self.encoding {
+            ResultEncoding::Text => {
+                let text = serde_json::to_string(&value).map_err(|error| error.to_string())?;
+                let bytes = text.len();
+                (
+                    CallToolResult::success(vec![ContentBlock::text(text)]),
+                    bytes,
+                )
+            }
+            ResultEncoding::Toon => {
+                let text = toon_format::encode_default(&value)
+                    .map_err(|error| format!("encode TOON result: {error}"))?;
+                let bytes = text.len();
+                (
+                    CallToolResult::success(vec![ContentBlock::text(text)]),
+                    bytes,
+                )
+            }
+            ResultEncoding::Structured => {
+                let bytes = serde_json::to_vec(&value)
+                    .map_err(|error| error.to_string())?
+                    .len();
+                let mut result = CallToolResult::default();
+                result.structured_content = Some(value);
+                result.is_error = Some(false);
+                (result, bytes)
+            }
+            ResultEncoding::Both => {
+                let text = serde_json::to_string(&value).map_err(|error| error.to_string())?;
+                let structured_bytes = serde_json::to_vec(&value)
+                    .map_err(|error| error.to_string())?
+                    .len();
+                let visible_bytes = text.len().saturating_add(structured_bytes);
+                let mut result = CallToolResult::success(vec![ContentBlock::text(text)]);
+                result.structured_content = Some(value);
+                (result, visible_bytes)
+            }
+        };
+        Ok(EncodedResult {
+            result,
+            visible_bytes,
+        })
+    }
+
+    pub(crate) fn encode_inspect(
+        &self,
+        mut value: InspectResult,
+        limit: usize,
+    ) -> Result<EncodedResult, String> {
+        loop {
+            let encoded = self.encode(&value)?;
+            if encoded.visible_bytes <= limit {
+                return Ok(encoded);
+            }
+            if !shrink_inspect(&mut value) {
+                return Err(
+                    "bounded bazel.inspect response could not fit its hard byte limit".into(),
+                );
+            }
+        }
+    }
+}
+
+impl RunResultBuilder {
+    #[must_use]
+    pub(crate) const fn new(encoder: ResultEncoder) -> Self {
+        Self { encoder }
+    }
+
+    pub(crate) fn build(&self, execution: ExecutionResult<'_>) -> Result<EncodedResult, String> {
+        let ExecutionResult { record, tool_error } = execution;
+        let exit_code = match &record.termination {
+            Some(Termination::Exit { code }) => Some(*code),
+            _ => None,
+        };
+        let summary = record
+            .summary
+            .as_ref()
+            .ok_or_else(|| "completed invocation has no summary".to_owned())?;
+        let mut result = RunResult {
+            invocation_id: record.request.id.to_string(),
+            state: record.state,
+            command: record.request.command.as_str().to_owned(),
+            exit_code,
+            duration_ms: record.metrics.bazel_wall_ms,
+            headline: summary.headline.clone(),
+            targets: summary.target_counts.clone(),
+            tests: summary.test_counts.clone(),
+            diagnostics: summary.diagnostics.clone(),
+            query_result_count: summary.query_result_count,
+            query_sample: summary.query_sample.clone(),
+            truncated: summary.truncated,
+            inspect_hint: summary.inspect_hint,
+            available_views: AvailableViews::follow_up(),
+            more_available: summary.truncated
+                || !summary.targets.is_empty()
+                || !summary.tests.is_empty()
+                || summary.inspect_hint.is_some(),
+        };
+        let limit = if summary.success { 2 * 1024 } else { 8 * 1024 };
+        loop {
+            let mut encoded = self.encoder.encode(&result)?;
+            if encoded.visible_bytes <= limit {
+                if tool_error {
+                    encoded.result.is_error = Some(true);
+                }
+                return Ok(encoded);
+            }
+            result.truncated = true;
+            result.more_available = true;
+            if result.query_sample.pop().is_some() || result.diagnostics.pop().is_some() {
+                continue;
+            }
+            if shrink_utf8(&mut result.headline, 96) || shrink_utf8(&mut result.command, 32) {
+                continue;
+            }
+            return Err("bounded bazel.run response could not fit its hard byte limit".into());
+        }
+    }
+}
+
+fn shrink_inspect(result: &mut InspectResult) -> bool {
+    match &mut result.items {
+        InspectPayload::Summary(items) => {
+            if let Some(summary) = items.last_mut() {
+                summary.truncated = true;
+                result.truncated = true;
+                if summary.query_sample.pop().is_some() || summary.diagnostics.pop().is_some() {
+                    return true;
+                }
+                if shrink_utf8(&mut summary.headline, 64) {
+                    return true;
+                }
+            }
+        }
+        InspectPayload::Tests(items) => {
+            if let Some(test) = items.iter_mut().rev().find(|test| !test.cases.is_empty()) {
+                test.cases.pop();
+                result.truncated = true;
+                return true;
+            }
+        }
+        _ => {}
+    }
+
+    let len = result.items.len();
+    if len == 0 {
+        return false;
+    }
+    result.truncate_items(len - 1);
+    true
+}
+
+fn shrink_utf8(value: &mut String, minimum: usize) -> bool {
+    if value.len() <= minimum {
+        return false;
+    }
+    let target = (value.len() * 3 / 4).max(minimum);
+    let mut boundary = target.min(value.len());
+    while !value.is_char_boundary(boundary) {
+        boundary -= 1;
+    }
+    value.truncate(boundary);
+    value.push('…');
+    true
+}
+
+#[cfg(test)]
+mod tests {
+    use bazel_mcp_types::{InspectPayload, InspectResult, InspectView};
+    use rmcp::model::ContentBlock;
+
+    use super::{ResultEncoder, shrink_utf8};
+    use crate::ResultEncoding;
+
+    #[test]
+    fn utf8_shrinking_stops_on_a_character_boundary() {
+        let mut value = "é".repeat(100);
+        assert!(shrink_utf8(&mut value, 16));
+        assert!(value.ends_with('…'));
+        assert!(value.len() < 203);
+    }
+
+    #[test]
+    fn every_encoding_packs_complete_inspection_items_to_the_exact_limit() {
+        for encoding in [
+            ResultEncoding::Text,
+            ResultEncoding::Toon,
+            ResultEncoding::Structured,
+            ResultEncoding::Both,
+        ] {
+            let start_cursor = "start-cursor".to_owned();
+            let result = InspectResult::new(
+                None,
+                InspectPayload::Log(vec![
+                    format!("first-{}", "a".repeat(180)),
+                    format!("second-{}", "b".repeat(180)),
+                    format!("third-{}", "c".repeat(180)),
+                ]),
+                None,
+                None,
+                Some("after-all".to_owned()),
+                true,
+                vec![
+                    "after-1".to_owned(),
+                    "after-2".to_owned(),
+                    "after-3".to_owned(),
+                ],
+            )
+            .with_start_cursor(Some(start_cursor.clone()));
+            let encoded = ResultEncoder::new(encoding)
+                .encode_inspect(result, 512)
+                .unwrap();
+            assert!(encoded.visible_bytes <= 512, "encoding={encoding:?}");
+
+            let value = match encoding {
+                ResultEncoding::Text => {
+                    let Some(ContentBlock::Text(text)) = encoded.result.content.first() else {
+                        panic!("text encoding omitted content");
+                    };
+                    serde_json::from_str(&text.text).unwrap()
+                }
+                ResultEncoding::Toon => {
+                    let Some(ContentBlock::Text(text)) = encoded.result.content.first() else {
+                        panic!("TOON encoding omitted content");
+                    };
+                    toon_format::decode_default(&text.text).unwrap()
+                }
+                ResultEncoding::Structured | ResultEncoding::Both => {
+                    encoded.result.structured_content.unwrap()
+                }
+            };
+            assert_eq!(value["view"], InspectView::Log.as_str());
+            let emitted = value["items"].as_array().unwrap().len();
+            assert!(emitted < 3, "test fixture must exercise final packing");
+            let expected_cursor = match emitted {
+                0 => start_cursor.as_str(),
+                1 => "after-1",
+                2 => "after-2",
+                _ => unreachable!(),
+            };
+            assert_eq!(value["next_cursor"], expected_cursor);
+        }
+    }
+}

--- a/crates/bazel-mcp-server/src/tasks.rs
+++ b/crates/bazel-mcp-server/src/tasks.rs
@@ -1,0 +1,187 @@
+//! Protocol-neutral task application state derived from durable runner data.
+
+use bazel_mcp_types::{
+    DeferredFailureKind, DeferredResultView, DeferredRetrieval, DeferredTerminalState,
+    InvocationId, InvocationState, unix_timestamp_ms,
+};
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum TaskState {
+    Working,
+    Completed,
+    Failed,
+    Cancelled,
+}
+
+impl TaskState {
+    pub(crate) const fn as_str(self) -> &'static str {
+        match self {
+            Self::Working => "working",
+            Self::Completed => "completed",
+            Self::Failed => "failed",
+            Self::Cancelled => "cancelled",
+        }
+    }
+
+    pub(crate) const fn is_terminal(self) -> bool {
+        !matches!(self, Self::Working)
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) enum TaskResultState {
+    Pending,
+    Invocation { tool_error: bool },
+    InternalFailure { redacted_message: String },
+    Cancelled,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) struct TaskSnapshot {
+    pub(crate) id: InvocationId,
+    pub(crate) state: TaskState,
+    pub(crate) result: TaskResultState,
+    pub(crate) created_at_ms: i64,
+    pub(crate) updated_at_ms: i64,
+    pub(crate) ttl_ms: u64,
+    pub(crate) poll_interval_ms: u64,
+    pub(crate) status_message: String,
+}
+
+impl TaskSnapshot {
+    #[must_use]
+    pub(crate) fn from_view(view: &DeferredResultView, poll_interval_ms: u64) -> Self {
+        let internal_failure = view
+            .deferred
+            .failure
+            .as_ref()
+            .filter(|failure| failure.kind == DeferredFailureKind::Internal);
+        let legacy_cancelled = view.deferred.retrieval == DeferredRetrieval::SeparateResult
+            && view.deferred.terminal_override == Some(DeferredTerminalState::Cancelled);
+        let (state, result) = if legacy_cancelled {
+            (
+                TaskState::Cancelled,
+                TaskResultState::Invocation {
+                    tool_error: view.deferred.failure.is_some(),
+                },
+            )
+        } else if let Some(failure) = internal_failure {
+            (
+                TaskState::Failed,
+                TaskResultState::InternalFailure {
+                    redacted_message: failure.redacted_message.clone(),
+                },
+            )
+        } else {
+            match view.deferred.retrieval {
+                DeferredRetrieval::InlineResult
+                    if view.invocation.state == InvocationState::Cancelled =>
+                {
+                    (TaskState::Cancelled, TaskResultState::Cancelled)
+                }
+                DeferredRetrieval::SeparateResult if view.deferred.failure.is_some() => (
+                    TaskState::Failed,
+                    TaskResultState::Invocation { tool_error: true },
+                ),
+                _ if view.invocation.state.is_terminal() => (
+                    TaskState::Completed,
+                    TaskResultState::Invocation {
+                        tool_error: view.deferred.failure.is_some(),
+                    },
+                ),
+                _ => (TaskState::Working, TaskResultState::Pending),
+            }
+        };
+        let elapsed_ms = unix_timestamp_ms()
+            .saturating_sub(view.deferred.created_at_ms)
+            .max(0);
+        let status_message = format!("state={} elapsed_ms={elapsed_ms}", state.as_str());
+        debug_assert!(status_message.len() <= 256);
+        Self {
+            id: view.deferred.invocation_id,
+            state,
+            result,
+            created_at_ms: view.deferred.created_at_ms,
+            updated_at_ms: view.deferred.updated_at_ms,
+            ttl_ms: view.deferred.advertised_ttl_ms(),
+            poll_interval_ms,
+            status_message,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::PathBuf;
+
+    use bazel_mcp_types::{
+        BazelCommand, DeferredFailure, DeferredFailureKind, DeferredResultRecord, InvocationRecord,
+        InvocationRequest,
+    };
+
+    use super::*;
+
+    fn view(retrieval: DeferredRetrieval) -> DeferredResultView {
+        let invocation = InvocationRecord::queued(InvocationRequest::new(
+            PathBuf::from("/workspace"),
+            BazelCommand::Build,
+            vec!["//...".to_owned()],
+        ));
+        DeferredResultView {
+            deferred: DeferredResultRecord::new(invocation.request.id, retrieval, 1_000, 61_000),
+            invocation,
+        }
+    }
+
+    #[test]
+    fn execution_failure_is_failed_for_legacy_and_completed_for_extension() {
+        let mut legacy = view(DeferredRetrieval::SeparateResult);
+        legacy.invocation.state = InvocationState::Failed;
+        legacy.deferred.failure = Some(DeferredFailure {
+            kind: DeferredFailureKind::Execution,
+            redacted_message: "bounded failure".to_owned(),
+        });
+        let legacy = TaskSnapshot::from_view(&legacy, 2_000);
+        assert_eq!(legacy.state, TaskState::Failed);
+        assert_eq!(
+            legacy.result,
+            TaskResultState::Invocation { tool_error: true }
+        );
+
+        let mut extension = view(DeferredRetrieval::InlineResult);
+        extension.invocation.state = InvocationState::Failed;
+        extension.deferred.failure = Some(DeferredFailure {
+            kind: DeferredFailureKind::Execution,
+            redacted_message: "bounded failure".to_owned(),
+        });
+        let extension = TaskSnapshot::from_view(&extension, 2_000);
+        assert_eq!(extension.state, TaskState::Completed);
+        assert_eq!(
+            extension.result,
+            TaskResultState::Invocation { tool_error: true }
+        );
+    }
+
+    #[test]
+    fn internal_failures_share_one_terminal_application_state() {
+        for retrieval in [
+            DeferredRetrieval::SeparateResult,
+            DeferredRetrieval::InlineResult,
+        ] {
+            let mut view = view(retrieval);
+            view.invocation.state = InvocationState::Failed;
+            view.deferred.failure = Some(DeferredFailure {
+                kind: DeferredFailureKind::Internal,
+                redacted_message: "redacted".to_owned(),
+            });
+            let snapshot = TaskSnapshot::from_view(&view, 2_000);
+            assert_eq!(snapshot.state, TaskState::Failed);
+            assert_eq!(
+                snapshot.result,
+                TaskResultState::InternalFailure {
+                    redacted_message: "redacted".to_owned()
+                }
+            );
+        }
+    }
+}

--- a/crates/bazel-mcp-store/src/cursor.rs
+++ b/crates/bazel-mcp-store/src/cursor.rs
@@ -36,6 +36,8 @@ pub(crate) struct FileCursor {
     context: [u8; CONTEXT_BYTES],
     pub offset: u64,
     pub ordinal: u64,
+    pub total_scanned: u64,
+    pub filtered_scanned: u64,
 }
 
 impl DeferredCursor {
@@ -135,25 +137,31 @@ impl FileCursor {
         filter: Option<&str>,
         offset: u64,
         ordinal: u64,
+        total_scanned: u64,
+        filtered_scanned: u64,
     ) -> Self {
         Self {
             context: cursor_context(&[scope, invocation_id, filter.unwrap_or_default()]),
             offset,
             ordinal,
+            total_scanned,
+            filtered_scanned,
         }
     }
 
     pub fn encode(&self) -> Result<String, StoreError> {
-        let mut bytes = Vec::with_capacity(34);
+        let mut bytes = Vec::with_capacity(50);
         bytes.extend_from_slice(&[VERSION, FILE_KIND]);
         bytes.extend_from_slice(&self.context);
         bytes.extend_from_slice(&self.offset.to_le_bytes());
         bytes.extend_from_slice(&self.ordinal.to_le_bytes());
+        bytes.extend_from_slice(&self.total_scanned.to_le_bytes());
+        bytes.extend_from_slice(&self.filtered_scanned.to_le_bytes());
         Ok(URL_SAFE_NO_PAD.encode(bytes))
     }
 
     pub fn decode(value: &str) -> Result<Self, StoreError> {
-        let bytes = decode_exact(value, 34, FILE_KIND)?;
+        let bytes = decode_exact(value, 50, FILE_KIND)?;
         let context = bytes[2..18]
             .try_into()
             .map_err(|_| StoreError::InvalidCursor)?;
@@ -167,10 +175,22 @@ impl FileCursor {
                 .try_into()
                 .map_err(|_| StoreError::InvalidCursor)?,
         );
+        let total_scanned = u64::from_le_bytes(
+            bytes[34..42]
+                .try_into()
+                .map_err(|_| StoreError::InvalidCursor)?,
+        );
+        let filtered_scanned = u64::from_le_bytes(
+            bytes[42..50]
+                .try_into()
+                .map_err(|_| StoreError::InvalidCursor)?,
+        );
         Ok(Self {
             context,
             offset,
             ordinal,
+            total_scanned,
+            filtered_scanned,
         })
     }
 
@@ -292,12 +312,14 @@ mod tests {
     #[test]
     fn fixed_binary_cursors_are_compact_and_context_bound() {
         let id = Uuid::now_v7().to_string();
-        let file = FileCursor::new("query_rows", &id, Some("needle"), 42, 7);
+        let file = FileCursor::new("query_rows", &id, Some("needle"), 42, 7, 8, 3);
         let encoded = file.encode().unwrap();
-        assert_eq!(encoded.len(), 46);
+        assert_eq!(encoded.len(), 67);
         let decoded = FileCursor::decode_for(&encoded, "query_rows", &id, Some("needle")).unwrap();
         assert_eq!(decoded.offset, 42);
         assert_eq!(decoded.ordinal, 7);
+        assert_eq!(decoded.total_scanned, 8);
+        assert_eq!(decoded.filtered_scanned, 3);
         assert!(FileCursor::decode_for(&encoded, "query_rows", &id, Some("other")).is_err());
         assert!(
             FileCursor::decode_for(

--- a/crates/bazel-mcp-store/src/deferred_repository.rs
+++ b/crates/bazel-mcp-store/src/deferred_repository.rs
@@ -56,55 +56,66 @@ impl Store {
         page: PageRequest,
     ) -> Result<Page<DeferredResultView>, StoreError> {
         self.refresh_index_if_stale().await?;
-        let limit = page.limit.clamp(1, 200) as usize;
+        let item_limit = page.item_limit.clamp(1, 200) as usize;
+        let scan_limit = page.scan_limit.clamp(page.item_limit.max(1), 20_000) as usize;
         let cursor = page
             .cursor
             .as_deref()
             .map(|value| DeferredCursor::decode_for(value, retrieval.as_str()))
             .transpose()?;
         let index = self.inner.index.read().await;
-        let mut items: Vec<_> = index
-            .deferred_by_created
-            .iter()
-            .rev()
-            .filter_map(|(_, id)| {
-                let entry = index.entries.get(id)?;
-                let deferred = entry.deferred.as_ref()?;
-                (deferred.retrieval == retrieval
-                    && !deferred.is_expired(now_ms, entry.record.state.is_terminal())
-                    && cursor.as_ref().is_none_or(|cursor| {
-                        deferred.created_at_ms < cursor.created_at_ms
-                            || (deferred.created_at_ms == cursor.created_at_ms
-                                && deferred.invocation_id.to_string() < cursor.id)
-                    }))
-                .then(|| DeferredResultView {
+        let mut items = Vec::with_capacity(item_limit);
+        let mut item_cursors = Vec::with_capacity(item_limit);
+        let mut continuation = None;
+        let mut scanned = 0_usize;
+        let mut truncated = false;
+        for (_, id) in index.deferred_by_created.iter().rev() {
+            let Some(entry) = index.entries.get(id) else {
+                continue;
+            };
+            let Some(deferred) = entry.deferred.as_ref() else {
+                continue;
+            };
+            if !cursor.as_ref().is_none_or(|cursor| {
+                deferred.created_at_ms < cursor.created_at_ms
+                    || (deferred.created_at_ms == cursor.created_at_ms
+                        && deferred.invocation_id.to_string() < cursor.id)
+            }) {
+                continue;
+            }
+            if scanned == scan_limit {
+                truncated = true;
+                break;
+            }
+            let matches = deferred.retrieval == retrieval
+                && !deferred.is_expired(now_ms, entry.record.state.is_terminal());
+            if matches && items.len() == item_limit {
+                truncated = true;
+                break;
+            }
+            scanned = scanned.saturating_add(1);
+            let cursor = DeferredCursor::new(
+                retrieval.as_str(),
+                deferred.created_at_ms,
+                deferred.invocation_id.to_string(),
+            )
+            .encode()?;
+            continuation = Some(cursor.clone());
+            if matches {
+                items.push(DeferredResultView {
                     deferred: deferred.clone(),
                     invocation: entry.record.clone().into_record(),
-                })
-            })
-            .take(limit + 1)
-            .collect();
-        let truncated = items.len() > limit;
-        items.truncate(limit);
-        let next_cursor = if truncated {
-            items
-                .last()
-                .map(|view| {
-                    DeferredCursor::new(
-                        retrieval.as_str(),
-                        view.deferred.created_at_ms,
-                        view.deferred.invocation_id.to_string(),
-                    )
-                    .encode()
-                })
-                .transpose()?
-        } else {
-            None
-        };
+                });
+                item_cursors.push(cursor);
+            }
+        }
         Ok(Page {
             items,
-            next_cursor,
+            total_count: None,
+            filtered_count: None,
+            next_cursor: if truncated { continuation } else { None },
             truncated,
+            item_cursors,
         })
     }
 

--- a/crates/bazel-mcp-store/src/invocation_repository.rs
+++ b/crates/bazel-mcp-store/src/invocation_repository.rs
@@ -1,6 +1,6 @@
 //! Compact invocation lookup and listing, plus explicit detail hydration.
 
-use std::{collections::BTreeSet, path::Path};
+use std::path::Path;
 
 use bazel_mcp_types::{
     BazelCommand, InvocationId, InvocationRecord, InvocationState, Page, PageRequest,
@@ -52,7 +52,8 @@ impl Store {
         page: PageRequest,
     ) -> Result<Page<InvocationHeader>, StoreError> {
         self.refresh_index_if_stale().await?;
-        let limit = page.limit.clamp(1, 200) as usize;
+        let item_limit = page.item_limit.clamp(1, 200) as usize;
+        let scan_limit = page.scan_limit.clamp(page.item_limit.max(1), 20_000) as usize;
         let workspace_text = workspace.map(|path| path.to_string_lossy().into_owned());
         let state_text = state.map(InvocationState::as_str);
         let command_text = command.map(BazelCommand::as_str);
@@ -69,57 +70,61 @@ impl Store {
             })
             .transpose()?;
         let index = self.inner.index.read().await;
-        let collect = |ordered: &BTreeSet<(i64, InvocationId)>| {
-            ordered
-                .iter()
-                .rev()
-                .filter(|(requested_at_ms, id)| {
-                    cursor.as_ref().is_none_or(|cursor| {
-                        *requested_at_ms < cursor.requested_at_ms
-                            || (*requested_at_ms == cursor.requested_at_ms
-                                && id.to_string() < cursor.id)
-                    })
-                })
-                .filter_map(|(_, id)| index.entries.get(id))
-                .filter(|entry| state.is_none_or(|state| entry.record.state == state))
-                .filter(|entry| {
-                    command.is_none_or(|command| entry.record.request.command == *command)
-                })
-                .map(|entry| entry.record.clone())
-                .take(limit + 1)
-                .collect::<Vec<_>>()
-        };
-        let mut items = if let Some(workspace) = workspace {
+        let ordered = if let Some(workspace) = workspace {
             index
                 .by_workspace
                 .get(workspace)
-                .map_or_else(Vec::new, collect)
+                .map_or_else(Vec::new, |ordered| ordered.iter().rev().copied().collect())
         } else {
-            collect(&index.by_requested)
+            index.by_requested.iter().rev().copied().collect()
         };
-        let truncated = items.len() > limit;
-        items.truncate(limit);
-        let next_cursor = if truncated {
-            items
-                .last()
-                .map(|record| {
-                    InvocationCursor::new(
-                        workspace_text.as_deref(),
-                        state_text,
-                        command_text,
-                        record.request.requested_at_ms,
-                        record.request.id.to_string(),
-                    )
-                    .encode()
-                })
-                .transpose()?
-        } else {
-            None
-        };
+        let mut items = Vec::with_capacity(item_limit);
+        let mut item_cursors = Vec::with_capacity(item_limit);
+        let mut continuation = None;
+        let mut scanned = 0_usize;
+        let mut truncated = false;
+        for (requested_at_ms, id) in ordered {
+            if !cursor.as_ref().is_none_or(|cursor| {
+                requested_at_ms < cursor.requested_at_ms
+                    || (requested_at_ms == cursor.requested_at_ms && id.to_string() < cursor.id)
+            }) {
+                continue;
+            }
+            if scanned == scan_limit {
+                truncated = true;
+                break;
+            }
+            let Some(entry) = index.entries.get(&id) else {
+                continue;
+            };
+            let matches = state.is_none_or(|state| entry.record.state == state)
+                && command.is_none_or(|command| entry.record.request.command == *command);
+            if matches && items.len() == item_limit {
+                truncated = true;
+                break;
+            }
+            scanned = scanned.saturating_add(1);
+            let cursor = InvocationCursor::new(
+                workspace_text.as_deref(),
+                state_text,
+                command_text,
+                requested_at_ms,
+                id.to_string(),
+            )
+            .encode()?;
+            continuation = Some(cursor.clone());
+            if matches {
+                items.push(entry.record.clone());
+                item_cursors.push(cursor);
+            }
+        }
         Ok(Page {
             items,
-            next_cursor,
+            total_count: None,
+            filtered_count: None,
+            next_cursor: if truncated { continuation } else { None },
             truncated,
+            item_cursors,
         })
     }
 }

--- a/crates/bazel-mcp-store/src/query_paging.rs
+++ b/crates/bazel-mcp-store/src/query_paging.rs
@@ -8,7 +8,6 @@ use std::{
 };
 
 use bazel_mcp_types::{InvocationId, Page, PageRequest, QueryRow};
-use serde::Serialize;
 
 use crate::{
     cursor::{FileCursor, OrdinalCursor},
@@ -18,201 +17,13 @@ use crate::{
 pub(crate) const QUERY_LINE_LIMIT: usize = 64 * 1024;
 const QUERY_COUNT_BUFFER_BYTES: usize = 64 * 1024;
 
-pub(crate) fn page_records<T, F>(
-    scope: &str,
-    id: InvocationId,
-    filter: Option<&str>,
-    page: PageRequest,
-    records: Vec<T>,
-    searchable: F,
-) -> Result<(Page<T>, u64, u64), StoreError>
-where
-    T: Serialize,
-    F: Fn(&T) -> String,
-{
-    let limit = page.limit.clamp(1, 100) as usize;
-    let maximum_bytes = page.max_bytes.unwrap_or(usize::MAX);
-    let invocation_id = id.to_string();
-    let after = page
-        .cursor
-        .as_deref()
-        .map(|value| OrdinalCursor::decode_for(value, scope, &invocation_id, filter))
-        .transpose()?
-        .map_or(-1, |cursor| cursor.ordinal);
-    let normalized_filter = filter.map(str::to_ascii_lowercase);
-    let total = records.len() as u64;
-    let filtered = records
-        .iter()
-        .filter(|record| {
-            normalized_filter
-                .as_ref()
-                .is_none_or(|filter| searchable(record).to_ascii_lowercase().contains(filter))
-        })
-        .count() as u64;
-    let mut selected = Vec::new();
-    let mut used_bytes = 2_usize;
-    let mut last_ordinal = None;
-    let mut truncated = false;
-    for (ordinal, record) in records.into_iter().enumerate() {
-        let ordinal = i64::try_from(ordinal).unwrap_or(i64::MAX);
-        if ordinal <= after
-            || !normalized_filter
-                .as_ref()
-                .is_none_or(|filter| searchable(&record).to_ascii_lowercase().contains(filter))
-        {
-            continue;
-        }
-        let item_bytes = serde_json::to_vec(&record)?.len();
-        let separator = usize::from(!selected.is_empty());
-        if selected.len() == limit
-            || (!selected.is_empty()
-                && used_bytes
-                    .saturating_add(separator)
-                    .saturating_add(item_bytes)
-                    > maximum_bytes)
-        {
-            truncated = true;
-            break;
-        }
-        used_bytes = used_bytes
-            .saturating_add(separator)
-            .saturating_add(item_bytes);
-        last_ordinal = Some(ordinal);
-        selected.push(record);
-    }
-    let next_cursor = if truncated {
-        last_ordinal
-            .map(|ordinal| OrdinalCursor::new(scope, &invocation_id, filter, ordinal).encode())
-            .transpose()?
-    } else {
-        None
-    };
-    Ok((
-        Page {
-            items: selected,
-            next_cursor,
-            truncated,
-        },
-        total,
-        filtered,
-    ))
-}
-
-pub(crate) struct QueryFilePage {
-    pub(crate) start_offset: u64,
-    pub(crate) start_ordinal: u64,
-    pub(crate) limit: usize,
-    pub(crate) maximum_bytes: usize,
-    pub(crate) known_total: Option<u64>,
-}
-
-pub(crate) fn page_query_file<F>(
-    path: &Path,
-    invocation_id: &str,
-    filter: Option<&str>,
-    request: QueryFilePage,
-    transform: F,
-) -> Result<(Page<QueryRow>, u64, u64), StoreError>
-where
-    F: Fn(&str, &mut String),
-{
+pub(crate) fn count_query_file(path: &Path) -> Result<u64, StoreError> {
     let file = match File::open(path) {
         Ok(file) => file,
-        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
-            return Ok((
-                Page {
-                    items: Vec::new(),
-                    next_cursor: None,
-                    truncated: false,
-                },
-                0,
-                0,
-            ));
-        }
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(0),
         Err(error) => return Err(error.into()),
     };
-    if filter.is_none() {
-        let total = if let Some(total) = request.known_total {
-            total
-        } else {
-            count_query_rows(&file)?
-        };
-        return page_unfiltered_query_file(file, invocation_id, request, total, transform);
-    }
-    let mut reader = BoundedLineReader::new(BufReader::new(file), QUERY_LINE_LIMIT);
-    let mut total = 0_u64;
-    let mut filtered = 0_u64;
-    let mut selected = Vec::with_capacity(request.limit);
-    let mut used_bytes = 2_usize;
-    let mut truncated = false;
-    let mut transformed = String::new();
-    let mut serialized = Vec::new();
-    while let Some(line) = reader.next_line()? {
-        total = total.saturating_add(1);
-        transform(line.value.as_ref(), &mut transformed);
-        let matches = filter.is_none_or(|filter| contains_ignore_ascii_case(&transformed, filter));
-        if matches {
-            filtered = filtered.saturating_add(1);
-            if line.start_offset >= request.start_offset && !truncated {
-                if selected.len() == request.limit {
-                    truncated = true;
-                } else {
-                    let item_bytes =
-                        serialized_query_row_len(line.ordinal, &transformed, &mut serialized)?;
-                    let separator = usize::from(!selected.is_empty());
-                    if !selected.is_empty()
-                        && used_bytes
-                            .saturating_add(separator)
-                            .saturating_add(item_bytes)
-                            > request.maximum_bytes
-                    {
-                        truncated = true;
-                    } else {
-                        used_bytes = used_bytes
-                            .saturating_add(separator)
-                            .saturating_add(item_bytes);
-                        selected.push(SelectedQueryLine {
-                            end_offset: line.end_offset,
-                            ordinal: line.ordinal,
-                            value: std::mem::take(&mut transformed),
-                        });
-                    }
-                }
-            }
-        }
-    }
-    let next_cursor = if truncated {
-        selected
-            .last()
-            .map(|line| {
-                FileCursor::new(
-                    "query_rows",
-                    invocation_id,
-                    filter,
-                    line.end_offset,
-                    line.ordinal,
-                )
-                .encode()
-            })
-            .transpose()?
-    } else {
-        None
-    };
-    Ok((
-        Page {
-            items: selected
-                .into_iter()
-                .map(|line| QueryRow {
-                    ordinal: line.ordinal,
-                    value: line.value,
-                })
-                .collect(),
-            next_cursor,
-            truncated,
-        },
-        total,
-        filtered,
-    ))
+    count_query_rows(&file)
 }
 
 fn count_query_rows(mut file: &File) -> Result<u64, StoreError> {
@@ -242,13 +53,126 @@ fn count_query_rows(mut file: &File) -> Result<u64, StoreError> {
     Ok(rows)
 }
 
-fn page_unfiltered_query_file<F>(
+pub(crate) fn page_records<T, F>(
+    scope: &str,
+    id: InvocationId,
+    filter: Option<&str>,
+    page: PageRequest,
+    records: Vec<T>,
+    searchable: F,
+) -> Result<Page<T>, StoreError>
+where
+    F: Fn(&T) -> String,
+{
+    let item_limit = page.item_limit.clamp(1, 100) as usize;
+    let scan_limit = page.scan_limit.clamp(page.item_limit.max(1), 10_000) as usize;
+    let invocation_id = id.to_string();
+    let after = page
+        .cursor
+        .as_deref()
+        .map(|value| OrdinalCursor::decode_for(value, scope, &invocation_id, filter))
+        .transpose()?
+        .map_or(-1, |cursor| cursor.ordinal);
+    let normalized_filter = filter.map(str::to_ascii_lowercase);
+    let total = records.len() as u64;
+    let started_at_beginning = after < 0;
+    let mut filtered = 0_u64;
+    let mut selected = Vec::new();
+    let mut item_cursors = Vec::new();
+    let mut last_scanned = None;
+    let mut scanned = 0_usize;
+    let mut truncated = false;
+    for (ordinal, record) in records.into_iter().enumerate() {
+        let ordinal = i64::try_from(ordinal).unwrap_or(i64::MAX);
+        if ordinal <= after {
+            continue;
+        }
+        if scanned == scan_limit {
+            truncated = true;
+            break;
+        }
+        let matches = normalized_filter
+            .as_ref()
+            .is_none_or(|filter| searchable(&record).to_ascii_lowercase().contains(filter));
+        filtered = filtered.saturating_add(u64::from(matches));
+        if matches && selected.len() == item_limit {
+            truncated = true;
+            break;
+        }
+        scanned = scanned.saturating_add(1);
+        last_scanned = Some(ordinal);
+        if matches {
+            item_cursors.push(OrdinalCursor::new(scope, &invocation_id, filter, ordinal).encode()?);
+            selected.push(record);
+        }
+    }
+    let next_cursor = if truncated {
+        last_scanned
+            .map(|ordinal| OrdinalCursor::new(scope, &invocation_id, filter, ordinal).encode())
+            .transpose()?
+    } else {
+        None
+    };
+    Ok(Page {
+        items: selected,
+        total_count: Some(total),
+        filtered_count: if normalized_filter.is_none() {
+            Some(total)
+        } else if started_at_beginning && !truncated {
+            Some(filtered)
+        } else {
+            None
+        },
+        next_cursor,
+        truncated,
+        item_cursors,
+    })
+}
+
+pub(crate) struct QueryFilePage {
+    pub(crate) start_offset: u64,
+    pub(crate) start_ordinal: u64,
+    pub(crate) prior_total: u64,
+    pub(crate) prior_filtered: u64,
+    pub(crate) item_limit: usize,
+    pub(crate) scan_limit: usize,
+    pub(crate) known_total: Option<u64>,
+}
+
+pub(crate) fn page_query_file<F>(
+    path: &Path,
+    invocation_id: &str,
+    filter: Option<&str>,
+    request: QueryFilePage,
+    transform: F,
+) -> Result<Page<QueryRow>, StoreError>
+where
+    F: Fn(&str, &mut String),
+{
+    let file = match File::open(path) {
+        Ok(file) => file,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            return Ok(Page {
+                items: Vec::new(),
+                total_count: Some(0),
+                filtered_count: Some(0),
+                next_cursor: None,
+                truncated: false,
+                item_cursors: Vec::new(),
+            });
+        }
+        Err(error) => return Err(error.into()),
+    };
+    page_query_file_from_cursor(file, invocation_id, filter, request, transform)
+}
+
+fn page_query_file_from_cursor<F>(
     mut file: File,
     invocation_id: &str,
+    filter: Option<&str>,
     request: QueryFilePage,
-    total: u64,
     transform: F,
-) -> Result<(Page<QueryRow>, u64, u64), StoreError>
+) -> Result<Page<QueryRow>, StoreError>
 where
     F: Fn(&str, &mut String),
 {
@@ -261,85 +185,100 @@ where
         request.start_offset,
         request.start_ordinal,
     );
-    let mut selected = Vec::with_capacity(request.limit);
-    let mut used_bytes = 2_usize;
+    let mut total = request.prior_total;
+    let mut filtered = request.prior_filtered;
+    let mut selected = Vec::with_capacity(request.item_limit);
+    let mut item_cursors = Vec::with_capacity(request.item_limit);
     let mut truncated = false;
+    let mut scan_exhausted = false;
     let mut transformed = String::new();
-    let mut serialized = Vec::new();
+    let mut continuation = None;
+    let mut scanned = 0_usize;
     while let Some(line) = reader.next_line()? {
-        if selected.len() == request.limit {
+        if scanned == request.scan_limit {
             truncated = true;
+            scan_exhausted = true;
             break;
+        }
+        if filter.is_none() && selected.len() == request.item_limit {
+            if let Some(known_total) = request.known_total {
+                truncated = total < known_total;
+                break;
+            }
+            scanned = scanned.saturating_add(1);
+            total = total.saturating_add(1);
+            filtered = filtered.saturating_add(1);
+            truncated = true;
+            continue;
         }
         transform(line.value.as_ref(), &mut transformed);
-        let item_bytes = serialized_query_row_len(line.ordinal, &transformed, &mut serialized)?;
-        let separator = usize::from(!selected.is_empty());
-        if !selected.is_empty()
-            && used_bytes
-                .saturating_add(separator)
-                .saturating_add(item_bytes)
-                > request.maximum_bytes
-        {
-            truncated = true;
-            break;
+        let matches = filter.is_none_or(|filter| contains_ignore_ascii_case(&transformed, filter));
+        scanned = scanned.saturating_add(1);
+        total = total.saturating_add(1);
+        if matches {
+            filtered = filtered.saturating_add(1);
+            if selected.len() == request.item_limit {
+                truncated = true;
+                continue;
+            }
+            let item_cursor = FileCursor::new(
+                "query_rows",
+                invocation_id,
+                filter,
+                line.end_offset,
+                line.ordinal,
+                total,
+                filtered,
+            );
+            item_cursors.push(item_cursor.encode()?);
+            selected.push(QueryRow {
+                ordinal: line.ordinal,
+                value: std::mem::take(&mut transformed),
+            });
+            continuation = Some((line.end_offset, line.ordinal, total, filtered));
+        } else if selected.len() < request.item_limit {
+            continuation = Some((line.end_offset, line.ordinal, total, filtered));
         }
-        used_bytes = used_bytes
-            .saturating_add(separator)
-            .saturating_add(item_bytes);
-        selected.push(SelectedQueryLine {
-            end_offset: line.end_offset,
-            ordinal: line.ordinal,
-            value: std::mem::take(&mut transformed),
-        });
     }
-    let next_cursor = if truncated {
-        selected
-            .last()
-            .map(|line| {
-                FileCursor::new(
-                    "query_rows",
-                    invocation_id,
-                    None,
-                    line.end_offset,
-                    line.ordinal,
-                )
-                .encode()
-            })
-            .transpose()?
-    } else {
+    let total_count = if let Some(known_total) = request.known_total {
+        Some(known_total.max(total))
+    } else if scan_exhausted {
         None
+    } else {
+        Some(total)
     };
-    Ok((
-        Page {
-            items: selected
-                .into_iter()
-                .map(|line| QueryRow {
-                    ordinal: line.ordinal,
-                    value: line.value,
+    let filtered_count = if filter.is_none() {
+        total_count
+    } else if scan_exhausted {
+        None
+    } else {
+        Some(filtered)
+    };
+    Ok(Page {
+        items: selected,
+        total_count,
+        filtered_count,
+        next_cursor: if truncated {
+            continuation
+                .map(|(offset, ordinal, total, filtered)| {
+                    FileCursor::new(
+                        "query_rows",
+                        invocation_id,
+                        filter,
+                        offset,
+                        ordinal,
+                        total,
+                        filtered,
+                    )
+                    .encode()
                 })
-                .collect(),
-            next_cursor,
-            truncated,
+                .transpose()?
+        } else {
+            None
         },
-        total,
-        total,
-    ))
-}
-
-#[derive(Serialize)]
-struct BorrowedQueryRow<'a> {
-    ordinal: u64,
-    value: &'a str,
-}
-
-fn serialized_query_row_len(
-    ordinal: u64,
-    value: &str,
-    buffer: &mut Vec<u8>,
-) -> Result<usize, StoreError> {
-    buffer.clear();
-    serde_json::to_writer(&mut *buffer, &BorrowedQueryRow { ordinal, value })?;
-    Ok(buffer.len())
+        truncated,
+        item_cursors,
+    })
 }
 
 fn contains_ignore_ascii_case(value: &str, needle: &str) -> bool {
@@ -360,23 +299,12 @@ struct BoundedLineReader<R> {
 }
 
 struct BoundedLine<'a> {
-    pub(crate) start_offset: u64,
     end_offset: u64,
     ordinal: u64,
     value: Cow<'a, str>,
 }
 
-struct SelectedQueryLine {
-    end_offset: u64,
-    ordinal: u64,
-    value: String,
-}
-
 impl<R: BufRead> BoundedLineReader<R> {
-    fn new(reader: R, limit: usize) -> Self {
-        Self::with_position(reader, limit, 0, 0)
-    }
-
     fn with_position(reader: R, limit: usize, offset: u64, ordinal: u64) -> Self {
         Self {
             reader,
@@ -388,7 +316,6 @@ impl<R: BufRead> BoundedLineReader<R> {
     }
 
     fn next_line(&mut self) -> std::io::Result<Option<BoundedLine<'_>>> {
-        let start_offset = self.offset;
         let ordinal = self.ordinal;
         self.value.clear();
         let mut saw_bytes = false;
@@ -429,7 +356,6 @@ impl<R: BufRead> BoundedLineReader<R> {
         }
         self.ordinal = self.ordinal.saturating_add(1);
         Ok(Some(BoundedLine {
-            start_offset,
             end_offset: self.offset,
             ordinal,
             value: String::from_utf8_lossy(&self.value),

--- a/crates/bazel-mcp-store/src/record.rs
+++ b/crates/bazel-mcp-store/src/record.rs
@@ -1,7 +1,7 @@
 //! Explicit compact and hydrated invocation record shapes.
 
 use bazel_mcp_types::{
-    CoverageFile, CoverageSummary, Diagnostic, InvocationMetrics, InvocationRecord,
+    CoverageFile, CoverageSummary, Diagnostic, InspectHint, InvocationMetrics, InvocationRecord,
     InvocationRequest, InvocationState, InvocationSummary, QueryRow, TargetCounts, TargetResult,
     Termination, TestCounts, TestResult,
 };
@@ -105,7 +105,7 @@ pub struct InvocationSummaryHeader {
     pub query_result_count: Option<u64>,
     pub elapsed_ms: u64,
     pub truncated: bool,
-    pub inspect_hint: Option<String>,
+    pub inspect_hint: Option<InspectHint>,
 }
 
 impl InvocationSummaryHeader {
@@ -148,7 +148,7 @@ impl From<InvocationSummary> for InvocationSummaryHeader {
             query_result_count: summary.query_result_count,
             elapsed_ms: summary.elapsed_ms,
             truncated: summary.truncated,
-            inspect_hint: summary.inspect_hint.clone(),
+            inspect_hint: summary.inspect_hint,
         }
     }
 }

--- a/crates/bazel-mcp-store/src/storage.rs
+++ b/crates/bazel-mcp-store/src/storage.rs
@@ -17,9 +17,9 @@ use std::sync::atomic::AtomicBool;
 use bazel_mcp_types::{DeferredRetrieval, TargetResult};
 
 use bazel_mcp_types::{
-    Artifact, CoverageFile, DeferredResultRecord, Diagnostic, InvocationId, InvocationMetrics,
-    InvocationRecord, InvocationState, InvocationSummary, Page, PageRequest, QueryRow, Termination,
-    TestResult,
+    Artifact, CoverageFile, DeferredResultRecord, Diagnostic, InspectHint, InvocationId,
+    InvocationMetrics, InvocationRecord, InvocationState, InvocationSummary, Page, PageRequest,
+    QueryRow, Termination, TestResult,
 };
 use serde::de::DeserializeOwned;
 use thiserror::Error;
@@ -40,7 +40,7 @@ use crate::{
     manifest::{
         CURRENT_SCHEMA_VERSION, DurableRecord, decode as decode_durable, read as read_durable,
     },
-    query_paging::{QueryFilePage, page_query_file, page_records},
+    query_paging::{QueryFilePage, count_query_file, page_query_file, page_records},
     record::{HydratedInvocation, InvocationDetails, InvocationHeader},
 };
 
@@ -702,7 +702,7 @@ impl Store {
         id: InvocationId,
         filter: Option<&str>,
         page: PageRequest,
-    ) -> Result<(Page<Diagnostic>, u64, u64), StoreError> {
+    ) -> Result<Page<Diagnostic>, StoreError> {
         let record = self.get_invocation_header(id).await?;
         let items = record
             .summary
@@ -721,7 +721,7 @@ impl Store {
         id: InvocationId,
         filter: Option<&str>,
         page: PageRequest,
-    ) -> Result<(Page<TestResult>, u64, u64), StoreError> {
+    ) -> Result<Page<TestResult>, StoreError> {
         let details = self.read_details(id).await?;
         let items = details.tests;
         page_records("test_results", id, filter, page, items, |item| {
@@ -734,7 +734,7 @@ impl Store {
         id: InvocationId,
         filter: Option<&str>,
         page: PageRequest,
-    ) -> Result<(Page<Artifact>, u64, u64), StoreError> {
+    ) -> Result<Page<Artifact>, StoreError> {
         let mutation_lock = self.mutation_lock(id).await;
         let _guard = mutation_lock.lock().await;
         self.ensure_invocation(id).await?;
@@ -750,7 +750,7 @@ impl Store {
         id: InvocationId,
         filter: Option<&str>,
         page: PageRequest,
-    ) -> Result<(Page<CoverageFile>, u64, u64), StoreError> {
+    ) -> Result<Page<CoverageFile>, StoreError> {
         let details = self.read_details(id).await?;
         let items = details.coverage_files;
         page_records("coverage_files", id, filter, page, items, |item| {
@@ -763,12 +763,21 @@ impl Store {
         id: InvocationId,
         filter: Option<&str>,
         page: PageRequest,
-    ) -> Result<(Page<QueryRow>, u64, u64), StoreError> {
+    ) -> Result<Page<QueryRow>, StoreError> {
         self.page_query_rows_mapped_into(id, filter, page, |value, output| {
             output.clear();
             output.push_str(value);
         })
         .await
+    }
+
+    /// Count newline-delimited query results without decoding or materializing rows.
+    pub async fn count_query_rows(&self, id: InvocationId) -> Result<u64, StoreError> {
+        let mutation_lock = self.mutation_lock(id).await;
+        let _guard = mutation_lock.lock().await;
+        self.ensure_invocation(id).await?;
+        let path = self.paths_for_id(id).stdout;
+        tokio::task::spawn_blocking(move || count_query_file(&path)).await?
     }
 
     /// Page raw query output after applying a caller-supplied text transform.
@@ -780,7 +789,7 @@ impl Store {
         filter: Option<&str>,
         page: PageRequest,
         transform: F,
-    ) -> Result<(Page<QueryRow>, u64, u64), StoreError>
+    ) -> Result<Page<QueryRow>, StoreError>
     where
         F: Fn(&str) -> String + Send + 'static,
     {
@@ -798,7 +807,7 @@ impl Store {
         filter: Option<&str>,
         page: PageRequest,
         transform: F,
-    ) -> Result<(Page<QueryRow>, u64, u64), StoreError>
+    ) -> Result<Page<QueryRow>, StoreError>
     where
         F: Fn(&str, &mut String) + Send + 'static,
     {
@@ -808,8 +817,7 @@ impl Store {
         let known_total = {
             let index = self.inner.index.read().await;
             let entry = index.entries.get(&id).ok_or(StoreError::NotFound(id))?;
-            filter
-                .is_none()
+            (filter.is_none() && entry.record.state.is_terminal())
                 .then(|| {
                     entry
                         .record
@@ -829,10 +837,12 @@ impl Store {
         let start_ordinal = cursor
             .as_ref()
             .map_or(0, |value| value.ordinal.saturating_add(1));
+        let prior_total = cursor.as_ref().map_or(0, |value| value.total_scanned);
+        let prior_filtered = cursor.as_ref().map_or(0, |value| value.filtered_scanned);
         let path = self.paths_for_id(id).stdout;
         let filter = filter.map(str::to_owned);
-        let limit = page.limit.clamp(1, 100) as usize;
-        let maximum_bytes = page.max_bytes.unwrap_or(usize::MAX);
+        let item_limit = page.item_limit.clamp(1, 100) as usize;
+        let scan_limit = page.scan_limit.clamp(page.item_limit.max(1), 10_000) as usize;
         tokio::task::spawn_blocking(move || {
             page_query_file(
                 &path,
@@ -841,8 +851,10 @@ impl Store {
                 QueryFilePage {
                     start_offset,
                     start_ordinal,
-                    limit,
-                    maximum_bytes,
+                    prior_total,
+                    prior_filtered,
+                    item_limit,
+                    scan_limit,
                     known_total,
                 },
                 transform,
@@ -1246,9 +1258,7 @@ async fn recover_interrupted_ids(
             success: false,
             headline: "Invocation was interrupted when the previous server stopped".into(),
             truncated: true,
-            inspect_hint: Some(format!(
-                "Inspect invocation {id} for preserved raw evidence"
-            )),
+            inspect_hint: Some(InspectHint::Log),
             ..InvocationSummary::default()
         });
         if let Some(deferred) = durable.deferred.as_mut() {
@@ -1613,16 +1623,7 @@ mod tests {
             first_id
         );
         let page = first
-            .list_invocations(
-                None,
-                None,
-                None,
-                PageRequest {
-                    cursor: None,
-                    limit: 10,
-                    max_bytes: None,
-                },
-            )
+            .list_invocations(None, None, None, PageRequest::new(None, 10))
             .await
             .unwrap();
         assert_eq!(page.items.len(), 2);
@@ -1743,16 +1744,7 @@ mod tests {
                 }
                 loop {
                     let page = store
-                        .list_invocations(
-                            None,
-                            None,
-                            None,
-                            PageRequest {
-                                cursor: None,
-                                limit: 10,
-                                max_bytes: None,
-                            },
-                        )
+                        .list_invocations(None, None, None, PageRequest::new(None, 10))
                         .await
                         .unwrap();
                     if page.items.len() == 2 {
@@ -1826,16 +1818,7 @@ mod tests {
             .unwrap();
 
         let workspace_page = store
-            .list_invocations(
-                Some(&workspace_a),
-                None,
-                None,
-                PageRequest {
-                    cursor: None,
-                    limit: 10,
-                    max_bytes: None,
-                },
-            )
+            .list_invocations(Some(&workspace_a), None, None, PageRequest::new(None, 10))
             .await
             .unwrap();
         assert_eq!(
@@ -1899,33 +1882,64 @@ mod tests {
             .await
             .unwrap();
         let first = store
+            .page_query_rows(id, Some("needle"), PageRequest::new(None, 1))
+            .await
+            .unwrap();
+        assert_eq!(first.items[0].ordinal, 1);
+        assert_eq!(
+            (first.total_count, first.filtered_count),
+            (Some(3), Some(2))
+        );
+        assert!(first.truncated);
+        let second = store
+            .page_query_rows(id, Some("needle"), PageRequest::new(first.next_cursor, 1))
+            .await
+            .unwrap();
+        assert_eq!(second.items[0].ordinal, 2);
+    }
+
+    #[tokio::test]
+    async fn query_scan_limits_resume_without_gaps_when_a_page_has_no_matches() {
+        let root = TempDir::new().unwrap();
+        let store = Store::open(root.path()).await.unwrap();
+        let record = record(root.path());
+        let id = record.request.id;
+        let paths = store.create_invocation(&record).await.unwrap();
+        tokio::fs::write(&paths.stdout, b"zero\none\nneedle\nthree\n")
+            .await
+            .unwrap();
+        let first = store
             .page_query_rows(
                 id,
                 Some("needle"),
                 PageRequest {
                     cursor: None,
-                    limit: 1,
-                    max_bytes: None,
+                    item_limit: 1,
+                    scan_limit: 2,
                 },
             )
             .await
             .unwrap();
-        assert_eq!(first.0.items[0].ordinal, 1);
-        assert_eq!((first.1, first.2), (3, 2));
-        assert!(first.0.truncated);
+        assert!(first.items.is_empty());
+        assert!(first.truncated);
+        assert_eq!(first.total_count, None);
+        assert_eq!(first.filtered_count, None);
+
         let second = store
             .page_query_rows(
                 id,
                 Some("needle"),
                 PageRequest {
-                    cursor: first.0.next_cursor,
-                    limit: 1,
-                    max_bytes: None,
+                    cursor: first.next_cursor,
+                    item_limit: 1,
+                    scan_limit: 2,
                 },
             )
             .await
             .unwrap();
-        assert_eq!(second.0.items[0].ordinal, 2);
+        assert_eq!(second.items.len(), 1);
+        assert_eq!(second.items[0].ordinal, 2);
+        assert_eq!(second.items[0].value, "needle");
     }
 
     #[tokio::test]
@@ -1940,7 +1954,7 @@ mod tests {
             .unwrap();
         let transformed = Arc::new(AtomicUsize::new(0));
         let observed = transformed.clone();
-        let (page, total, filtered) = store
+        let page = store
             .page_query_rows_mapped_into(
                 id,
                 Some("mixed NEEDLE"),
@@ -1954,13 +1968,13 @@ mod tests {
             .await
             .unwrap();
 
-        assert_eq!((total, filtered), (3, 1));
+        assert_eq!((page.total_count, page.filtered_count), (Some(3), Some(1)));
         assert_eq!(page.items[0].value, "MiXeD needle");
         assert_eq!(transformed.load(AtomicOrdering::Relaxed), 3);
     }
 
     #[tokio::test]
-    async fn serialized_byte_packing_preserves_limit_filter_and_cursor_continuity() {
+    async fn item_limits_preserve_filter_and_cursor_continuity() {
         let root = TempDir::new().unwrap();
         let store = Store::open(root.path()).await.unwrap();
         let record = record(root.path());
@@ -1974,16 +1988,8 @@ mod tests {
         let mut cursor = None;
         let mut ordinals = Vec::new();
         loop {
-            let (page, _, _) = store
-                .page_query_rows(
-                    id,
-                    None,
-                    PageRequest {
-                        cursor,
-                        limit: 100,
-                        max_bytes: Some(120),
-                    },
-                )
+            let page = store
+                .page_query_rows(id, None, PageRequest::new(cursor, 1))
                 .await
                 .unwrap();
             assert_eq!(page.items.len(), 1);
@@ -1995,34 +2001,18 @@ mod tests {
         }
         assert_eq!(ordinals, vec![0, 1, 2, 3, 4]);
 
-        let (requested, _, _) = store
-            .page_query_rows(
-                id,
-                None,
-                PageRequest {
-                    cursor: None,
-                    limit: 3,
-                    max_bytes: Some(8 * 1024),
-                },
-            )
+        let requested = store
+            .page_query_rows(id, None, PageRequest::new(None, 3))
             .await
             .unwrap();
         assert_eq!(requested.items.len(), 3);
         assert!(requested.truncated);
 
-        let (filtered, _, filtered_count) = store
-            .page_query_rows(
-                id,
-                Some("row_3"),
-                PageRequest {
-                    cursor: None,
-                    limit: 100,
-                    max_bytes: Some(8 * 1024),
-                },
-            )
+        let filtered = store
+            .page_query_rows(id, Some("row_3"), PageRequest::new(None, 100))
             .await
             .unwrap();
-        assert_eq!(filtered_count, 1);
+        assert_eq!(filtered.filtered_count, Some(1));
         assert_eq!(filtered.items[0].ordinal, 3);
     }
 
@@ -2039,23 +2029,17 @@ mod tests {
         tokio::fs::write(&paths.stdout, contents).await.unwrap();
         let transformed = Arc::new(AtomicUsize::new(0));
         let observed = transformed.clone();
-        let (page, total, filtered) = store
-            .page_query_rows_mapped(
-                id,
-                None,
-                PageRequest {
-                    cursor: None,
-                    limit: 3,
-                    max_bytes: None,
-                },
-                move |value| {
-                    observed.fetch_add(1, AtomicOrdering::Relaxed);
-                    value.to_owned()
-                },
-            )
+        let page = store
+            .page_query_rows_mapped(id, None, PageRequest::new(None, 3), move |value| {
+                observed.fetch_add(1, AtomicOrdering::Relaxed);
+                value.to_owned()
+            })
             .await
             .unwrap();
-        assert_eq!((total, filtered), (100, 100));
+        assert_eq!(
+            (page.total_count, page.filtered_count),
+            (Some(100), Some(100))
+        );
         assert_eq!(page.items.len(), 3);
         assert_eq!(transformed.load(AtomicOrdering::Relaxed), 3);
     }
@@ -2070,31 +2054,19 @@ mod tests {
         tokio::fs::write(&paths.stdout, b"first\r\ninvalid-\xff\nlast")
             .await
             .unwrap();
-        let (first, total, filtered) = store
-            .page_query_rows(
-                id,
-                None,
-                PageRequest {
-                    cursor: None,
-                    limit: 2,
-                    max_bytes: None,
-                },
-            )
+        assert_eq!(store.count_query_rows(id).await.unwrap(), 3);
+        let first = store
+            .page_query_rows(id, None, PageRequest::new(None, 2))
             .await
             .unwrap();
-        assert_eq!((total, filtered), (3, 3));
+        assert_eq!(
+            (first.total_count, first.filtered_count),
+            (Some(3), Some(3))
+        );
         assert_eq!(first.items[0].value, "first");
         assert_eq!(first.items[1].value, "invalid-�");
-        let (last, _, _) = store
-            .page_query_rows(
-                id,
-                None,
-                PageRequest {
-                    cursor: first.next_cursor,
-                    limit: 2,
-                    max_bytes: None,
-                },
-            )
+        let last = store
+            .page_query_rows(id, None, PageRequest::new(first.next_cursor, 2))
             .await
             .unwrap();
         assert_eq!(last.items[0].value, "last");
@@ -2212,7 +2184,6 @@ mod tests {
                 .page_tests(id, None, PageRequest::default())
                 .await
                 .unwrap()
-                .0
                 .items[0]
                 .label,
             "//private:large-test-detail"
@@ -2222,7 +2193,6 @@ mod tests {
                 .page_coverage(id, None, PageRequest::default())
                 .await
                 .unwrap()
-                .0
                 .items[0]
                 .path,
             "private/large-coverage-detail.rs"
@@ -2785,11 +2755,11 @@ mod tests {
         tokio::fs::write(&paths.stdout, vec![b'x'; 2 * QUERY_LINE_LIMIT])
             .await
             .unwrap();
-        let (page, total, filtered) = store
+        let page = store
             .page_query_rows(id, None, PageRequest::default())
             .await
             .unwrap();
-        assert_eq!((total, filtered), (1, 1));
+        assert_eq!((page.total_count, page.filtered_count), (Some(1), Some(1)));
         assert_eq!(page.items[0].value.len(), QUERY_LINE_LIMIT);
     }
 
@@ -2800,12 +2770,12 @@ mod tests {
         let empty = record(root.path());
         let empty_id = empty.request.id;
         store.create_invocation(&empty).await.unwrap();
-        let (page, total, filtered) = store
+        let page = store
             .page_query_rows(empty_id, None, PageRequest::default())
             .await
             .unwrap();
         assert!(page.items.is_empty());
-        assert_eq!((total, filtered), (0, 0));
+        assert_eq!((page.total_count, page.filtered_count), (Some(0), Some(0)));
 
         let million = record(root.path());
         let million_id = million.request.id;
@@ -2815,20 +2785,13 @@ mod tests {
             writer.write_all(b"row\n").unwrap();
         }
         writer.flush().unwrap();
-        let (page, total, filtered) = store
-            .page_query_rows(
-                million_id,
-                None,
-                PageRequest {
-                    cursor: None,
-                    limit: 3,
-                    max_bytes: None,
-                },
-            )
+        let page = store
+            .page_query_rows(million_id, None, PageRequest::new(None, 3))
             .await
             .unwrap();
         assert_eq!(page.items.len(), 3);
-        assert_eq!((total, filtered), (1_000_000, 1_000_000));
+        assert_eq!((page.total_count, page.filtered_count), (None, None));
+        assert!(page.truncated);
     }
 
     #[tokio::test]

--- a/crates/bazel-mcp-types/Cargo.toml
+++ b/crates/bazel-mcp-types/Cargo.toml
@@ -13,3 +13,5 @@ serde.workspace = true
 thiserror.workspace = true
 uuid.workspace = true
 
+[dev-dependencies]
+serde_json.workspace = true

--- a/crates/bazel-mcp-types/src/inspection.rs
+++ b/crates/bazel-mcp-types/src/inspection.rs
@@ -1,0 +1,357 @@
+use serde::{Deserialize, Serialize, Serializer};
+
+use crate::{
+    Artifact, BazelCommand, CoverageFile, Diagnostic, InspectHint, InvocationId, InvocationMetrics,
+    InvocationState, QueryRow, TargetCounts, Termination, TestCounts, TestResult,
+};
+
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum InspectView {
+    Summary,
+    Metrics,
+    Diagnostics,
+    Tests,
+    TestLog,
+    Coverage,
+    Artifacts,
+    QueryResults,
+    Log,
+    Invocations,
+}
+
+impl InspectView {
+    pub const FOLLOW_UP: [Self; 9] = [
+        Self::Summary,
+        Self::Metrics,
+        Self::Diagnostics,
+        Self::Tests,
+        Self::TestLog,
+        Self::Coverage,
+        Self::Artifacts,
+        Self::QueryResults,
+        Self::Log,
+    ];
+
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Summary => "summary",
+            Self::Metrics => "metrics",
+            Self::Diagnostics => "diagnostics",
+            Self::Tests => "tests",
+            Self::TestLog => "test_log",
+            Self::Coverage => "coverage",
+            Self::Artifacts => "artifacts",
+            Self::QueryResults => "query_results",
+            Self::Log => "log",
+            Self::Invocations => "invocations",
+        }
+    }
+
+    #[must_use]
+    pub fn parse(value: &str) -> Option<Self> {
+        match value {
+            "summary" => Some(Self::Summary),
+            "metrics" => Some(Self::Metrics),
+            "diagnostics" => Some(Self::Diagnostics),
+            "tests" => Some(Self::Tests),
+            "test_log" => Some(Self::TestLog),
+            "coverage" => Some(Self::Coverage),
+            "artifacts" => Some(Self::Artifacts),
+            "query_results" => Some(Self::QueryResults),
+            "log" => Some(Self::Log),
+            "invocations" => Some(Self::Invocations),
+            _ => None,
+        }
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+#[serde(transparent)]
+pub struct AvailableViews(Vec<InspectView>);
+
+impl AvailableViews {
+    #[must_use]
+    pub fn follow_up() -> Self {
+        Self(InspectView::FOLLOW_UP.to_vec())
+    }
+
+    #[must_use]
+    pub fn contains(&self, view: InspectView) -> bool {
+        self.0.contains(&view)
+    }
+
+    #[must_use]
+    pub fn has_details(&self) -> bool {
+        self.0
+            .iter()
+            .any(|view| !matches!(view, InspectView::Summary | InspectView::Metrics))
+    }
+
+    pub fn iter(&self) -> impl Iterator<Item = InspectView> + '_ {
+        self.0.iter().copied()
+    }
+}
+
+impl Default for AvailableViews {
+    fn default() -> Self {
+        Self::follow_up()
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize)]
+pub struct InspectSummary {
+    pub success: bool,
+    pub headline: String,
+    pub targets: TargetCounts,
+    pub tests: TestCounts,
+    pub diagnostics: Vec<Diagnostic>,
+    pub coverage: Option<InspectCoverageSummary>,
+    pub query_result_count: Option<u64>,
+    pub query_sample: Vec<QueryRow>,
+    pub elapsed_ms: u64,
+    pub truncated: bool,
+    pub inspect_hint: Option<InspectHint>,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize)]
+pub struct InspectCoverageSummary {
+    pub lines_found: u64,
+    pub lines_hit: u64,
+    pub coverage_percent: f64,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub struct InspectMetrics {
+    pub state: InvocationState,
+    pub requested_at_ms: i64,
+    pub started_at_ms: Option<i64>,
+    pub finished_at_ms: Option<i64>,
+    pub termination: Option<Termination>,
+    pub metrics: InvocationMetrics,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize)]
+#[serde(untagged)]
+pub enum InspectCoverageItem {
+    File(CoverageFile),
+    Unavailable(InspectCoverageUnavailable),
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub struct InspectCoverageUnavailable {
+    pub availability_reason: &'static str,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub artifact: Option<Artifact>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub struct InvocationLedgerEntry {
+    pub invocation_id: InvocationId,
+    pub workspace: String,
+    pub state: InvocationState,
+    pub command: BazelCommand,
+    pub arguments: Vec<String>,
+    pub arguments_truncated: bool,
+    pub requested_at_ms: i64,
+    pub finished_at_ms: Option<i64>,
+    pub exit_code: Option<i32>,
+    pub duration_ms: u64,
+    pub headline: Option<String>,
+    pub targets: Option<TargetCounts>,
+    pub tests: Option<TestCounts>,
+    pub raw_output_bytes: u64,
+    pub model_visible_bytes: u64,
+    pub inspect_calls: u64,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub enum InspectPayload {
+    Summary(Vec<InspectSummary>),
+    Metrics(Vec<InspectMetrics>),
+    Diagnostics(Vec<Diagnostic>),
+    Tests(Vec<TestResult>),
+    TestLog(Vec<String>),
+    Coverage(Vec<InspectCoverageItem>),
+    Artifacts(Vec<Artifact>),
+    QueryResults(Vec<QueryRow>),
+    Log(Vec<String>),
+    Invocations(Vec<InvocationLedgerEntry>),
+}
+
+impl InspectPayload {
+    #[must_use]
+    pub fn view(&self) -> InspectView {
+        match self {
+            Self::Summary(_) => InspectView::Summary,
+            Self::Metrics(_) => InspectView::Metrics,
+            Self::Diagnostics(_) => InspectView::Diagnostics,
+            Self::Tests(_) => InspectView::Tests,
+            Self::TestLog(_) => InspectView::TestLog,
+            Self::Coverage(_) => InspectView::Coverage,
+            Self::Artifacts(_) => InspectView::Artifacts,
+            Self::QueryResults(_) => InspectView::QueryResults,
+            Self::Log(_) => InspectView::Log,
+            Self::Invocations(_) => InspectView::Invocations,
+        }
+    }
+
+    #[must_use]
+    pub fn len(&self) -> usize {
+        match self {
+            Self::Summary(items) => items.len(),
+            Self::Metrics(items) => items.len(),
+            Self::Diagnostics(items) => items.len(),
+            Self::Tests(items) => items.len(),
+            Self::TestLog(items) | Self::Log(items) => items.len(),
+            Self::Coverage(items) => items.len(),
+            Self::Artifacts(items) => items.len(),
+            Self::QueryResults(items) => items.len(),
+            Self::Invocations(items) => items.len(),
+        }
+    }
+
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    pub fn truncate(&mut self, len: usize) {
+        match self {
+            Self::Summary(items) => items.truncate(len),
+            Self::Metrics(items) => items.truncate(len),
+            Self::Diagnostics(items) => items.truncate(len),
+            Self::Tests(items) => items.truncate(len),
+            Self::TestLog(items) | Self::Log(items) => items.truncate(len),
+            Self::Coverage(items) => items.truncate(len),
+            Self::Artifacts(items) => items.truncate(len),
+            Self::QueryResults(items) => items.truncate(len),
+            Self::Invocations(items) => items.truncate(len),
+        }
+    }
+}
+
+impl Serialize for InspectPayload {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        match self {
+            Self::Summary(items) => items.serialize(serializer),
+            Self::Metrics(items) => items.serialize(serializer),
+            Self::Diagnostics(items) => items.serialize(serializer),
+            Self::Tests(items) => items.serialize(serializer),
+            Self::TestLog(items) | Self::Log(items) => items.serialize(serializer),
+            Self::Coverage(items) => items.serialize(serializer),
+            Self::Artifacts(items) => items.serialize(serializer),
+            Self::QueryResults(items) => items.serialize(serializer),
+            Self::Invocations(items) => items.serialize(serializer),
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize)]
+pub struct InspectResult {
+    pub invocation_id: Option<InvocationId>,
+    pub view: InspectView,
+    pub items: InspectPayload,
+    pub total_count: Option<u64>,
+    pub filtered_count: Option<u64>,
+    pub next_cursor: Option<String>,
+    pub truncated: bool,
+    #[serde(skip)]
+    pub start_cursor: Option<String>,
+    #[serde(skip)]
+    pub item_cursors: Vec<String>,
+}
+
+impl InspectResult {
+    #[must_use]
+    pub fn new(
+        invocation_id: Option<InvocationId>,
+        items: InspectPayload,
+        total_count: Option<u64>,
+        filtered_count: Option<u64>,
+        next_cursor: Option<String>,
+        truncated: bool,
+        item_cursors: Vec<String>,
+    ) -> Self {
+        let view = items.view();
+        Self {
+            invocation_id,
+            view,
+            items,
+            total_count,
+            filtered_count,
+            next_cursor,
+            truncated,
+            start_cursor: None,
+            item_cursors,
+        }
+    }
+
+    #[must_use]
+    pub fn with_start_cursor(mut self, start_cursor: Option<String>) -> Self {
+        self.start_cursor = start_cursor;
+        self
+    }
+
+    pub fn truncate_items(&mut self, len: usize) {
+        if len >= self.items.len() {
+            return;
+        }
+        self.items.truncate(len);
+        self.truncated = true;
+        self.next_cursor = len.checked_sub(1).map_or_else(
+            || self.start_cursor.clone(),
+            |index| self.item_cursors.get(index).cloned(),
+        );
+        self.item_cursors.truncate(len);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn typed_views_and_available_views_preserve_the_wire_contract() {
+        assert_eq!(
+            serde_json::to_value(AvailableViews::follow_up()).unwrap(),
+            serde_json::json!([
+                "summary",
+                "metrics",
+                "diagnostics",
+                "tests",
+                "test_log",
+                "coverage",
+                "artifacts",
+                "query_results",
+                "log"
+            ])
+        );
+        for view in InspectView::FOLLOW_UP {
+            assert_eq!(InspectView::parse(view.as_str()), Some(view));
+        }
+        assert_eq!(InspectView::parse("unknown"), None);
+    }
+
+    #[test]
+    fn packing_cursor_points_after_the_last_emitted_item() {
+        let mut result = InspectResult::new(
+            None,
+            InspectPayload::Log(vec!["one".to_owned(), "two".to_owned()]),
+            None,
+            None,
+            Some("after-two".to_owned()),
+            true,
+            vec!["after-one".to_owned(), "after-two".to_owned()],
+        )
+        .with_start_cursor(Some("start".to_owned()));
+        result.truncate_items(1);
+        assert_eq!(result.next_cursor.as_deref(), Some("after-one"));
+        result.truncate_items(0);
+        assert_eq!(result.next_cursor.as_deref(), Some("start"));
+    }
+}

--- a/crates/bazel-mcp-types/src/lib.rs
+++ b/crates/bazel-mcp-types/src/lib.rs
@@ -5,6 +5,7 @@ mod command;
 mod coverage;
 mod deferred;
 mod diagnostic;
+mod inspection;
 mod invocation;
 mod pagination;
 mod query;
@@ -19,11 +20,16 @@ pub use deferred::{
     DeferredRetrieval, DeferredTerminalState, ResultDisposition,
 };
 pub use diagnostic::{Diagnostic, DiagnosticCategory, DiagnosticLocation, Severity};
+pub use inspection::{
+    AvailableViews, InspectCoverageItem, InspectCoverageSummary, InspectCoverageUnavailable,
+    InspectMetrics, InspectPayload, InspectResult, InspectSummary, InspectView,
+    InvocationLedgerEntry,
+};
 pub use invocation::{
     InvocationId, InvocationMetrics, InvocationRecord, InvocationRequest, InvocationState,
     StateTransitionError, Termination, unix_timestamp_ms,
 };
 pub use pagination::{Page, PageRequest};
 pub use query::QueryRow;
-pub use result::{InvocationSummary, TargetCounts, TargetResult, TestCounts};
+pub use result::{InspectHint, InvocationSummary, TargetCounts, TargetResult, TestCounts};
 pub use test::{TestCase, TestResult, TestStatus};

--- a/crates/bazel-mcp-types/src/pagination.rs
+++ b/crates/bazel-mcp-types/src/pagination.rs
@@ -3,19 +3,30 @@ use serde::{Deserialize, Serialize};
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub struct PageRequest {
     pub cursor: Option<String>,
-    pub limit: u32,
-    /// Optional serialized item-array budget. The storage layer packs complete
-    /// records up to this limit and advances cursors only past emitted records.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub max_bytes: Option<usize>,
+    /// Maximum matching records returned to the caller.
+    pub item_limit: u32,
+    /// Maximum source records examined while producing one page. This keeps
+    /// filtering work bounded independently of representation encoding.
+    pub scan_limit: u32,
 }
 
 impl Default for PageRequest {
     fn default() -> Self {
         Self {
             cursor: None,
-            limit: 50,
-            max_bytes: None,
+            item_limit: 50,
+            scan_limit: 1_000,
+        }
+    }
+}
+
+impl PageRequest {
+    #[must_use]
+    pub fn new(cursor: Option<String>, item_limit: u32) -> Self {
+        Self {
+            cursor,
+            item_limit,
+            ..Self::default()
         }
     }
 }
@@ -23,6 +34,15 @@ impl Default for PageRequest {
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub struct Page<T> {
     pub items: Vec<T>,
+    /// Total source records when known without violating the scan limit.
+    pub total_count: Option<u64>,
+    /// Total matching records when known without violating the scan limit.
+    pub filtered_count: Option<u64>,
     pub next_cursor: Option<String>,
     pub truncated: bool,
+    /// Continuation after each returned item. This stays inside the
+    /// application boundary so a final encoder can pack fewer complete items
+    /// without creating cursor gaps or duplicates.
+    #[serde(default, skip)]
+    pub item_cursors: Vec<String>,
 }

--- a/crates/bazel-mcp-types/src/result.rs
+++ b/crates/bazel-mcp-types/src/result.rs
@@ -2,6 +2,47 @@ use serde::{Deserialize, Serialize};
 
 use crate::{CoverageSummary, Diagnostic, QueryRow, TestResult};
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum InspectHint {
+    Diagnostics,
+    Tests,
+    TestLog,
+    Coverage,
+    Artifacts,
+    QueryResults,
+    Log,
+}
+
+impl InspectHint {
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Diagnostics => "diagnostics",
+            Self::Tests => "tests",
+            Self::TestLog => "test_log",
+            Self::Coverage => "coverage",
+            Self::Artifacts => "artifacts",
+            Self::QueryResults => "query_results",
+            Self::Log => "log",
+        }
+    }
+}
+
+#[cfg(test)]
+mod inspect_hint_tests {
+    use super::InspectHint;
+
+    #[test]
+    fn typed_inspect_hints_preserve_wire_names() {
+        assert_eq!(
+            serde_json::to_string(&InspectHint::QueryResults).unwrap(),
+            "\"query_results\""
+        );
+        assert_eq!(InspectHint::TestLog.as_str(), "test_log");
+    }
+}
+
 #[derive(Clone, Debug, Default, Eq, PartialEq, Serialize, Deserialize)]
 pub struct TargetCounts {
     pub requested: usize,
@@ -40,5 +81,5 @@ pub struct InvocationSummary {
     pub query_result_count: Option<u64>,
     pub elapsed_ms: u64,
     pub truncated: bool,
-    pub inspect_hint: Option<String>,
+    pub inspect_hint: Option<InspectHint>,
 }


### PR DESCRIPTION
## Summary

- introduce typed inspection views, payloads, hints, and available views across types, store, runner, and server
- add protocol-neutral task state plus explicit synchronous, legacy-task, and task-extension adapters
- enforce model-visible byte limits against the exact final Text, TOON, Structured, or Both representation while preserving cursor continuity
- replace JSON-byte pagination with independent item and scan limits while retaining a dedicated buffered query-count path

## Why

Inspection previously became dynamic JSON inside the runner, while approximate byte budgets and retries were spread across storage, runner, and server layers. Task dialect conversion and capability negotiation were likewise interleaved in the main handler. This change centralizes application semantics in typed models, keeps MCP wire concerns at the server boundary, and makes pagination and final response budgeting explicit.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo shear`
- `make test`
- `make mcp-conformance`
- storage A/B benchmark on macOS arm64 with 10,000 query rows and 100 retained invocations:
  - filtered page: 0.585 ms vs 0.584 ms baseline
  - query postprocess: 0.145 ms vs 0.132 ms baseline
  - storage: 401,037 bytes in both runs
  - whole benchmark: 2.984 s vs 3.050 s baseline

`make check` completed formatting and Clippy locally; its Nix wrapper could not run because Nix is unavailable, so `cargo shear` was run directly. The local Claude compatibility harness requires Claude Code 2.1.204, which is not installed. Bazel was not invoked directly because repository policy requires Bazel MCP and that tool is unavailable in this session. CI supplies the Nix, Claude compatibility, Bazel, and cross-platform gates.
