### PR TITLE
build(types): expose dev dependencies to Bazel tests

### DIFF
--- a/crates/bazel-mcp-types/BUILD.bazel
+++ b/crates/bazel-mcp-types/BUILD.bazel
@@ -17,4 +17,7 @@ rust_test(
     name = "unit_test",
     crate = ":bazel_mcp_types",
     size = "small",
+    deps = all_crate_deps(
+        normal_dev = True,
+    ),
 )


### PR DESCRIPTION
## Summary

- expose `bazel-mcp-types` Cargo dev dependencies to its Bazel `rust_test` target

## Why

PR #93 added serialization contract tests using `serde_json`. Cargo correctly resolved the crate from `[dev-dependencies]`, but the Bazel unit-test target did not project dev dependencies and therefore failed to compile in CI.

## Validation

- `cargo test -p bazel-mcp-types`
- `cargo fmt --all -- --check`
- `cargo clippy -p bazel-mcp-types --all-targets --all-features -- -D warnings`
- `git diff --check`

This follows the existing `normal_dev = True` pattern used by the repository's other Bazel Rust unit-test targets. The Bazel compile is verified by CI because repository policy requires Bazel MCP for local Bazel invocations and that tool is unavailable in this session.
