### PR TITLE
fix(runner): preserve filtered test log context

### DIFF
--- a/LEARNINGS.md
+++ b/LEARNINGS.md
@@ -12,10 +12,3 @@ knowledge, Bazel usage, CI or release issues, or workflow advice unrelated to
 MCP efficiency. Do not include secrets or raw sensitive output.
 
 ## Highest priority remaining
-
-1. **Return bounded context for filtered test logs.** Filtering
-   `bazel.inspect test_log` to a failing test name retained the panic header but
-   dropped the adjacent `Result` error because the continuation line did not
-   repeat the filter text. Return a small context window around matches so the
-   causal message remains visible without a targeted rerun. Thread:
-   `019f6df4-be14-75b2-8e2b-654b60a669c3`.

--- a/crates/bazel-mcp-runner/src/inspection.rs
+++ b/crates/bazel-mcp-runner/src/inspection.rs
@@ -23,6 +23,8 @@ use crate::{
     service::{InvocationService, RunnerError, bounded_text},
 };
 
+const TEST_LOG_FILTER_CONTEXT_LINES: usize = 1;
+
 #[derive(Clone, Debug)]
 pub struct InspectRequest {
     pub invocation_id: Option<InvocationId>,
@@ -402,7 +404,7 @@ impl InvocationService {
                     &stdout,
                     &stderr,
                 );
-                return page_evidence_records(records.into_iter(), start, request, invocation_id);
+                return page_evidence_records(records, start, request, invocation_id);
             }
             Err(error) => return Err(error.into()),
         };
@@ -411,7 +413,7 @@ impl InvocationService {
         while let Some(line) = lines.next_line().await? {
             records.push(serde_json::from_str::<EvidenceRecord>(&line)?);
         }
-        page_evidence_records(records.into_iter(), start, request, invocation_id)
+        page_evidence_records(records, start, request, invocation_id)
     }
 
     async fn read_test_log_unavailable_page(
@@ -522,7 +524,7 @@ impl InvocationService {
 }
 
 pub(crate) fn page_evidence_records(
-    records: impl Iterator<Item = EvidenceRecord>,
+    records: Vec<EvidenceRecord>,
     start: u64,
     request: &InspectRequest,
     invocation_id: InvocationId,
@@ -537,8 +539,8 @@ pub(crate) fn page_evidence_records(
     let mut next_record = start;
     let mut scanned = 0_usize;
     let mut truncated = false;
-    for (index, record) in records.enumerate() {
-        let index = u64::try_from(index).unwrap_or(u64::MAX);
+    for (record_index, record) in records.iter().enumerate() {
+        let index = u64::try_from(record_index).unwrap_or(u64::MAX);
         if index < start {
             continue;
         }
@@ -546,12 +548,12 @@ pub(crate) fn page_evidence_records(
             truncated = true;
             break;
         }
-        let matches = filter.as_ref().is_none_or(|filter| {
-            record.text.to_ascii_lowercase().contains(filter)
-                || record
-                    .label
-                    .as_deref()
-                    .is_some_and(|label| label.to_ascii_lowercase().contains(filter))
+        let matches = filter.as_deref().is_none_or(|filter| {
+            if request.view == InspectView::TestLog {
+                test_log_record_matches_context(&records, record_index, filter)
+            } else {
+                evidence_record_matches(record, filter)
+            }
         });
         if matches && items.len() == maximum_items {
             next_record = index;
@@ -568,7 +570,7 @@ pub(crate) fn page_evidence_records(
                 filter: request.filter.clone(),
             }
             .encode()?;
-            items.push(record.text);
+            items.push(record.text.clone());
             item_cursors.push(cursor);
         }
     }
@@ -587,6 +589,25 @@ pub(crate) fn page_evidence_records(
         truncated,
         next_cursor,
     })
+}
+
+fn test_log_record_matches_context(records: &[EvidenceRecord], index: usize, filter: &str) -> bool {
+    let start = index.saturating_sub(TEST_LOG_FILTER_CONTEXT_LINES);
+    let end = index
+        .saturating_add(TEST_LOG_FILTER_CONTEXT_LINES)
+        .saturating_add(1)
+        .min(records.len());
+    records[start..end].iter().any(|candidate| {
+        candidate.label == records[index].label && evidence_record_matches(candidate, filter)
+    })
+}
+
+fn evidence_record_matches(record: &EvidenceRecord, filter: &str) -> bool {
+    record.text.to_ascii_lowercase().contains(filter)
+        || record
+            .label
+            .as_deref()
+            .is_some_and(|label| label.to_ascii_lowercase().contains(filter))
 }
 
 pub(crate) fn should_persist_failure_evidence(command: &BazelCommand, failed: bool) -> bool {

--- a/crates/bazel-mcp-runner/src/service.rs
+++ b/crates/bazel-mcp-runner/src/service.rs
@@ -1151,8 +1151,7 @@ mod tests {
                 .as_deref()
                 .map(|cursor| LogCursor::decode_for(cursor, id, InspectView::Log, None).unwrap())
                 .map_or(0, |cursor| cursor.next_record);
-            let page =
-                page_evidence_records(records.clone().into_iter(), start, &request, id).unwrap();
+            let page = page_evidence_records(records.clone(), start, &request, id).unwrap();
             observed.extend(page.items);
             request.cursor = page.next_cursor;
             if !page.truncated {
@@ -1165,6 +1164,108 @@ mod tests {
                 .map(|index| format!("ERROR: item {index}"))
                 .collect::<Vec<_>>()
         );
+    }
+
+    #[test]
+    fn filtered_test_logs_include_bounded_same_target_context_across_pages() {
+        let id = InvocationId::new();
+        let label = Some("//pkg:process_test".to_owned());
+        let records = vec![
+            EvidenceRecord {
+                label: label.clone(),
+                text: "unrelated setup".to_owned(),
+            },
+            EvidenceRecord {
+                label: label.clone(),
+                text: "---- failing_case stdout ----".to_owned(),
+            },
+            EvidenceRecord {
+                label: label.clone(),
+                text: "thread 'failing_case' panicked at tests/process.rs:42:5".to_owned(),
+            },
+            EvidenceRecord {
+                label,
+                text: "called `Result::unwrap()` on an `Err` value: not found".to_owned(),
+            },
+            EvidenceRecord {
+                label: Some("//pkg:other_test".to_owned()),
+                text: "other target output".to_owned(),
+            },
+        ];
+        let mut request = InspectRequest {
+            invocation_id: Some(id),
+            workspace: None,
+            state: None,
+            command: None,
+            view: InspectView::TestLog,
+            cursor: None,
+            filter: Some("failing_case".to_owned()),
+            item_limit: 2,
+            scan_limit: 2,
+        };
+        let mut observed = Vec::new();
+        loop {
+            let start = request
+                .cursor
+                .as_deref()
+                .map(|cursor| {
+                    LogCursor::decode_for(
+                        cursor,
+                        id,
+                        InspectView::TestLog,
+                        request.filter.as_deref(),
+                    )
+                    .unwrap()
+                })
+                .map_or(0, |cursor| cursor.next_record);
+            let page = page_evidence_records(records.clone(), start, &request, id).unwrap();
+            observed.extend(page.items);
+            request.cursor = page.next_cursor;
+            if !page.truncated {
+                break;
+            }
+        }
+        assert_eq!(
+            observed,
+            vec![
+                "unrelated setup",
+                "---- failing_case stdout ----",
+                "thread 'failing_case' panicked at tests/process.rs:42:5",
+                "called `Result::unwrap()` on an `Err` value: not found",
+            ]
+        );
+    }
+
+    #[test]
+    fn ordinary_log_filters_do_not_expand_to_adjacent_context() {
+        let id = InvocationId::new();
+        let records = vec![
+            EvidenceRecord {
+                label: None,
+                text: "before".to_owned(),
+            },
+            EvidenceRecord {
+                label: None,
+                text: "ERROR: direct match".to_owned(),
+            },
+            EvidenceRecord {
+                label: None,
+                text: "after".to_owned(),
+            },
+        ];
+        let request = InspectRequest {
+            invocation_id: Some(id),
+            workspace: None,
+            state: None,
+            command: None,
+            view: InspectView::Log,
+            cursor: None,
+            filter: Some("direct match".to_owned()),
+            item_limit: 20,
+            scan_limit: 100,
+        };
+        let page = page_evidence_records(records, 0, &request, id).unwrap();
+        assert_eq!(page.items, vec!["ERROR: direct match"]);
     }
 
     #[test]

--- a/crates/bazel-mcp-runner/tests/process.rs
+++ b/crates/bazel-mcp-runner/tests/process.rs
@@ -704,9 +704,12 @@ async fn failed_test_logs_are_snapshotted_and_retrieved_without_a_public_uri() {
     tokio::fs::create_dir_all(&test_directory).await.unwrap();
     let test_log = test_directory.join("test.log");
     let test_xml = test_directory.join("test.xml");
-    tokio::fs::write(&test_log, "setup\npkg/failing_test.go:42: got 1, want 2\n")
-        .await
-        .unwrap();
+    tokio::fs::write(
+        &test_log,
+        "setup\npkg/failing_test.go:42: got 1, want 2\ncaused by adjacent detail token=SUPERSECRET\n",
+    )
+    .await
+    .unwrap();
     tokio::fs::write(
         &test_xml,
         r#"<testsuites><testsuite><testcase name="failing_case" time="0.01"><failure message="expected true"/></testcase></testsuite></testsuites>"#,
@@ -732,7 +735,10 @@ async fn failed_test_logs_are_snapshotted_and_retrieved_without_a_public_uri() {
         bep.display(),
         failed_once.display(),
     );
-    let service = configured_service(&root, &workspace, &script, |_| {}).await;
+    let service = configured_service(&root, &workspace, &script, |config| {
+        config.policy.redaction_patterns = vec![r"token=[^\s]+".to_owned()];
+    })
+    .await;
 
     let failed = service
         .run(InvocationRequest::new(
@@ -788,6 +794,29 @@ async fn failed_test_logs_are_snapshotted_and_retrieved_without_a_public_uri() {
         panic!("test-log inspection returned a different payload type");
     };
     assert!(items.iter().any(|item| item.contains("got 1, want 2")));
+
+    let contextual = service
+        .inspect(InspectRequest {
+            invocation_id: Some(failed.request.id),
+            workspace: None,
+            state: None,
+            command: None,
+            view: InspectView::TestLog,
+            cursor: None,
+            filter: Some("got 1, want 2".into()),
+            item_limit: 20,
+            scan_limit: 10_000,
+        })
+        .await
+        .unwrap();
+    assert_eq!(
+        contextual.items,
+        InspectPayload::TestLog(vec![
+            "[//pkg:failing] setup".to_owned(),
+            "[//pkg:failing] pkg/failing_test.go:42: got 1, want 2".to_owned(),
+            "[//pkg:failing] caused by adjacent detail [REDACTED]".to_owned(),
+        ])
+    );
 
     let failed_paths = service.test_support().paths_for(&failed);
     let retained_before = tokio::fs::read(&failed_paths.test_logs_raw).await.unwrap();

--- a/specs/004-outcome-aware-evidence-retention.md
+++ b/specs/004-outcome-aware-evidence-retention.md
@@ -197,7 +197,10 @@ bounded fallback tail, and opaque forward pagination apply before return.
 The `test_log` view uses the same public string shape. Complete failed-test logs
 are first copied into private invocation storage so a later Bazel invocation
 cannot mutate prior evidence. Redacted line records provide bounded filtering
-and pagination; missing, remote, rejected-by-containment, and expired evidence
+and pagination. A literal line match includes one redacted line of same-target
+context on either side; overlapping windows merge in source order, and every
+context line consumes the ordinary item and byte budgets. Missing, remote,
+rejected-by-containment, and expired evidence
 have explicit reasons.
 
 ## Default retention policy


### PR DESCRIPTION
## Summary

- include one redacted, same-target context line on either side of filtered `test_log` matches
- merge overlapping windows in source order while preserving scan, item, byte, and cursor bounds
- add pagination and snapshot integration coverage, document the behavior, and remove the resolved MCP learning

## Root cause

`bazel.inspect` filtered retained test logs one line at a time. A panic header could match a failing test name while the adjacent continuation containing the causal `Result` error did not, forcing a targeted rerun or second inspection.

## Impact

Filtered test-log inspection now keeps the adjacent causal line in the first bounded response without exposing raw or cross-target evidence.

## Validation

- `bazel.run test //crates/...` — 32 targets built; 14 tests passed
- `make test`
- `cargo clippy -p bazel-mcp-runner --all-targets --all-features -- -D warnings`
- `cargo fmt --all -- --check`
- rebuilt `//:bazel-mcp` and verified the original retained failure through MCP with item and byte pagination

`make check` completed formatting and full-workspace Clippy; its final `cargo shear` step could not start because `nix` was unavailable in the local shell.
