### PR TITLE
fix(reducer): omit Bazel status lines from diagnostics

### DIFF
--- a/crates/bazel-mcp-reducer/src/build.rs
+++ b/crates/bazel-mcp-reducer/src/build.rs
@@ -1034,12 +1034,13 @@ mod tests {
         let summary = reduce_invocation(ReductionInput {
             events: &[],
             stdout: b"",
-            stderr: b"ERROR: Build did NOT complete successfully\nconfig/config.go:12:40: cannot use 42 (untyped int constant) as string value in variable declaration\n",
+            stderr: b"INFO: Analyzed target //config:config (12 packages loaded, 34 targets configured)\nERROR: Build did NOT complete successfully\nconfig/config.go:12:40: cannot use 42 (untyped int constant) as string value in variable declaration\n",
             exit_code: Some(1),
             elapsed_ms: 1,
             budget: Budget::result_default(),
         });
 
+        assert_eq!(summary.diagnostics.len(), 1);
         let diagnostic = &summary.diagnostics[0];
         assert_eq!(diagnostic.category, DiagnosticCategory::Compilation);
         assert_eq!(

--- a/crates/bazel-mcp-reducer/src/diagnostics/arbitration.rs
+++ b/crates/bazel-mcp-reducer/src/diagnostics/arbitration.rs
@@ -34,6 +34,9 @@ pub(super) fn reduce_lines(
         .count();
 
     for (line, count) in candidates {
+        if is_bazel_status_line(&line) {
+            continue;
+        }
         if context.swc_consumed_lines.contains(line.trim())
             || (context.has_swc_diagnostics && javascript::is_swc_action_wrapper(&line))
         {
@@ -132,6 +135,11 @@ fn is_actionable(line: &str) -> bool {
         || (lower.contains("assertion") && lower.contains(" failed"))
         || lower.starts_with("test result: failed")
         || (line.starts_with("test ") && line.ends_with(" ... FAILED"))
+}
+
+fn is_bazel_status_line(line: &str) -> bool {
+    let lower = line.trim().to_ascii_lowercase();
+    lower.starts_with("info:") || lower == "error: build did not complete successfully"
 }
 
 fn category_from_text(line: &str) -> DiagnosticCategory {

--- a/crates/bazel-mcp-reducer/tests/fixtures/bazel-8/keep-going-actions.expected.json
+++ b/crates/bazel-mcp-reducer/tests/fixtures/bazel-8/keep-going-actions.expected.json
@@ -58,15 +58,6 @@
       {
         "severity": "error",
         "category": "compilation",
-        "message": "ERROR: Build did NOT complete successfully",
-        "location": null,
-        "target": null,
-        "action": null,
-        "repetition_count": 1
-      },
-      {
-        "severity": "error",
-        "category": "compilation",
         "message": "ERROR: <WORKSPACE>/BUILD.bazel:3:15: Running fixture action //:compile_failure failed: (Exit 1): bash failed: error executing FixtureAction command (from target //:compile_failure) /bin/bash -c 'echo '\\''fixture.cc:7: error: BAZEL_MCP_CPP_ROOT_CAUSE'\\'' >&2; exit 1'",
         "location": null,
         "target": null,

--- a/crates/bazel-mcp-reducer/tests/fixtures/bazel-8/loading.expected.json
+++ b/crates/bazel-mcp-reducer/tests/fixtures/bazel-8/loading.expected.json
@@ -40,15 +40,6 @@
       },
       {
         "severity": "error",
-        "category": "compilation",
-        "message": "ERROR: Build did NOT complete successfully",
-        "location": null,
-        "target": null,
-        "action": null,
-        "repetition_count": 1
-      },
-      {
-        "severity": "error",
         "category": "unknown",
         "message": "FAILED:",
         "location": null,

--- a/crates/bazel-mcp-reducer/tests/fixtures/bazel-8/visibility.expected.json
+++ b/crates/bazel-mcp-reducer/tests/fixtures/bazel-8/visibility.expected.json
@@ -58,15 +58,6 @@
       },
       {
         "severity": "error",
-        "category": "compilation",
-        "message": "ERROR: Build did NOT complete successfully",
-        "location": null,
-        "target": null,
-        "action": null,
-        "repetition_count": 1
-      },
-      {
-        "severity": "error",
         "category": "unknown",
         "message": "FAILED:",
         "location": null,

--- a/crates/bazel-mcp-reducer/tests/fixtures/bazel-9/keep-going-actions.expected.json
+++ b/crates/bazel-mcp-reducer/tests/fixtures/bazel-9/keep-going-actions.expected.json
@@ -58,15 +58,6 @@
       {
         "severity": "error",
         "category": "compilation",
-        "message": "ERROR: Build did NOT complete successfully",
-        "location": null,
-        "target": null,
-        "action": null,
-        "repetition_count": 1
-      },
-      {
-        "severity": "error",
-        "category": "compilation",
         "message": "ERROR: <WORKSPACE>/BUILD.bazel:3:15: Running fixture action //:compile_failure failed: (Exit 1): bash failed: error executing FixtureAction command (from fixture_action rule target //:compile_failure) /bin/bash -c 'echo '\\''fixture.cc:7: error: BAZEL_MCP_CPP_ROOT_CAUSE'\\'' >&2; exit 1'",
         "location": null,
         "target": null,

--- a/crates/bazel-mcp-reducer/tests/fixtures/bazel-9/loading.expected.json
+++ b/crates/bazel-mcp-reducer/tests/fixtures/bazel-9/loading.expected.json
@@ -40,15 +40,6 @@
       },
       {
         "severity": "error",
-        "category": "compilation",
-        "message": "ERROR: Build did NOT complete successfully",
-        "location": null,
-        "target": null,
-        "action": null,
-        "repetition_count": 1
-      },
-      {
-        "severity": "error",
         "category": "unknown",
         "message": "FAILED:",
         "location": null,

--- a/crates/bazel-mcp-reducer/tests/fixtures/bazel-9/visibility.expected.json
+++ b/crates/bazel-mcp-reducer/tests/fixtures/bazel-9/visibility.expected.json
@@ -58,15 +58,6 @@
       },
       {
         "severity": "error",
-        "category": "compilation",
-        "message": "ERROR: Build did NOT complete successfully",
-        "location": null,
-        "target": null,
-        "action": null,
-        "repetition_count": 1
-      },
-      {
-        "severity": "error",
         "category": "unknown",
         "message": "FAILED:",
         "location": null,

--- a/crates/bazel-mcp-runner/tests/process.rs
+++ b/crates/bazel-mcp-runner/tests/process.rs
@@ -572,6 +572,69 @@ async fn protobuf_source_locations_are_workspace_relative() {
 }
 
 #[tokio::test]
+async fn go_compiler_run_and_diagnostics_inspection_omit_bazel_status_lines() {
+    let root = tempfile::tempdir().unwrap();
+    let workspace = root.path().join("workspace");
+    tokio::fs::create_dir(&workspace).await.unwrap();
+    let service = service(
+        &root,
+        &workspace,
+        "#!/bin/sh\necho 'INFO: Analyzed target //example:broken (8 packages loaded, 12 targets configured)' >&2\necho 'main.go:3:17: cannot use \"not an integer\" (untyped string constant) as int value in variable declaration' >&2\necho 'ERROR: Build did NOT complete successfully' >&2\nexit 1\n",
+    )
+    .await;
+
+    let failed = service
+        .run(InvocationRequest::new(
+            workspace,
+            BazelCommand::Build,
+            vec!["//example:broken".into()],
+        ))
+        .await
+        .unwrap();
+    let summary = failed.summary.as_ref().unwrap();
+    assert_eq!(summary.diagnostics.len(), 1);
+    let diagnostic = &summary.diagnostics[0];
+    assert_eq!(diagnostic.category, DiagnosticCategory::Compilation);
+    assert_eq!(
+        diagnostic.message,
+        "cannot use \"not an integer\" (untyped string constant) as int value in variable declaration"
+    );
+    assert_eq!(
+        diagnostic.location,
+        Some(bazel_mcp_types::DiagnosticLocation {
+            path: "main.go".into(),
+            line: Some(3),
+            column: Some(17),
+        })
+    );
+    assert!(summary.diagnostics.iter().all(|diagnostic| {
+        !diagnostic.message.starts_with("INFO:")
+            && !diagnostic
+                .message
+                .contains("Build did NOT complete successfully")
+    }));
+
+    let inspected = service
+        .inspect(InspectRequest {
+            invocation_id: Some(failed.request.id),
+            workspace: None,
+            state: None,
+            command: None,
+            view: InspectView::Diagnostics,
+            cursor: None,
+            filter: None,
+            item_limit: 20,
+            scan_limit: 10_000,
+        })
+        .await
+        .unwrap();
+    assert_eq!(
+        inspected.items,
+        InspectPayload::Diagnostics(vec![diagnostic.clone()])
+    );
+}
+
+#[tokio::test]
 async fn log_inspection_uses_bounded_opaque_cursors() {
     let root = tempfile::tempdir().unwrap();
     let workspace = root.path().join("workspace");

--- a/testdata/reducer-corpus/bazel-core/action/failure/expected.json
+++ b/testdata/reducer-corpus/bazel-core/action/failure/expected.json
@@ -28,15 +28,6 @@
       {
         "severity": "error",
         "category": "compilation",
-        "message": "ERROR: Build did NOT complete successfully",
-        "location": null,
-        "target": null,
-        "action": null,
-        "repetition_count": 1
-      },
-      {
-        "severity": "error",
-        "category": "compilation",
         "message": "ERROR: <WORKSPACE>/cases/BUILD.bazel:3:16: Running reducer fixture //cases:action_failure failed: (Exit 1): bash failed: error executing ReducerFixtureFailure command (from fixture_failure rule target //cases:action_failure) /bin/bash -c 'echo '\\''ERROR: BAZEL_MCP_ACTION_ROOT_CAUSE'\\'' >&2; exit 1'",
         "location": null,
         "target": null,

--- a/testdata/reducer-corpus/bazel-core/action/fanout/expected.json
+++ b/testdata/reducer-corpus/bazel-core/action/fanout/expected.json
@@ -41,15 +41,6 @@
       {
         "severity": "error",
         "category": "compilation",
-        "message": "ERROR: Build did NOT complete successfully",
-        "location": null,
-        "target": null,
-        "action": null,
-        "repetition_count": 1
-      },
-      {
-        "severity": "error",
-        "category": "compilation",
         "message": "ERROR: <WORKSPACE>/cases/BUILD.bazel:12:16: Running reducer fixture //cases:fanout_one failed: (Exit 1): bash failed: error executing ReducerFixtureFailure command (from fixture_failure rule target //cases:fanout_one) /bin/bash -c 'echo '\\''ERROR: BAZEL_MCP_FANOUT_ROOT_CAUSE_ONE'\\'' >&2; exit 1'",
         "location": null,
         "target": null,

--- a/testdata/reducer-corpus/bazel-core/analysis/rule-failure/expected.json
+++ b/testdata/reducer-corpus/bazel-core/analysis/rule-failure/expected.json
@@ -77,15 +77,6 @@
         "target": null,
         "action": null,
         "repetition_count": 1
-      },
-      {
-        "severity": "error",
-        "category": "compilation",
-        "message": "ERROR: Build did NOT complete successfully",
-        "location": null,
-        "target": null,
-        "action": null,
-        "repetition_count": 1
       }
     ],
     "tests": [],

--- a/testdata/reducer-corpus/bazel-core/loading/missing-package/expected.json
+++ b/testdata/reducer-corpus/bazel-core/loading/missing-package/expected.json
@@ -37,15 +37,6 @@
         "target": null,
         "action": null,
         "repetition_count": 1
-      },
-      {
-        "severity": "error",
-        "category": "compilation",
-        "message": "ERROR: Build did NOT complete successfully",
-        "location": null,
-        "target": null,
-        "action": null,
-        "repetition_count": 1
       }
     ],
     "tests": [],

--- a/testdata/reducer-corpus/bazel-core/visibility/private-target/expected.json
+++ b/testdata/reducer-corpus/bazel-core/visibility/private-target/expected.json
@@ -55,15 +55,6 @@
         "target": null,
         "action": null,
         "repetition_count": 1
-      },
-      {
-        "severity": "error",
-        "category": "compilation",
-        "message": "ERROR: Build did NOT complete successfully",
-        "location": null,
-        "target": null,
-        "action": null,
-        "repetition_count": 1
       }
     ],
     "tests": [],

--- a/testdata/reducer-corpus/cpp/compiler/missing-header/expected.json
+++ b/testdata/reducer-corpus/cpp/compiler/missing-header/expected.json
@@ -32,15 +32,6 @@
       {
         "severity": "error",
         "category": "compilation",
-        "message": "ERROR: Build did NOT complete successfully",
-        "location": null,
-        "target": null,
-        "action": null,
-        "repetition_count": 1
-      },
-      {
-        "severity": "error",
-        "category": "compilation",
         "message": "ERROR: <WORKSPACE>/cases/BUILD.bazel:18:10: Compiling cases/missing_header.cc failed: (Exit 1): cc_wrapper.sh failed: error executing CppCompile command (from cc_binary rule target //cases:missing_header) external/rules_cc++cc_configure_extension+local_config_cc/cc_wrapper.sh -U_FORTIFY_SOURCE -fstack-protector -Wall -Wthread-safety -Wself-assign -Wunused-but-set-parameter -Wno-free-nonheap-object ... (remaining 30 arguments skipped)",
         "location": null,
         "target": null,

--- a/testdata/reducer-corpus/cpp/compiler/type-mismatch/expected.json
+++ b/testdata/reducer-corpus/cpp/compiler/type-mismatch/expected.json
@@ -32,15 +32,6 @@
       {
         "severity": "error",
         "category": "compilation",
-        "message": "ERROR: Build did NOT complete successfully",
-        "location": null,
-        "target": null,
-        "action": null,
-        "repetition_count": 1
-      },
-      {
-        "severity": "error",
-        "category": "compilation",
         "message": "ERROR: <WORKSPACE>/cases/BUILD.bazel:9:10: Compiling cases/type_mismatch.cc failed: (Exit 1): cc_wrapper.sh failed: error executing CppCompile command (from cc_binary rule target //cases:type_mismatch) external/rules_cc++cc_configure_extension+local_config_cc/cc_wrapper.sh -U_FORTIFY_SOURCE -fstack-protector -Wall -Wthread-safety -Wself-assign -Wunused-but-set-parameter -Wno-free-nonheap-object ... (remaining 30 arguments skipped)",
         "location": null,
         "target": null,

--- a/testdata/reducer-corpus/cpp/link/undefined-reference-macos/expected.json
+++ b/testdata/reducer-corpus/cpp/link/undefined-reference-macos/expected.json
@@ -37,15 +37,6 @@
       {
         "severity": "error",
         "category": "compilation",
-        "message": "ERROR: Build did NOT complete successfully",
-        "location": null,
-        "target": null,
-        "action": null,
-        "repetition_count": 1
-      },
-      {
-        "severity": "error",
-        "category": "compilation",
         "message": "ERROR: <WORKSPACE>/cases/BUILD.bazel:27:10: Linking cases/undefined_reference failed: (Exit 1): cc_wrapper.sh failed: error executing CppLink command (from cc_binary rule target //cases:undefined_reference) external/rules_cc++cc_configure_extension+local_config_cc/cc_wrapper.sh @bazel-out/darwin_arm64-fastbuild/bin/cases/undefined_reference-0.params",
         "location": null,
         "target": null,

--- a/testdata/reducer-corpus/go/compiler/type-mismatch/case.toml
+++ b/testdata/reducer-corpus/go/compiler/type-mismatch/case.toml
@@ -1,5 +1,6 @@
 schema_version = 1
 id = "go/compiler/type-mismatch"
+issue = 97
 workspace = "examples/go"
 command = "build"
 args = ["//cases:compile_failure"]
@@ -28,8 +29,10 @@ category = "compilation"
 message_contains = "cannot use \"USD\""
 path = "cases/compile_failure.go"
 line = 4
+column = 9
 
 [expect.absent]
+message_contains = ["INFO: Analyzed target", "Build did NOT complete successfully"]
 raw_contains = ["token=", "authorization:"]
 
 [provenance]

--- a/testdata/reducer-corpus/go/compiler/type-mismatch/expected.json
+++ b/testdata/reducer-corpus/go/compiler/type-mismatch/expected.json
@@ -32,15 +32,6 @@
       {
         "severity": "error",
         "category": "compilation",
-        "message": "ERROR: Build did NOT complete successfully",
-        "location": null,
-        "target": null,
-        "action": null,
-        "repetition_count": 1
-      },
-      {
-        "severity": "error",
-        "category": "compilation",
         "message": "ERROR: <WORKSPACE>/cases/BUILD.bazel:3:11: GoCompilePkg cases/compile_failure.a failed: (Exit 1): builder failed: error executing GoCompilePkg command (from go_library rule target //cases:compile_failure) bazel-out/darwin_arm64-opt-exec/bin/external/rules_go++go_sdk+main___download_0_darwin_arm64/builder_reset/builder compilepkg -sdk external/rules_go++go_sdk+main___download_0_darwin_arm64 -goroot ... (remaining 27 arguments skipped)",
         "location": null,
         "target": null,

--- a/testdata/reducer-corpus/java/compiler/missing-symbol/expected.json
+++ b/testdata/reducer-corpus/java/compiler/missing-symbol/expected.json
@@ -32,15 +32,6 @@
       {
         "severity": "error",
         "category": "compilation",
-        "message": "ERROR: Build did NOT complete successfully",
-        "location": null,
-        "target": null,
-        "action": null,
-        "repetition_count": 1
-      },
-      {
-        "severity": "error",
-        "category": "compilation",
         "message": "ERROR: <WORKSPACE>/cases/BUILD.bazel:3:13: Building cases/libcompile_failure.jar (1 source file) failed: (Exit 1): java failed: error executing Javac command (from java_library rule target //cases:compile_failure) external/rules_java++toolchains+remotejdk25_macos_aarch64/bin/java '--add-exports=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED' '--add-exports=jdk.compiler/com.sun.tools.javac.main=ALL-UNNAMED' ... (remaining 19 arguments skipped)",
         "location": null,
         "target": null,

--- a/testdata/reducer-corpus/protobuf/import/failure/expected.json
+++ b/testdata/reducer-corpus/protobuf/import/failure/expected.json
@@ -45,15 +45,6 @@
       {
         "severity": "error",
         "category": "compilation",
-        "message": "ERROR: Build did NOT complete successfully",
-        "location": null,
-        "target": null,
-        "action": null,
-        "repetition_count": 1
-      },
-      {
-        "severity": "error",
-        "category": "compilation",
         "message": "ERROR: <WORKSPACE>/cases/BUILD.bazel:9:14: Generating Descriptor Set proto_library //cases:import_failure failed: (Exit 1): protoc failed: error executing GenProtoDescriptorSet command (from proto_library rule target //cases:import_failure) external/protobuf++protoc+prebuilt_protoc.osx_aarch_64/bin/protoc '--descriptor_set_out=bazel-out/darwin_arm64-fastbuild/bin/cases/import_failure-descriptor-set.proto.bin' -I. ... (remaining 8 arguments skipped)",
         "location": null,
         "target": null,

--- a/testdata/reducer-corpus/protobuf/syntax/failure/expected.json
+++ b/testdata/reducer-corpus/protobuf/syntax/failure/expected.json
@@ -32,15 +32,6 @@
       {
         "severity": "error",
         "category": "compilation",
-        "message": "ERROR: Build did NOT complete successfully",
-        "location": null,
-        "target": null,
-        "action": null,
-        "repetition_count": 1
-      },
-      {
-        "severity": "error",
-        "category": "compilation",
         "message": "ERROR: <WORKSPACE>/cases/BUILD.bazel:3:14: Generating Descriptor Set proto_library //cases:syntax_failure failed: (Exit 1): protoc failed: error executing GenProtoDescriptorSet command (from proto_library rule target //cases:syntax_failure) external/protobuf++protoc+prebuilt_protoc.osx_aarch_64/bin/protoc '--descriptor_set_out=bazel-out/darwin_arm64-fastbuild/bin/cases/syntax_failure-descriptor-set.proto.bin' -I. ... (remaining 8 arguments skipped)",
         "location": null,
         "target": null,

--- a/testdata/reducer-corpus/protobuf/type/undefined-message/expected.json
+++ b/testdata/reducer-corpus/protobuf/type/undefined-message/expected.json
@@ -32,15 +32,6 @@
       {
         "severity": "error",
         "category": "compilation",
-        "message": "ERROR: Build did NOT complete successfully",
-        "location": null,
-        "target": null,
-        "action": null,
-        "repetition_count": 1
-      },
-      {
-        "severity": "error",
-        "category": "compilation",
         "message": "ERROR: <WORKSPACE>/cases/BUILD.bazel:15:14: Generating Descriptor Set proto_library //cases:type_failure failed: (Exit 1): protoc failed: error executing GenProtoDescriptorSet command (from proto_library rule target //cases:type_failure) external/protobuf++protoc+prebuilt_protoc.osx_aarch_64/bin/protoc '--descriptor_set_out=bazel-out/darwin_arm64-fastbuild/bin/cases/type_failure-descriptor-set.proto.bin' -I. cases/type_failure.proto ... (remaining 7 arguments skipped)",
         "location": null,
         "target": null,

--- a/testdata/reducer-corpus/rust/compiler/type-mismatch/expected.json
+++ b/testdata/reducer-corpus/rust/compiler/type-mismatch/expected.json
@@ -41,15 +41,6 @@
       {
         "severity": "error",
         "category": "compilation",
-        "message": "ERROR: Build did NOT complete successfully",
-        "location": null,
-        "target": null,
-        "action": null,
-        "repetition_count": 1
-      },
-      {
-        "severity": "error",
-        "category": "compilation",
         "message": "ERROR: <WORKSPACE>/cases/BUILD.bazel:3:12: Compiling Rust bin type_mismatch (1 file) failed: (Exit 1): process_wrapper failed: error executing Rustc command (from rust_binary rule target //cases:type_mismatch) bazel-out/darwin_arm64-opt-exec/bin/external/rules_rust+/util/process_wrapper/process_wrapper --subst 'pwd=${pwd}' --subst 'exec_root=${exec_root}' --subst 'output_base=${output_base}' -- ... (remaining 2 arguments skipped)",
         "location": null,
         "target": null,

--- a/testdata/reducer-corpus/starlark/analysis/failure/expected.json
+++ b/testdata/reducer-corpus/starlark/analysis/failure/expected.json
@@ -68,15 +68,6 @@
         "target": null,
         "action": null,
         "repetition_count": 1
-      },
-      {
-        "severity": "error",
-        "category": "compilation",
-        "message": "ERROR: Build did NOT complete successfully",
-        "location": null,
-        "target": null,
-        "action": null,
-        "repetition_count": 1
       }
     ],
     "tests": [],

--- a/testdata/reducer-corpus/starlark/loading/missing-symbol/expected.json
+++ b/testdata/reducer-corpus/starlark/loading/missing-symbol/expected.json
@@ -63,15 +63,6 @@
         "target": null,
         "action": null,
         "repetition_count": 1
-      },
-      {
-        "severity": "error",
-        "category": "compilation",
-        "message": "ERROR: Build did NOT complete successfully",
-        "location": null,
-        "target": null,
-        "action": null,
-        "repetition_count": 1
       }
     ],
     "tests": [],

--- a/testdata/reducer-corpus/starlark/macro/failure/expected.json
+++ b/testdata/reducer-corpus/starlark/macro/failure/expected.json
@@ -50,15 +50,6 @@
         "target": null,
         "action": null,
         "repetition_count": 1
-      },
-      {
-        "severity": "error",
-        "category": "compilation",
-        "message": "ERROR: Build did NOT complete successfully",
-        "location": null,
-        "target": null,
-        "action": null,
-        "repetition_count": 1
       }
     ],
     "tests": [],

--- a/testdata/reducer-corpus/starlark/syntax/failure/expected.json
+++ b/testdata/reducer-corpus/starlark/syntax/failure/expected.json
@@ -59,15 +59,6 @@
         "target": null,
         "action": null,
         "repetition_count": 1
-      },
-      {
-        "severity": "error",
-        "category": "compilation",
-        "message": "ERROR: Build did NOT complete successfully",
-        "location": null,
-        "target": null,
-        "action": null,
-        "repetition_count": 1
       }
     ],
     "tests": [],

--- a/testdata/reducer-corpus/typescript/compiler/type-mismatch/expected.json
+++ b/testdata/reducer-corpus/typescript/compiler/type-mismatch/expected.json
@@ -32,15 +32,6 @@
       {
         "severity": "error",
         "category": "compilation",
-        "message": "ERROR: Build did NOT complete successfully",
-        "location": null,
-        "target": null,
-        "action": null,
-        "repetition_count": 1
-      },
-      {
-        "severity": "error",
-        "category": "compilation",
         "message": "ERROR: <WORKSPACE>/cases/BUILD.bazel:15:8: Executing genrule //cases:typescript_failure failed: (Exit 2): bash failed: error executing Genrule command (from genrule rule target //cases:typescript_failure) /bin/bash -c ... (remaining 1 argument skipped)",
         "location": null,
         "target": null,


### PR DESCRIPTION
## Summary

- filter Bazel `INFO:` progress and terminal `ERROR: Build did NOT complete successfully` lines before generic diagnostic arbitration
- preserve the located Go compiler root cause and its file, line, and column
- add `bazel.run` and retained `bazel.inspect` regression coverage
- update the reviewed Bazel 8/9 and reducer-corpus goldens

## Root cause

Generic line arbitration treated Bazel status output as actionable because it matched broad error heuristics. That promoted non-actionable status text to compilation diagnostics and polluted the initial headline/diagnostic list.

## Validation

- `cargo test --workspace --all-features`
- `cargo test -p bazel-mcp-reducer-cases --test corpus`
- `make check`
- `git diff --check`

Fixes #97
