### PR TITLE
feat(reducer): add Go test failure reducer

### DIFF
--- a/crates/bazel-mcp-reducer-cases/src/replay.rs
+++ b/crates/bazel-mcp-reducer-cases/src/replay.rs
@@ -9,7 +9,7 @@ use bazel_mcp_reducer::{
 };
 use bazel_mcp_types::{
     Artifact, Diagnostic, DiagnosticCategory, DiagnosticLocation, InspectHint, InvocationSummary,
-    Severity,
+    Severity, TestCase, TestStatus,
 };
 use serde::{Deserialize, Serialize};
 
@@ -276,19 +276,46 @@ fn enrich_from_test_log(path: &Path, target: &str, summary: &mut InvocationSumma
         push_test_diagnostic(summary, target, diagnostic);
     }
     for failure in accumulator.finish() {
-        summary.diagnostics.push(Diagnostic {
-            severity: Severity::Error,
-            category: DiagnosticCategory::Test,
-            message: failure.message,
-            location: failure.location.map(|location| DiagnosticLocation {
-                path: location.path,
-                line: location.line,
-                column: location.column,
-            }),
-            target: Some(target.to_owned()),
-            action: None,
-            repetition_count: 1,
-        });
+        let is_go_failure = failure.message.starts_with("Go test ");
+        if is_go_failure {
+            summary.diagnostics.retain(|existing| {
+                !(existing.category == DiagnosticCategory::Test
+                    && existing.target.as_deref() == Some(target)
+                    && existing.location.as_ref() == failure.location.as_ref()
+                    && failure.message.contains(&existing.message))
+            });
+        }
+        if is_go_failure
+            && let Some(test) = summary.tests.iter_mut().find(|test| test.label == target)
+            && test.cases.len() < 20
+            && !test.cases.iter().any(|case| {
+                case.name == failure.name && case.message.as_deref() == Some(&failure.message)
+            })
+        {
+            test.cases.push(TestCase {
+                name: failure.name.clone(),
+                status: TestStatus::Failed,
+                duration_ms: None,
+                message: Some(failure.message.clone()),
+            });
+        }
+        push_test_diagnostic(
+            summary,
+            target,
+            Diagnostic {
+                severity: Severity::Error,
+                category: DiagnosticCategory::Test,
+                message: failure.message,
+                location: failure.location.map(|location| DiagnosticLocation {
+                    path: location.path,
+                    line: location.line,
+                    column: location.column,
+                }),
+                target: Some(target.to_owned()),
+                action: None,
+                repetition_count: 1,
+            },
+        );
     }
     Ok(())
 }
@@ -297,10 +324,15 @@ fn push_test_diagnostic(summary: &mut InvocationSummary, target: &str, mut diagn
     diagnostic.category = DiagnosticCategory::Test;
     diagnostic.target = Some(target.to_owned());
     summary.diagnostics.retain(|existing| {
+        let same_message = existing.message == diagnostic.message;
+        let embedded_located_message = existing.location.is_some()
+            && existing.location == diagnostic.location
+            && diagnostic.message.contains(&existing.message);
         !((existing.category == DiagnosticCategory::Compilation
             || (existing.category == diagnostic.category && existing.target.is_none()))
-            && existing.message == diagnostic.message
-            && (existing.location == diagnostic.location || existing.location.is_none()))
+            && ((same_message
+                && (existing.location == diagnostic.location || existing.location.is_none()))
+                || embedded_located_message))
     });
     summary.diagnostics.push(diagnostic);
 }

--- a/crates/bazel-mcp-reducer/src/test.rs
+++ b/crates/bazel-mcp-reducer/src/test.rs
@@ -14,6 +14,8 @@ const MAX_TEST_NAME_BYTES: usize = 512;
 const MAX_FAILURE_MESSAGE_BYTES: usize = 1_000;
 const MAX_FAILURE_DETAIL_BYTES: usize = 256;
 const MAX_GTEST_DETAILS: usize = 8;
+const MAX_GO_DETAILS: usize = 6;
+const MAX_GO_BLOCKS: usize = MAX_LOG_FAILURES * 4;
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct TestFailureEvidence {
@@ -24,9 +26,10 @@ pub struct TestFailureEvidence {
 
 /// Streaming, bounded extraction of concrete failed-test evidence from test logs.
 ///
-/// The first supported structured format is Rust's libtest output. Keeping this
-/// state machine in the reducer makes selection deterministic without retaining
-/// an entire potentially large test log in memory.
+/// Supported structured formats include Rust libtest, GoogleTest, and Go's
+/// standard test output. Keeping these state machines in the reducer makes
+/// selection deterministic without retaining an entire potentially large test
+/// log in memory.
 #[derive(Default)]
 pub struct TestFailureAccumulator {
     failed_names: Vec<String>,
@@ -34,6 +37,9 @@ pub struct TestFailureAccumulator {
     current: Option<RustFailureBlock>,
     gtest_running_name: Option<String>,
     gtest_current: Option<GtestFailureBlock>,
+    go_running_name: Option<String>,
+    go_panic_name: Option<String>,
+    go_blocks: Vec<GoFailureBlock>,
 }
 
 #[derive(Default)]
@@ -53,10 +59,55 @@ struct GtestFailureBlock {
     details: Vec<String>,
 }
 
+#[derive(Default, Eq, PartialEq)]
+struct GoFailureBlock {
+    name: String,
+    location: Option<DiagnosticLocation>,
+    location_rank: u8,
+    assertion: Option<String>,
+    panic_message: Option<String>,
+    details: Vec<String>,
+    failed: bool,
+}
+
 impl TestFailureAccumulator {
     pub fn observe_line(&mut self, line: &str) {
         let line = line.trim();
         if line.is_empty() {
+            return;
+        }
+
+        if let Some(name) = go_running_name(line) {
+            self.compact_go_blocks();
+            self.go_running_name = Some(bounded_text(name, MAX_TEST_NAME_BYTES));
+            self.go_panic_name = None;
+            return;
+        }
+
+        if let Some(name) = go_failed_status_name(line) {
+            self.observe_go_failure_status(name);
+            return;
+        }
+
+        if is_go_nonfailure_status(line) && self.go_running_name.is_some() {
+            self.go_panic_name = None;
+            self.go_running_name = None;
+            return;
+        }
+
+        if let Some(message) = go_panic_message(line)
+            && self.observe_go_panic(message)
+        {
+            return;
+        }
+
+        if let Some((location, message, stack_frame)) = go_test_location(line)
+            && self.observe_go_location(location, message, stack_frame)
+        {
+            return;
+        }
+
+        if self.observe_go_detail(line) {
             return;
         }
 
@@ -164,6 +215,7 @@ impl TestFailureAccumulator {
     pub fn finish(mut self) -> Vec<TestFailureEvidence> {
         self.finish_current();
         self.finish_gtest_current();
+        self.finish_go_failures();
         for name in self.failed_names {
             if self.failures.len() >= MAX_LOG_FAILURES {
                 break;
@@ -241,6 +293,213 @@ impl TestFailureAccumulator {
             message: bounded_text(&message, MAX_FAILURE_MESSAGE_BYTES),
             location: current.location,
         });
+    }
+
+    fn observe_go_failure_status(&mut self, name: &str) {
+        let name = bounded_text(name, MAX_TEST_NAME_BYTES);
+        let index = self
+            .go_blocks
+            .iter()
+            .rposition(|block| block.name == name && !block.failed)
+            .or_else(|| self.push_go_block(&name));
+        if let Some(index) = index {
+            self.go_blocks[index].failed = true;
+        }
+        self.go_running_name = Some(name.clone());
+        self.go_panic_name = Some(name);
+    }
+
+    fn observe_go_panic(&mut self, message: &str) -> bool {
+        let Some(name) = self
+            .go_panic_name
+            .clone()
+            .or_else(|| self.go_running_name.clone())
+        else {
+            return false;
+        };
+        let Some(index) = self.go_block_index(&name, true) else {
+            return true;
+        };
+        let block = &mut self.go_blocks[index];
+        if block.panic_message.is_none() {
+            block.panic_message = Some(bounded_text(message, MAX_FAILURE_DETAIL_BYTES));
+        }
+        self.go_panic_name = Some(name);
+        true
+    }
+
+    fn observe_go_location(
+        &mut self,
+        location: DiagnosticLocation,
+        message: Option<&str>,
+        stack_frame: bool,
+    ) -> bool {
+        let panic_context = self.go_panic_name.is_some();
+        let Some(name) = self
+            .go_panic_name
+            .clone()
+            .or_else(|| self.go_running_name.clone())
+        else {
+            return false;
+        };
+        if stack_frame && is_go_runtime_path(&location.path) {
+            return true;
+        }
+        let Some(index) = self.go_block_index(&name, panic_context) else {
+            return true;
+        };
+        let block = &mut self.go_blocks[index];
+        let rank = if stack_frame && !location.path.ends_with("_test.go") {
+            1
+        } else {
+            0
+        };
+        if block.location.is_none() || rank < block.location_rank {
+            block.location = Some(location);
+            block.location_rank = rank;
+        }
+        if let Some(message) = message.filter(|message| !message.is_empty()) {
+            if block.assertion.is_none() {
+                block.assertion = Some(bounded_text(message, MAX_FAILURE_DETAIL_BYTES));
+            } else if is_go_assertion_detail(message) {
+                push_unique_bounded(
+                    &mut block.details,
+                    message,
+                    MAX_GO_DETAILS,
+                    MAX_FAILURE_DETAIL_BYTES,
+                );
+            }
+        }
+        true
+    }
+
+    fn observe_go_detail(&mut self, line: &str) -> bool {
+        let panic_context = self.go_panic_name.is_some();
+        let Some(name) = self
+            .go_panic_name
+            .clone()
+            .or_else(|| self.go_running_name.clone())
+        else {
+            return false;
+        };
+        if is_go_framework_noise(line) || looks_like_go_stack_frame(line) {
+            return false;
+        }
+        let existing = self
+            .go_blocks
+            .iter()
+            .rposition(|block| block.name == name && (panic_context || !block.failed));
+        if !is_go_assertion_detail(line)
+            && !existing.is_some_and(|index| {
+                let block = &self.go_blocks[index];
+                block.location.is_some() && block.assertion.is_none()
+            })
+        {
+            return false;
+        }
+        let Some(index) = existing.or_else(|| self.push_go_block(&name)) else {
+            return false;
+        };
+        let block = &mut self.go_blocks[index];
+        if is_go_assertion_detail(line) {
+            if block.assertion.is_none() {
+                block.assertion = Some(bounded_text(line, MAX_FAILURE_DETAIL_BYTES));
+            } else {
+                push_unique_bounded(
+                    &mut block.details,
+                    line,
+                    MAX_GO_DETAILS,
+                    MAX_FAILURE_DETAIL_BYTES,
+                );
+            }
+            return true;
+        }
+        if block.location.is_some() && block.assertion.is_none() {
+            block.assertion = Some(bounded_text(line, MAX_FAILURE_DETAIL_BYTES));
+            return true;
+        }
+        false
+    }
+
+    fn go_block_index(&mut self, name: &str, include_failed: bool) -> Option<usize> {
+        self.go_blocks
+            .iter()
+            .rposition(|block| block.name == name && (include_failed || !block.failed))
+            .or_else(|| self.push_go_block(name))
+    }
+
+    fn push_go_block(&mut self, name: &str) -> Option<usize> {
+        if self.go_blocks.len() >= MAX_GO_BLOCKS {
+            self.compact_go_blocks();
+            if self.go_blocks.len() >= MAX_GO_BLOCKS {
+                return None;
+            }
+        }
+        self.go_blocks.push(GoFailureBlock {
+            name: bounded_text(name, MAX_TEST_NAME_BYTES),
+            location_rank: u8::MAX,
+            ..GoFailureBlock::default()
+        });
+        Some(self.go_blocks.len() - 1)
+    }
+
+    fn compact_go_blocks(&mut self) {
+        let mut unique = Vec::with_capacity(self.go_blocks.len());
+        for block in std::mem::take(&mut self.go_blocks) {
+            if block.failed
+                && unique
+                    .iter()
+                    .any(|current: &GoFailureBlock| current.failed && current == &block)
+            {
+                continue;
+            }
+            unique.push(block);
+        }
+        self.go_blocks = unique;
+    }
+
+    fn finish_go_failures(&mut self) {
+        for block in std::mem::take(&mut self.go_blocks)
+            .into_iter()
+            .filter(|block| block.failed)
+        {
+            if self.failures.len() >= MAX_LOG_FAILURES {
+                break;
+            }
+            let mut message = if block.panic_message.is_some() {
+                format!("Go test {} panicked", block.name)
+            } else {
+                format!("Go test {} failed", block.name)
+            };
+            if let Some(location) = &block.location {
+                message.push_str(" at ");
+                message.push_str(&location.path);
+                if let Some(line) = location.line {
+                    message.push(':');
+                    message.push_str(&line.to_string());
+                }
+                if let Some(column) = location.column {
+                    message.push(':');
+                    message.push_str(&column.to_string());
+                }
+            }
+            if let Some(reason) = block.panic_message.or(block.assertion) {
+                message.push_str(": ");
+                message.push_str(&reason);
+            }
+            for detail in block.details {
+                message.push_str("; ");
+                message.push_str(&detail);
+            }
+            let evidence = TestFailureEvidence {
+                name: block.name,
+                message: bounded_text(&message, MAX_FAILURE_MESSAGE_BYTES),
+                location: block.location,
+            };
+            if !self.failures.iter().any(|current| current == &evidence) {
+                self.failures.push(evidence);
+            }
+        }
     }
 }
 
@@ -333,6 +592,126 @@ fn gtest_failed_name(line: &str) -> Option<&str> {
             .map_or(name, |_| name)
     });
     (!name.is_empty()).then_some(name)
+}
+
+fn go_running_name(line: &str) -> Option<&str> {
+    line.strip_prefix("=== RUN")
+        .map(str::trim)
+        .filter(|name| !name.is_empty())
+}
+
+fn go_failed_status_name(line: &str) -> Option<&str> {
+    let name = line.strip_prefix("--- FAIL:")?.trim();
+    let name = name.rsplit_once(" (").map_or(name, |(name, duration)| {
+        duration.strip_suffix(')').map_or(name, |_| name)
+    });
+    (!name.is_empty()).then_some(name)
+}
+
+fn is_go_nonfailure_status(line: &str) -> bool {
+    line.starts_with("--- PASS:") || line.starts_with("--- SKIP:")
+}
+
+fn go_panic_message(line: &str) -> Option<&str> {
+    let message = line.strip_prefix("panic:")?.trim();
+    let message = [" [recovered, repanicked]", " [recovered]"]
+        .into_iter()
+        .find_map(|suffix| message.strip_suffix(suffix))
+        .unwrap_or(message)
+        .trim();
+    (!message.is_empty()).then_some(message)
+}
+
+fn go_test_location(line: &str) -> Option<(DiagnosticLocation, Option<&str>, bool)> {
+    let marker = line.rfind(".go:")?;
+    let path_end = marker + ".go".len();
+    let raw_path = line[..path_end].trim();
+    let error_trace = raw_path.strip_prefix("Error Trace:").map(str::trim);
+    let path = error_trace.unwrap_or(raw_path);
+    if path.is_empty() {
+        return None;
+    }
+
+    let remainder = &line[path_end + 1..];
+    let digit_count = remainder.bytes().take_while(u8::is_ascii_digit).count();
+    if digit_count == 0 {
+        return None;
+    }
+    let line_number = remainder[..digit_count].parse::<u32>().ok()?;
+    let mut remainder = &remainder[digit_count..];
+    let mut column = None;
+    let mut stack_frame = error_trace.is_none() && !remainder.starts_with(':');
+    let mut message = None;
+    if let Some(after_colon) = remainder.strip_prefix(':') {
+        remainder = after_colon;
+        let column_digits = remainder.bytes().take_while(u8::is_ascii_digit).count();
+        if column_digits > 0 && remainder[column_digits..].starts_with(':') {
+            column = remainder[..column_digits].parse::<u32>().ok();
+            remainder = &remainder[column_digits + 1..];
+        }
+        let text = remainder.trim();
+        if !text.is_empty() {
+            stack_frame = text.starts_with("+0x");
+            if !stack_frame {
+                message = Some(text);
+            }
+        }
+    }
+
+    Some((
+        DiagnosticLocation {
+            path: bounded_text(&compact_test_path(path), MAX_FAILURE_DETAIL_BYTES),
+            line: Some(line_number),
+            column,
+        },
+        message,
+        stack_frame,
+    ))
+}
+
+fn is_go_runtime_path(path: &str) -> bool {
+    let absolute = path.starts_with('/') || path.as_bytes().get(1) == Some(&b':');
+    absolute
+        && ["/src/runtime/", "/src/testing/"]
+            .iter()
+            .any(|component| path.contains(component))
+}
+
+fn is_go_assertion_detail(line: &str) -> bool {
+    let lower = line.to_ascii_lowercase();
+    [
+        "got:",
+        "want:",
+        "expected:",
+        "actual:",
+        "error:",
+        "fatal:",
+        "message:",
+        "messages:",
+        "diff:",
+    ]
+    .iter()
+    .any(|prefix| lower.starts_with(prefix))
+}
+
+fn is_go_framework_noise(line: &str) -> bool {
+    let lower = line.to_ascii_lowercase();
+    line.starts_with("=== ")
+        || line.starts_with("--- ")
+        || line.starts_with("goroutine ")
+        || line.starts_with("created by ")
+        || lower == "pass"
+        || lower == "fail"
+        || lower.starts_with("ok\t")
+        || lower.starts_with("?\t")
+        || lower.starts_with("coverage:")
+        || lower.starts_with("exit status ")
+}
+
+fn looks_like_go_stack_frame(line: &str) -> bool {
+    (line.contains('(') && line.split_whitespace().count() == 1)
+        || line.starts_with("testing.")
+        || line.starts_with("runtime.")
 }
 
 fn gtest_failure_location(line: &str) -> Option<Option<DiagnosticLocation>> {
@@ -446,7 +825,15 @@ fn bounded_text(value: &str, maximum_bytes: usize) -> String {
     if value.len() <= maximum_bytes {
         return value.to_owned();
     }
-    let mut boundary = maximum_bytes;
+    let ellipsis_bytes = '…'.len_utf8();
+    if maximum_bytes < ellipsis_bytes {
+        let mut boundary = maximum_bytes;
+        while !value.is_char_boundary(boundary) {
+            boundary -= 1;
+        }
+        return value[..boundary].to_owned();
+    }
+    let mut boundary = maximum_bytes - ellipsis_bytes;
     while !value.is_char_boundary(boundary) {
         boundary -= 1;
     }
@@ -602,5 +989,57 @@ mod tests {
         );
         assert_eq!(failures[0].location, None);
         assert!(!failures[0].message.contains("unknown file"));
+    }
+
+    #[test]
+    fn bounds_go_failure_items_names_locations_and_messages() {
+        let mut accumulator = TestFailureAccumulator::default();
+        let path = format!("{}failure_test.go", "very-long-segment/".repeat(24));
+        for index in 0..25 {
+            let name = format!("Test{index:02}_{}", "name".repeat(160));
+            accumulator.observe_line(&format!("=== RUN   {name}"));
+            accumulator.observe_line(&format!("{path}:7: assertion {}", "message".repeat(80)));
+            for detail in 0..6 {
+                accumulator
+                    .observe_line(&format!("expected: detail {detail} {}", "value".repeat(80)));
+            }
+            accumulator.observe_line(&format!("--- FAIL: {name} (0.00s)"));
+        }
+
+        let failures = accumulator.finish();
+        assert_eq!(failures.len(), MAX_LOG_FAILURES);
+        for failure in failures {
+            assert!(failure.name.len() <= MAX_TEST_NAME_BYTES);
+            assert!(failure.message.len() <= MAX_FAILURE_MESSAGE_BYTES);
+            let location = failure.location.unwrap();
+            assert!(location.path.len() <= MAX_FAILURE_DETAIL_BYTES);
+            assert_eq!(location.line, Some(7));
+        }
+    }
+
+    #[test]
+    fn repeated_go_fanout_does_not_consume_the_unique_failure_budget() {
+        let mut accumulator = TestFailureAccumulator::default();
+        for _ in 0..(MAX_GO_BLOCKS + 5) {
+            for line in [
+                "=== RUN   TestRepeated",
+                "repeat_test.go:4: got false; want true",
+                "--- FAIL: TestRepeated (0.00s)",
+            ] {
+                accumulator.observe_line(line);
+            }
+        }
+        for line in [
+            "=== RUN   TestUnique",
+            "unique_test.go:8: fatal: unique failure",
+            "--- FAIL: TestUnique (0.00s)",
+        ] {
+            accumulator.observe_line(line);
+        }
+
+        let failures = accumulator.finish();
+        assert_eq!(failures.len(), 2);
+        assert_eq!(failures[0].name, "TestRepeated");
+        assert_eq!(failures[1].name, "TestUnique");
     }
 }

--- a/crates/bazel-mcp-reducer/src/test_evidence.rs
+++ b/crates/bazel-mcp-reducer/src/test_evidence.rs
@@ -257,4 +257,38 @@ mod tests {
         assert_eq!(result.diagnostics.len(), 1);
         assert!(result.diagnostics[0].message.contains("assertion"));
     }
+
+    #[test]
+    fn reducer_collapses_duplicate_go_fanout_and_excludes_framework_noise() {
+        let mut reducer = TestEvidenceReducer::new(TestEvidenceInput {
+            label: "//example:go_test",
+        });
+        for _ in 0..2 {
+            for line in [
+                "=== RUN   TestInvoiceTotal",
+                "invoice_test.go:18: got 42; want 41",
+                "--- FAIL: TestInvoiceTotal (0.00s)",
+                "FAIL",
+            ] {
+                reducer.observe_line(line);
+            }
+            reducer.finish_log(true);
+        }
+        let result = reducer.finish();
+
+        assert_eq!(result.cases.len(), 1);
+        assert_eq!(result.cases[0].name, "TestInvoiceTotal");
+        assert_eq!(result.diagnostics.len(), 1);
+        assert_eq!(
+            result.diagnostics[0].category,
+            bazel_mcp_types::DiagnosticCategory::Test
+        );
+        assert_eq!(
+            result.diagnostics[0].target.as_deref(),
+            Some("//example:go_test")
+        );
+        assert!(result.diagnostics[0].message.contains("got 42; want 41"));
+        assert!(!result.diagnostics[0].message.contains("=== RUN"));
+        assert!(!result.diagnostics[0].message.ends_with("FAIL"));
+    }
 }

--- a/crates/bazel-mcp-reducer/tests/fixtures/test-logs/go/ordinary.expected.json
+++ b/crates/bazel-mcp-reducer/tests/fixtures/test-logs/go/ordinary.expected.json
@@ -1,0 +1,11 @@
+[
+  {
+    "name": "TestInvoiceTotal",
+    "message": "Go test TestInvoiceTotal failed at invoice_test.go:18: got 42; want 41",
+    "location": {
+      "path": "invoice_test.go",
+      "line": 18,
+      "column": null
+    }
+  }
+]

--- a/crates/bazel-mcp-reducer/tests/fixtures/test-logs/go/ordinary.log
+++ b/crates/bazel-mcp-reducer/tests/fixtures/test-logs/go/ordinary.log
@@ -1,0 +1,4 @@
+=== RUN   TestInvoiceTotal
+    invoice_test.go:18: got 42; want 41
+--- FAIL: TestInvoiceTotal (0.00s)
+FAIL

--- a/crates/bazel-mcp-reducer/tests/fixtures/test-logs/go/panic.expected.json
+++ b/crates/bazel-mcp-reducer/tests/fixtures/test-logs/go/panic.expected.json
@@ -1,0 +1,11 @@
+[
+  {
+    "name": "TestWorkerPanic",
+    "message": "Go test TestWorkerPanic panicked at pkg/worker_test.go:57: queue closed",
+    "location": {
+      "path": "pkg/worker_test.go",
+      "line": 57,
+      "column": null
+    }
+  }
+]

--- a/crates/bazel-mcp-reducer/tests/fixtures/test-logs/go/panic.log
+++ b/crates/bazel-mcp-reducer/tests/fixtures/test-logs/go/panic.log
@@ -1,0 +1,16 @@
+=== RUN   TestWorkerPanic
+--- FAIL: TestWorkerPanic (0.00s)
+panic: queue closed [recovered, repanicked]
+
+goroutine 19 [running]:
+testing.tRunner.func1.2(...)
+    /usr/local/go/src/testing/testing.go:1872 +0x237
+testing.tRunner.func1()
+    /usr/local/go/src/testing/testing.go:1875 +0x35b
+example.com/project/pkg.TestWorkerPanic(...)
+    /private/tmp/_bazel_user/hash/sandbox/darwin-sandbox/7/execroot/_main/pkg/worker_test.go:57 +0x45
+runtime.goexit({})
+    /usr/local/go/src/runtime/asm_amd64.s:1700 +0x1
+created by testing.(*T).Run in goroutine 1
+    /usr/local/go/src/testing/testing.go:1934 +0x485
+FAIL

--- a/crates/bazel-mcp-reducer/tests/fixtures/test-logs/go/repeated.expected.json
+++ b/crates/bazel-mcp-reducer/tests/fixtures/test-logs/go/repeated.expected.json
@@ -1,0 +1,20 @@
+[
+  {
+    "name": "TestRetry",
+    "message": "Go test TestRetry failed at retry_test.go:9: got false; want true",
+    "location": {
+      "path": "retry_test.go",
+      "line": 9,
+      "column": null
+    }
+  },
+  {
+    "name": "TestBackend",
+    "message": "Go test TestBackend failed at backend_test.go:11: fatal: service unavailable",
+    "location": {
+      "path": "backend_test.go",
+      "line": 11,
+      "column": null
+    }
+  }
+]

--- a/crates/bazel-mcp-reducer/tests/fixtures/test-logs/go/repeated.log
+++ b/crates/bazel-mcp-reducer/tests/fixtures/test-logs/go/repeated.log
@@ -1,0 +1,10 @@
+=== RUN   TestRetry
+    retry_test.go:9: got false; want true
+--- FAIL: TestRetry (0.00s)
+=== RUN   TestRetry
+    retry_test.go:9: got false; want true
+--- FAIL: TestRetry (0.00s)
+=== RUN   TestBackend
+    backend_test.go:11: fatal: service unavailable
+--- FAIL: TestBackend (0.00s)
+FAIL

--- a/crates/bazel-mcp-reducer/tests/fixtures/test-logs/go/subtests.expected.json
+++ b/crates/bazel-mcp-reducer/tests/fixtures/test-logs/go/subtests.expected.json
@@ -1,0 +1,16 @@
+[
+  {
+    "name": "TestCache/miss",
+    "message": "Go test TestCache/miss failed at cache_test.go:42: cache lookup returned an empty entry",
+    "location": {
+      "path": "cache_test.go",
+      "line": 42,
+      "column": null
+    }
+  },
+  {
+    "name": "TestCache",
+    "message": "Go test TestCache failed",
+    "location": null
+  }
+]

--- a/crates/bazel-mcp-reducer/tests/fixtures/test-logs/go/subtests.log
+++ b/crates/bazel-mcp-reducer/tests/fixtures/test-logs/go/subtests.log
@@ -1,0 +1,6 @@
+=== RUN   TestCache
+=== RUN   TestCache/miss
+    cache_test.go:42: cache lookup returned an empty entry
+--- FAIL: TestCache (0.00s)
+    --- FAIL: TestCache/miss (0.00s)
+FAIL

--- a/crates/bazel-mcp-reducer/tests/fixtures/test-logs/go/table.expected.json
+++ b/crates/bazel-mcp-reducer/tests/fixtures/test-logs/go/table.expected.json
@@ -1,0 +1,16 @@
+[
+  {
+    "name": "TestNormalize/unicode",
+    "message": "Go test TestNormalize/unicode failed at normalize_test.go:31: got: \"cafe\"; want: \"café\"",
+    "location": {
+      "path": "normalize_test.go",
+      "line": 31,
+      "column": null
+    }
+  },
+  {
+    "name": "TestNormalize",
+    "message": "Go test TestNormalize failed",
+    "location": null
+  }
+]

--- a/crates/bazel-mcp-reducer/tests/fixtures/test-logs/go/table.log
+++ b/crates/bazel-mcp-reducer/tests/fixtures/test-logs/go/table.log
@@ -1,0 +1,10 @@
+=== RUN   TestNormalize
+=== RUN   TestNormalize/empty
+--- PASS: TestNormalize/empty (0.00s)
+=== RUN   TestNormalize/unicode
+    normalize_test.go:31:
+        got: "cafe"
+        want: "café"
+--- FAIL: TestNormalize (0.00s)
+    --- FAIL: TestNormalize/unicode (0.00s)
+FAIL

--- a/crates/bazel-mcp-reducer/tests/test_log_golden.rs
+++ b/crates/bazel-mcp-reducer/tests/test_log_golden.rs
@@ -1,0 +1,54 @@
+use std::{fs, path::Path};
+
+use bazel_mcp_reducer::{TestFailureAccumulator, normalize_terminal_text};
+use bazel_mcp_types::DiagnosticLocation;
+use serde::Serialize;
+
+const CASES: [&str; 5] = ["ordinary", "subtests", "table", "panic", "repeated"];
+
+#[derive(Serialize)]
+struct GoldenFailure<'a> {
+    name: &'a str,
+    message: &'a str,
+    location: &'a Option<DiagnosticLocation>,
+}
+
+#[test]
+fn go_test_log_goldens_preserve_reviewed_reducer_behavior() {
+    let root = Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/test-logs/go");
+    for case in CASES {
+        assert_golden(&root, case);
+    }
+}
+
+fn assert_golden(root: &Path, case: &str) {
+    let prefix = root.join(case);
+    let input = fs::read(prefix.with_extension("log")).unwrap();
+    let normalized = normalize_terminal_text(&input);
+    let mut accumulator = TestFailureAccumulator::default();
+    for line in normalized.lines() {
+        accumulator.observe_line(line);
+    }
+    let failures = accumulator.finish();
+    let output = failures
+        .iter()
+        .map(|failure| GoldenFailure {
+            name: &failure.name,
+            message: &failure.message,
+            location: &failure.location,
+        })
+        .collect::<Vec<_>>();
+    let actual = serde_json::to_string_pretty(&output).unwrap() + "\n";
+    let expected_path = prefix.with_extension("expected.json");
+    if std::env::var_os("UPDATE_GOLDENS").is_some() {
+        fs::write(&expected_path, &actual).unwrap();
+    } else {
+        let expected = fs::read_to_string(&expected_path).unwrap_or_else(|error| {
+            panic!(
+                "missing reviewed golden {}: {error}; run UPDATE_GOLDENS=1 cargo test -p bazel-mcp-reducer --test test_log_golden",
+                expected_path.display()
+            )
+        });
+        assert_eq!(actual, expected, "Go test-log golden changed for {case}");
+    }
+}

--- a/crates/bazel-mcp-runner/src/test_evidence.rs
+++ b/crates/bazel-mcp-runner/src/test_evidence.rs
@@ -235,11 +235,16 @@ impl InvocationService {
         if committed {
             for diagnostic in &diagnostics {
                 summary.diagnostics.retain(|existing| {
+                    let same_message = existing.message == diagnostic.message;
+                    let embedded_located_message = existing.location.is_some()
+                        && existing.location == diagnostic.location
+                        && diagnostic.message.contains(&existing.message);
                     !((existing.category == DiagnosticCategory::Compilation
                         || (existing.category == diagnostic.category && existing.target.is_none()))
-                        && existing.message == diagnostic.message
-                        && (existing.location == diagnostic.location
-                            || existing.location.is_none()))
+                        && ((same_message
+                            && (existing.location == diagnostic.location
+                                || existing.location.is_none()))
+                            || embedded_located_message))
                 });
             }
             summary.diagnostics.extend(diagnostics);

--- a/crates/bazel-mcp-runner/tests/process.rs
+++ b/crates/bazel-mcp-runner/tests/process.rs
@@ -1132,6 +1132,89 @@ invoice total should include the service fee
 }
 
 #[tokio::test]
+async fn failed_go_test_logs_promote_the_located_subtest_assertion() {
+    let root = tempfile::tempdir().unwrap();
+    let workspace = root.path().join("workspace");
+    let output_root = root.path().join("output-user-root");
+    let test_directory = output_root.join("execroot/ws/bazel-out/testlogs/pkg/failing");
+    tokio::fs::create_dir_all(&workspace).await.unwrap();
+    tokio::fs::create_dir_all(&test_directory).await.unwrap();
+    let test_log = test_directory.join("test.log");
+    let test_xml = test_directory.join("test.xml");
+    tokio::fs::write(
+        &test_log,
+        "=== RUN   TestInvoiceTotal\n\
+=== RUN   TestInvoiceTotal/service_fee\n\
+    invoice_test.go:18: got 42; want 41\n\
+--- FAIL: TestInvoiceTotal (0.00s)\n\
+    --- FAIL: TestInvoiceTotal/service_fee (0.00s)\n\
+FAIL\n",
+    )
+    .await
+    .unwrap();
+    tokio::fs::write(
+        &test_xml,
+        r#"<testsuites><testsuite><testcase name="go_default_test"><failure message="exited with error code 1"/></testcase></testsuite></testsuites>"#,
+    )
+    .await
+    .unwrap();
+    let bep = root.path().join("failed-go-test.bep");
+    tokio::fs::write(
+        &bep,
+        failed_test_bep(
+            &format!("file://{}", test_log.display()),
+            &format!("file://{}", test_xml.display()),
+        ),
+    )
+    .await
+    .unwrap();
+    let script = format!(
+        "#!/bin/sh\nif [ \"${{1:-}}\" = --version ]; then echo 'bazel 9.1.0'; exit 0; fi\nfor arg in \"$@\"; do\n  case \"$arg\" in\n    --build_event_binary_file=*) bep_path=${{arg#*=}} ;;\n  esac\ndone\ncp '{}' \"$bep_path\"\necho 'invoice_test.go:18: got 42; want 41'\nexit 1\n",
+        bep.display(),
+    );
+    let service = configured_service(&root, &workspace, &script, |_| {}).await;
+
+    let failed = service
+        .run(InvocationRequest::new(
+            workspace,
+            BazelCommand::Test,
+            vec!["//pkg:failing".into()],
+        ))
+        .await
+        .unwrap();
+
+    let summary = failed.summary.as_ref().unwrap();
+    assert_eq!(summary.inspect_hint, Some(InspectHint::TestLog));
+    assert!(summary.headline.contains("TestInvoiceTotal/service_fee"));
+    assert!(summary.headline.contains("got 42; want 41"));
+    let matching = summary
+        .diagnostics
+        .iter()
+        .filter(|diagnostic| diagnostic.message.contains("got 42; want 41"))
+        .collect::<Vec<_>>();
+    assert_eq!(matching.len(), 1);
+    let diagnostic = matching[0];
+    assert_eq!(diagnostic.category, DiagnosticCategory::Test);
+    assert_eq!(diagnostic.target.as_deref(), Some("//pkg:failing"));
+    assert_eq!(
+        diagnostic.location.as_ref().unwrap().path,
+        "invoice_test.go"
+    );
+    assert_eq!(diagnostic.location.as_ref().unwrap().line, Some(18));
+    assert!(
+        summary
+            .diagnostics
+            .iter()
+            .all(|diagnostic| !diagnostic.message.contains("=== RUN")
+                && diagnostic.message != "FAIL")
+    );
+    assert_eq!(
+        summary.tests[0].cases[0].name,
+        "TestInvoiceTotal/service_fee"
+    );
+}
+
+#[tokio::test]
 async fn failed_rust_test_log_promotes_case_and_assertion_to_initial_summary() {
     let root = tempfile::tempdir().unwrap();
     let workspace = root.path().join("workspace");

--- a/testdata/reducer-corpus/go/test/failure/expected.json
+++ b/testdata/reducer-corpus/go/test/failure/expected.json
@@ -3,7 +3,7 @@
   "terminal_error": null,
   "summary": {
     "success": false,
-    "headline": "Bazel failed: invoice total mismatch: got 41, want 42",
+    "headline": "Bazel failed: Go test TestInvoiceTotal failed at invoice_test.go:9: invoice total mismatch: got 41, want 42",
     "targets": [
       {
         "label": "//cases:test_failure",
@@ -19,7 +19,7 @@
       {
         "severity": "error",
         "category": "test",
-        "message": "invoice total mismatch: got 41, want 42",
+        "message": "Go test TestInvoiceTotal failed at invoice_test.go:9: invoice total mismatch: got 41, want 42",
         "location": {
           "path": "invoice_test.go",
           "line": 9,
@@ -46,7 +46,14 @@
         "duration_ms": null,
         "attempts": 1,
         "shard": null,
-        "cases": [],
+        "cases": [
+          {
+            "name": "TestInvoiceTotal",
+            "status": "failed",
+            "duration_ms": null,
+            "message": "Go test TestInvoiceTotal failed at invoice_test.go:9: invoice total mismatch: got 41, want 42"
+          }
+        ],
         "test_log_available": false,
         "test_log_unavailable_reason": "test_log_not_snapshotted"
       }


### PR DESCRIPTION
## Summary

- add a bounded streaming reducer for Go test failures, subtests, table-driven assertions, fatal messages, and panics
- prefer relevant user `.go` locations while excluding goroutine and runtime stack noise
- collapse duplicate fanout deterministically and preserve the existing item and byte budgets
- add reviewed Go test-log goldens, an end-to-end runner regression test, and an accepted live rules_go corpus update

## Why

Go test logs were previously handled as generic location-bearing lines because the structured test failure accumulator only understood Rust libtest and GoogleTest output. That lost failed test and subtest names, allowed redundant compilation-form diagnostics, and could leave panic/runtime noise ahead of the actionable assertion.

This change promotes compact structured Go failures into the initial summary and failed test cases while keeping complete raw test logs available for inspection.

## Validation

- `make test`
- `make check`
- `cargo test -p bazel-mcp-reducer-cases --test corpus`
- `cargo test -p bazel-mcp-runner --test process failed_go_test_logs_promote_the_located_subtest_assertion -- --exact`
- `git diff --check`

Closes #48
