### PR TITLE
refactor: introduce typed execution phases

### DIFF
--- a/crates/bazel-mcp-runner/src/execution.rs
+++ b/crates/bazel-mcp-runner/src/execution.rs
@@ -2,7 +2,7 @@
 
 use std::{
     panic::{AssertUnwindSafe, catch_unwind},
-    path::Path,
+    path::{Path, PathBuf},
     process::ExitStatus,
     sync::Arc,
     time::{Duration, Instant},
@@ -11,18 +11,22 @@ use std::{
 #[cfg(unix)]
 use std::io;
 
+use bazel_mcp_bep::StreamOutcome;
 use bazel_mcp_policy::filtered_environment;
 use bazel_mcp_reducer::{
-    Budget, REDUCER_API_VERSION, ReducerContext, StreamReductionOutput, finalize_diagnostics,
-    normalize_terminal_text,
+    BepAccumulator, Budget, REDUCER_API_VERSION, ReducerContext, StreamReductionOutput,
+    finalize_diagnostics, normalize_terminal_text,
 };
 use bazel_mcp_store::{InvocationCompletion, InvocationPaths, StoreError};
 use bazel_mcp_types::{
     BazelCommand, CommandClass, Diagnostic, DiagnosticCategory, InspectHint, InvocationId,
-    InvocationMetrics, InvocationRecord, InvocationRequest, InvocationState, PageRequest, Severity,
-    Termination, TestStatus,
+    InvocationMetrics, InvocationRecord, InvocationRequest, InvocationState, InvocationSummary,
+    PageRequest, QueryRow, Severity, Termination, TestStatus,
 };
-use tokio::{process::Command, task};
+use tokio::{
+    process::{Child, Command},
+    task,
+};
 use tokio_util::sync::CancellationToken;
 
 use crate::{
@@ -39,6 +43,211 @@ use crate::{
 #[cfg(unix)]
 use crate::service::RunnerConfig;
 
+/// Immutable inputs selected before Bazel is spawned.
+///
+/// Owning these values prevents later phases from reaching back into queued
+/// state or reconstructing transport and timeout decisions.
+struct ExecutionPlan {
+    request: InvocationRequest,
+    paths: InvocationPaths,
+    executable: PathBuf,
+    cancellation: CancellationToken,
+    explicit_output_base: Option<PathBuf>,
+    output_base_wait: Arc<OutputBaseWaitStatus>,
+    extension_limits: Option<(usize, usize)>,
+    queue_ms: u64,
+    timeout: Duration,
+}
+
+/// A spawned process together with every guard required to shut it down and
+/// finish its live evidence stream.
+struct RunningInvocation {
+    plan: ExecutionPlan,
+    child: Child,
+    process_group: ProcessGroupGuard,
+    native_output_base_wait: NativeOutputBaseWaitObserver,
+    live_bep: Option<capture::LiveBepCapture>,
+    started: Instant,
+}
+
+/// Process termination is known, but durable evidence has not yet been
+/// drained and reduced.
+struct ExitedInvocation {
+    plan: ExecutionPlan,
+    status: Option<ExitStatus>,
+    termination: Termination,
+    state: InvocationState,
+    live_bep: Option<capture::LiveBepCapture>,
+    bazel_wall_ms: u64,
+    output_base_lock_wait_ms: u64,
+}
+
+/// Raw local evidence and its decoded BEP accumulator. Redaction and public
+/// byte budgets deliberately happen only in the next phase.
+struct CapturedEvidence {
+    exited: ExitedInvocation,
+    bep: BepAccumulator,
+    bep_outcome: StreamOutcome,
+    stdout: Vec<u8>,
+    stderr: Vec<u8>,
+    query_row_count: u64,
+    query_sample: Vec<QueryRow>,
+    reduction_started: Instant,
+}
+
+/// A fully redacted and enriched result ready for its single durable commit.
+struct ReducedOutcome {
+    id: InvocationId,
+    completion: InvocationCompletion,
+}
+
+/// The only phase allowed to move an invocation into a terminal state.
+struct TerminalCommit {
+    id: InvocationId,
+    completion: InvocationCompletion,
+    recover_without_evidence: bool,
+}
+
+enum StartExecution {
+    Running(Box<RunningInvocation>),
+    Terminal(Box<TerminalCommit>),
+}
+
+#[derive(Clone)]
+struct TerminalContext {
+    id: InvocationId,
+    workspace: PathBuf,
+    state: InvocationState,
+    termination: Termination,
+    elapsed_ms: u64,
+}
+
+impl ExecutionPlan {
+    fn new(
+        service: &InvocationService,
+        queued: &InvocationRecord,
+        paths: &InvocationPaths,
+        executable: &Path,
+        cancellation: CancellationToken,
+        explicit_output_base: Option<&Path>,
+        output_base_wait: Arc<OutputBaseWaitStatus>,
+    ) -> Self {
+        let queue_ms = u64::try_from(
+            bazel_mcp_types::unix_timestamp_ms().saturating_sub(queued.request.requested_at_ms),
+        )
+        .unwrap_or_default();
+        let timeout = queued
+            .request
+            .timeout_ms
+            .map(Duration::from_millis)
+            .unwrap_or(service.config.default_timeout)
+            .max(Duration::from_secs(1))
+            .min(service.config.maximum_timeout);
+        let extension_limits = (!service.reducers.is_empty()).then_some((
+            service.config.starlark_reducers.limits.max_events,
+            service.config.starlark_reducers.limits.max_input_bytes,
+        ));
+        Self {
+            request: queued.request.clone(),
+            paths: paths.clone(),
+            executable: executable.to_owned(),
+            cancellation,
+            explicit_output_base: explicit_output_base.map(Path::to_owned),
+            output_base_wait,
+            extension_limits,
+            queue_ms,
+            timeout,
+        }
+    }
+
+    fn failure_context(&self) -> TerminalContext {
+        TerminalContext {
+            id: self.request.id,
+            workspace: self.request.workspace.clone(),
+            state: InvocationState::Failed,
+            termination: Termination::Interrupted,
+            elapsed_ms: 0,
+        }
+    }
+}
+
+impl RunningInvocation {
+    fn failure_context(&self) -> TerminalContext {
+        TerminalContext {
+            id: self.plan.request.id,
+            workspace: self.plan.request.workspace.clone(),
+            state: InvocationState::Failed,
+            termination: Termination::Interrupted,
+            elapsed_ms: duration_millis(self.started.elapsed()),
+        }
+    }
+}
+
+impl ExitedInvocation {
+    fn terminal_context(&self) -> TerminalContext {
+        TerminalContext {
+            id: self.plan.request.id,
+            workspace: self.plan.request.workspace.clone(),
+            state: self.state,
+            termination: self.termination.clone(),
+            elapsed_ms: self.bazel_wall_ms,
+        }
+    }
+}
+
+impl ReducedOutcome {
+    fn into_terminal(self) -> TerminalCommit {
+        TerminalCommit {
+            id: self.id,
+            completion: self.completion,
+            recover_without_evidence: false,
+        }
+    }
+}
+
+impl TerminalCommit {
+    fn failure(
+        id: InvocationId,
+        termination: Termination,
+        summary: InvocationSummary,
+        queue_ms: u64,
+    ) -> Self {
+        Self {
+            id,
+            completion: InvocationCompletion {
+                state: InvocationState::Failed,
+                termination,
+                summary,
+                metrics: InvocationMetrics {
+                    queue_ms,
+                    ..Default::default()
+                },
+                canonical_arguments: None,
+                artifacts: Vec::new(),
+            },
+            recover_without_evidence: false,
+        }
+    }
+
+    fn cancelled(id: InvocationId, queue_ms: u64) -> Self {
+        Self {
+            id,
+            completion: InvocationCompletion {
+                state: InvocationState::Cancelled,
+                termination: Termination::Cancelled,
+                summary: cancelled_summary(),
+                metrics: InvocationMetrics {
+                    queue_ms,
+                    ..Default::default()
+                },
+                canonical_arguments: None,
+                artifacts: Vec::new(),
+            },
+            recover_without_evidence: false,
+        }
+    }
+}
+
 impl InvocationService {
     pub(crate) async fn execute(
         &self,
@@ -49,13 +258,60 @@ impl InvocationService {
         explicit_output_base: Option<&Path>,
         output_base_wait: Arc<OutputBaseWaitStatus>,
     ) -> Result<InvocationRecord, RunnerError> {
-        if cancellation.is_cancelled() {
-            return self.finish_cancelled(queued.request.id).await;
+        let plan = ExecutionPlan::new(
+            self,
+            queued,
+            paths,
+            executable,
+            cancellation,
+            explicit_output_base,
+            output_base_wait,
+        );
+        let starting_context = plan.failure_context();
+        let started = match self.start_execution(plan).await {
+            Ok(started) => started,
+            Err(error) => return self.recover_terminal_failure(starting_context, error).await,
+        };
+        let running = match started {
+            StartExecution::Running(running) => *running,
+            StartExecution::Terminal(commit) => {
+                return match self.commit_terminal(*commit).await {
+                    Ok(record) => Ok(record),
+                    Err(error) => self.recover_terminal_failure(starting_context, error).await,
+                };
+            }
+        };
+        let running_context = running.failure_context();
+        let exited = match self.wait_for_exit(running).await {
+            Ok(exited) => exited,
+            Err(error) => return self.recover_terminal_failure(running_context, error).await,
+        };
+        let terminal_context = exited.terminal_context();
+        let result = async {
+            let captured = self.capture_evidence(exited).await?;
+            let reduced = self.reduce_evidence(captured).await?;
+            self.commit_terminal(reduced.into_terminal()).await
         }
-        let queue_ms = u64::try_from(
-            bazel_mcp_types::unix_timestamp_ms().saturating_sub(queued.request.requested_at_ms),
-        )
-        .unwrap_or_default();
+        .await;
+        match result {
+            Ok(record) => Ok(record),
+            Err(error) => self.recover_terminal_failure(terminal_context, error).await,
+        }
+    }
+
+    async fn start_execution(&self, plan: ExecutionPlan) -> Result<StartExecution, RunnerError> {
+        let queued = &plan;
+        let paths = &plan.paths;
+        let executable = plan.executable.as_path();
+        let cancellation = plan.cancellation.clone();
+        let explicit_output_base = plan.explicit_output_base.as_deref();
+        let output_base_wait = plan.output_base_wait.clone();
+        let queue_ms = plan.queue_ms;
+        if cancellation.is_cancelled() {
+            return Ok(StartExecution::Terminal(Box::new(
+                TerminalCommit::cancelled(queued.request.id, queue_ms),
+            )));
+        }
         let (stdout, stderr) = match capture::open_stdio(paths).await {
             Ok(streams) => streams,
             Err(error) => {
@@ -63,23 +319,18 @@ impl InvocationService {
                     &format!("could not create Bazel evidence files: {error}"),
                     1_000,
                 );
-                let summary = bazel_mcp_types::InvocationSummary {
+                let summary = InvocationSummary {
                     success: false,
                     headline: format!("Could not prepare Bazel invocation: {message}"),
                     truncated: true,
                     ..Default::default()
                 };
-                return self
-                    .transition_invocation(
-                        queued.request.id,
-                        InvocationState::Failed,
-                        Some(Termination::SpawnFailure {
-                            message: message.clone(),
-                        }),
-                        Some(summary),
-                    )
-                    .await
-                    .map_err(Into::into);
+                return Ok(StartExecution::Terminal(Box::new(TerminalCommit::failure(
+                    queued.request.id,
+                    Termination::SpawnFailure { message },
+                    summary,
+                    queue_ms,
+                ))));
             }
         };
         let native_output_base_wait = NativeOutputBaseWaitObserver::start(
@@ -136,14 +387,11 @@ impl InvocationService {
             );
         }
         if cancellation.is_cancelled() {
-            return self.finish_cancelled(queued.request.id).await;
+            return Ok(StartExecution::Terminal(Box::new(
+                TerminalCommit::cancelled(queued.request.id, queue_ms),
+            )));
         }
-        let extension_limits = (!self.reducers.is_empty()).then_some({
-            (
-                self.config.starlark_reducers.limits.max_events,
-                self.config.starlark_reducers.limits.max_input_bytes,
-            )
-        });
+        let extension_limits = plan.extension_limits;
         let bes_bep = if queued.request.command.class() == CommandClass::BuildLike {
             match &self.bes {
                 Some(server) => Some(capture::LiveBepCapture::Bes(capture::BesBepCapture::start(
@@ -230,20 +478,17 @@ impl InvocationService {
             Ok(child) => child,
             Err(error) => {
                 let message = self.redactor.redact_bounded(&error.to_string(), 1_000);
-                let summary = bazel_mcp_types::InvocationSummary {
+                let summary = InvocationSummary {
                     success: false,
                     headline: format!("Could not start Bazel: {message}"),
                     ..Default::default()
                 };
-                return self
-                    .transition_invocation(
-                        queued.request.id,
-                        InvocationState::Failed,
-                        Some(Termination::SpawnFailure { message }),
-                        Some(summary),
-                    )
-                    .await
-                    .map_err(Into::into);
+                return Ok(StartExecution::Terminal(Box::new(TerminalCommit::failure(
+                    queued.request.id,
+                    Termination::SpawnFailure { message },
+                    summary,
+                    queue_ms,
+                ))));
             }
         };
         #[cfg(unix)]
@@ -256,7 +501,7 @@ impl InvocationService {
                 extension_limits,
             ))
         });
-        let mut process_group = ProcessGroupGuard::for_child(&child);
+        let process_group = ProcessGroupGuard::for_child(&child);
         if let Err(error) = self
             .transition_invocation(queued.request.id, InvocationState::Running, None, None)
             .await
@@ -277,35 +522,18 @@ impl InvocationService {
                 error = %message,
                 "could not record running Bazel invocation"
             );
-            if self
-                .store
-                .get_invocation_header(queued.request.id)
-                .await
-                .is_ok_and(|record| !record.state.is_terminal())
-            {
-                let summary = bazel_mcp_types::InvocationSummary {
+            return Ok(StartExecution::Terminal(Box::new(TerminalCommit::failure(
+                queued.request.id,
+                Termination::Interrupted,
+                InvocationSummary {
                     success: false,
                     headline: format!("Could not record Bazel execution state: {message}"),
                     truncated: true,
                     inspect_hint: Some(InspectHint::Log),
                     ..Default::default()
-                };
-                let _ = self
-                    .transition_invocation(
-                        queued.request.id,
-                        InvocationState::Failed,
-                        Some(Termination::Interrupted),
-                        Some(summary),
-                    )
-                    .await;
-            }
-            if let Ok(record) = self.store.get_invocation_header(queued.request.id).await
-                && record.state.is_terminal()
-                && record.summary.is_some()
-            {
-                return Ok(record.into_record());
-            }
-            return Err(error.into());
+                },
+                queue_ms,
+            ))));
         }
         #[cfg(unix)]
         let incremental_bep = fifo_bep.or(bes_bep).or_else(|| {
@@ -329,14 +557,30 @@ impl InvocationService {
                     ))
                 })
         });
-        let started = Instant::now();
-        let timeout = queued
-            .request
-            .timeout_ms
-            .map(Duration::from_millis)
-            .unwrap_or(self.config.default_timeout)
-            .max(Duration::from_secs(1))
-            .min(self.config.maximum_timeout);
+        Ok(StartExecution::Running(Box::new(RunningInvocation {
+            plan,
+            child,
+            process_group,
+            native_output_base_wait,
+            live_bep: incremental_bep,
+            started: Instant::now(),
+        })))
+    }
+
+    async fn wait_for_exit(
+        &self,
+        running: RunningInvocation,
+    ) -> Result<ExitedInvocation, RunnerError> {
+        let RunningInvocation {
+            plan,
+            mut child,
+            mut process_group,
+            native_output_base_wait,
+            live_bep,
+            started,
+        } = running;
+        let cancellation = plan.cancellation.clone();
+        let timeout = plan.timeout;
         let timeout_sleep = tokio::time::sleep(timeout);
         tokio::pin!(timeout_sleep);
         let (status, termination, state) = tokio::select! {
@@ -360,292 +604,369 @@ impl InvocationService {
         };
         process_group.disarm();
         native_output_base_wait.finish().await;
-        let output_base_wait_snapshot = output_base_wait.snapshot();
         let bazel_wall_ms = duration_millis(started.elapsed());
-        let postprocess: Result<InvocationRecord, RunnerError> = async {
-            let reduction_started = Instant::now();
-            let incremental_reduction = match incremental_bep {
-                Some(capture) => {
-                    let reduction = capture.finish(BES_COMPLETION_GRACE).await?;
-                    tracing::debug!(
-                        invocation_id = %queued.request.id,
-                        source = ?reduction.source,
-                        finalize_ms = reduction.finalize_ms,
-                        events = reduction.outcome.event_count,
-                        bytes = reduction.outcome.decoded_bytes,
-                        "completed incremental BEP reduction"
-                    );
-                    Some(reduction)
-                }
-                None => None,
-            };
-            let (query_row_count, query_sample) =
-                if queued.request.command.class() == CommandClass::Query {
-                    let query_row_count = self.store.count_query_rows(queued.request.id).await?;
-                    let redactor = self.redactor.clone();
-                    let page = self
-                        .store
-                        .page_query_rows_mapped_into(
-                            queued.request.id,
-                            None,
-                            PageRequest {
-                                scan_limit: 3,
-                                ..PageRequest::new(None, 3)
-                            },
-                            move |value, output| {
-                                redactor.redact_bounded_into(value, 4 * 1024, output);
-                            },
-                        )
-                        .await?;
-                    (query_row_count, page.items)
-                } else {
-                    (0, Vec::new())
-                };
-            let (bep, bep_outcome) = match incremental_reduction {
-                Some(reduction) => (reduction.accumulator, reduction.outcome),
-                None => capture::reduce_bep(paths.bep.clone(), extension_limits).await?,
-            };
-            if let Some(error) = &bep_outcome.terminal_error {
-                tracing::warn!(invocation_id = %queued.request.id, %error, "partially decoded BEP");
+        Ok(ExitedInvocation {
+            output_base_lock_wait_ms: plan.output_base_wait.snapshot().elapsed_ms,
+            plan,
+            status,
+            termination,
+            state,
+            live_bep,
+            bazel_wall_ms,
+        })
+    }
+
+    async fn capture_evidence(
+        &self,
+        mut exited: ExitedInvocation,
+    ) -> Result<CapturedEvidence, RunnerError> {
+        let queued = &exited.plan;
+        let paths = &exited.plan.paths;
+        let status = &exited.status;
+        let reduction_started = Instant::now();
+        let incremental_reduction = match exited.live_bep.take() {
+            Some(capture) => {
+                let reduction = capture.finish(BES_COMPLETION_GRACE).await?;
+                tracing::debug!(
+                    invocation_id = %exited.plan.request.id,
+                    source = ?reduction.source,
+                    finalize_ms = reduction.finalize_ms,
+                    events = reduction.outcome.event_count,
+                    bytes = reduction.outcome.decoded_bytes,
+                    "completed incremental BEP reduction"
+                );
+                Some(reduction)
             }
-            // Complete structured evidence needs only a small diagnostic tail;
-            // partial or missing BEP retains a larger bounded fallback.
-            let log_limit = if bep_outcome.event_count > 0 && bep_outcome.terminal_error.is_none() {
-                COMPLETE_BEP_LOG_LIMIT
+            None => None,
+        };
+        let (query_row_count, query_sample) =
+            if queued.request.command.class() == CommandClass::Query {
+                let query_row_count = self.store.count_query_rows(queued.request.id).await?;
+                let redactor = self.redactor.clone();
+                let page = self
+                    .store
+                    .page_query_rows_mapped_into(
+                        queued.request.id,
+                        None,
+                        PageRequest {
+                            scan_limit: 3,
+                            ..PageRequest::new(None, 3)
+                        },
+                        move |value, output| {
+                            redactor.redact_bounded_into(value, 4 * 1024, output);
+                        },
+                    )
+                    .await?;
+                (query_row_count, page.items)
             } else {
-                FALLBACK_LOG_LIMIT
+                (0, Vec::new())
             };
-            let stdout = capture::read_bounded_tail(&paths.stdout, log_limit).await?;
-            let stderr = capture::read_bounded_tail(&paths.stderr, log_limit).await?;
-            let exit_code = status.as_ref().and_then(ExitStatus::code);
-            let failed = exit_code != Some(0);
-            if should_persist_failure_evidence(&queued.request.command, failed) {
-                self.persist_failure_evidence(
-                    paths,
-                    &queued.request.workspace,
-                    &queued.request.command,
-                    failed,
-                    &stdout,
-                    &stderr,
-                )
-                .await?;
-            }
-            let reduced = catch_unwind(AssertUnwindSafe(|| {
-                bep.finish(
-                    &stdout,
-                    &stderr,
-                    exit_code,
-                    bazel_wall_ms,
-                    // Enrichment can add higher-value failed-test evidence.
-                    // Apply the public result budget only after that evidence
-                    // is present so ranking and aggregation precede limits.
-                    Budget {
-                        max_bytes: usize::MAX,
-                        max_items: usize::MAX,
-                    },
-                )
-            }));
-            let StreamReductionOutput {
-                mut summary,
-                mut artifacts,
-                canonical_arguments,
-                reducer_events,
-                reducer_input_truncated,
-            } = reduced.unwrap_or_else(|_| {
-                tracing::warn!(
-                    invocation_id = %queued.request.id,
-                    "streaming BEP reducer panicked; using bounded fallback summary"
-                );
-                StreamReductionOutput {
-                    summary: fallback_summary(exit_code, bazel_wall_ms, &stderr, &stdout),
-                    artifacts: Vec::new(),
-                    canonical_arguments: None,
-                    reducer_events: Vec::new(),
-                    reducer_input_truncated: false,
-                }
-            });
-            let canonical_arguments = canonical_arguments.map(|mut arguments| {
-                let workspace = queued.request.workspace.to_string_lossy();
-                for argument in &mut arguments {
-                    *argument = self.redactor.redact_bounded(
-                        &argument.replace(workspace.as_ref(), "<workspace>"),
-                        64 * 1024,
-                    );
-                }
-                arguments
-            });
-            for artifact in &mut artifacts {
-                artifact.name = self.redactor.redact_bounded(&artifact.name, 1_000);
-                artifact.uri = self.redactor.redact_bounded(&artifact.uri, 1_000);
-            }
-            if queued.request.command.class() == CommandClass::Query && exit_code == Some(0) {
-                summary.headline = format!("Bazel query returned {query_row_count} rows");
-                summary.inspect_hint =
-                    (query_row_count > 0).then_some(InspectHint::QueryResults);
-                summary.query_result_count = Some(query_row_count);
-                summary.query_sample = query_sample;
-            } else if matches!(
-                queued.request.command.class(),
-                CommandClass::Informational | CommandClass::Unknown
-            ) && exit_code == Some(0)
-            {
-                let text = if stdout.is_empty() { &stderr } else { &stdout };
-                let excerpt = normalize_terminal_text(text);
-                if !excerpt.is_empty() {
-                    summary.headline = bounded_text(&excerpt, 1_000);
-                    if excerpt.len() > 1_000 {
-                        summary.truncated = true;
-                        summary.inspect_hint = Some(InspectHint::Log);
-                    }
-                }
-            }
-            self.enrich_tests(paths, &queued.request.workspace, &mut summary, &artifacts)
-                .await;
-            if queued.request.command == BazelCommand::Coverage {
-                summary.coverage = self
-                    .load_coverage(&queued.request.workspace, &artifacts)
-                    .await;
-            }
-            let mut custom_headline = None;
-            let mut custom_notices = Vec::new();
-            if !self.reducers.is_empty() {
-                let context = self.reducer_context(
-                    &queued.request,
-                    exit_code,
-                    bazel_wall_ms,
-                    &stdout,
-                    &stderr,
-                    reducer_events,
-                    reducer_input_truncated,
-                    &summary,
-                );
-                let reducers = self.reducers.clone();
-                let (next_summary, report) = task::spawn_blocking(move || {
-                    let mut next_summary = summary;
-                    let report = reducers.apply(&context, &mut next_summary);
-                    (next_summary, report)
-                })
-                .await?;
-                summary = next_summary;
-                if report.headline_applied {
-                    custom_headline = Some(summary.headline.clone());
-                }
-                for name in report.applied {
-                    let name = self.redactor.redact_bounded(&name, 128);
-                    tracing::debug!(invocation_id = %queued.request.id, reducer = %name, "applied custom reducer");
-                }
-                for failure in report.failures {
-                    let name = self.redactor.redact_bounded(&failure.name, 128);
-                    let error = self.redactor.redact_bounded(&failure.error, 2 * 1024);
-                    tracing::warn!(
-                        invocation_id = %queued.request.id,
-                        reducer = %name,
-                        %error,
-                        "custom reducer failed; native result retained"
-                    );
-                    custom_notices.push(custom_reducer_notice(format!(
-                        "Custom reducer {:?} failed; native reducer output was retained",
-                        name
-                    )));
-                }
-                for collision in report.override_collisions {
-                    let collision = self.redactor.redact_bounded(&collision, 512);
-                    tracing::warn!(invocation_id = %queued.request.id, %collision, "custom reducer override collision");
-                    custom_notices.push(custom_reducer_notice(collision));
-                }
-            }
-            finalize_with_custom_notices(&mut summary, custom_notices);
-            if let Some(headline) = custom_headline {
-                summary.headline = headline;
-            }
-            if !summary.success && summary.inspect_hint.is_none() {
-                let hint = if summary
-                    .tests
-                    .iter()
-                    .any(|test| test.status != TestStatus::Passed && test.test_log_available)
-                {
-                    InspectHint::TestLog
-                } else {
-                    InspectHint::Log
-                };
-                summary.inspect_hint = Some(hint);
-            }
-            self.sanitize_summary(queued.request.id, &queued.request.workspace, &mut summary);
-            let metrics = InvocationMetrics {
-                raw_output_bytes: capture::file_size(&paths.stdout)
-                    .await
-                    .saturating_add(capture::file_size(&paths.stderr).await),
-                bep_bytes: capture::file_size(&paths.bep).await,
-                bep_events: u64::try_from(bep_outcome.event_count).unwrap_or(u64::MAX),
-                queue_ms,
-                output_base_lock_wait_ms: output_base_wait_snapshot.elapsed_ms,
+        let (bep, bep_outcome) = match incremental_reduction {
+            Some(reduction) => (reduction.accumulator, reduction.outcome),
+            None => capture::reduce_bep(paths.bep.clone(), exited.plan.extension_limits).await?,
+        };
+        if let Some(error) = &bep_outcome.terminal_error {
+            tracing::warn!(invocation_id = %queued.request.id, %error, "partially decoded BEP");
+        }
+        // Complete structured evidence needs only a small diagnostic tail;
+        // partial or missing BEP retains a larger bounded fallback.
+        let log_limit = if bep_outcome.event_count > 0 && bep_outcome.terminal_error.is_none() {
+            COMPLETE_BEP_LOG_LIMIT
+        } else {
+            FALLBACK_LOG_LIMIT
+        };
+        let stdout = capture::read_bounded_tail(&paths.stdout, log_limit).await?;
+        let stderr = capture::read_bounded_tail(&paths.stderr, log_limit).await?;
+        let exit_code = status.as_ref().and_then(ExitStatus::code);
+        let failed = exit_code != Some(0);
+        if should_persist_failure_evidence(&queued.request.command, failed) {
+            self.persist_failure_evidence(
+                paths,
+                &queued.request.workspace,
+                &queued.request.command,
+                failed,
+                &stdout,
+                &stderr,
+            )
+            .await?;
+        }
+        Ok(CapturedEvidence {
+            exited,
+            bep,
+            bep_outcome,
+            stdout,
+            stderr,
+            query_row_count,
+            query_sample,
+            reduction_started,
+        })
+    }
+
+    async fn reduce_evidence(
+        &self,
+        captured: CapturedEvidence,
+    ) -> Result<ReducedOutcome, RunnerError> {
+        let CapturedEvidence {
+            exited,
+            bep,
+            bep_outcome,
+            stdout,
+            stderr,
+            query_row_count,
+            query_sample,
+            reduction_started,
+        } = captured;
+        let queued = &exited.plan;
+        let paths = &exited.plan.paths;
+        let exit_code = exited.status.as_ref().and_then(ExitStatus::code);
+        let bazel_wall_ms = exited.bazel_wall_ms;
+        let reduced = catch_unwind(AssertUnwindSafe(|| {
+            bep.finish(
+                &stdout,
+                &stderr,
+                exit_code,
                 bazel_wall_ms,
-                reduction_ms: duration_millis(reduction_started.elapsed()),
-                ..Default::default()
-            };
-            self.finish_invocation(
-                queued.request.id,
-                InvocationCompletion {
-                    state,
-                    termination: termination.clone(),
-                    summary,
-                    metrics,
-                    canonical_arguments,
-                    artifacts,
+                // Enrichment can add higher-value failed-test evidence.
+                // Apply the public result budget only after that evidence
+                // is present so ranking and aggregation precede limits.
+                Budget {
+                    max_bytes: usize::MAX,
+                    max_items: usize::MAX,
                 },
             )
-            .await
-            .map_err(Into::into)
-        }
-        .await;
-
-        if let Err(error) = &postprocess {
-            let workspace = queued.request.workspace.to_string_lossy();
-            let message = self.redactor.redact_bounded(
-                &error.to_string().replace(workspace.as_ref(), "<workspace>"),
-                1_000,
-            );
+        }));
+        let StreamReductionOutput {
+            mut summary,
+            mut artifacts,
+            canonical_arguments,
+            reducer_events,
+            reducer_input_truncated,
+        } = reduced.unwrap_or_else(|_| {
             tracing::warn!(
                 invocation_id = %queued.request.id,
-                error = %message,
-                "Bazel result post-processing failed"
+                "streaming BEP reducer panicked; using bounded fallback summary"
             );
-            if self
-                .store
-                .get_invocation_header(queued.request.id)
-                .await
-                .is_ok_and(|record| !record.state.is_terminal())
+            StreamReductionOutput {
+                summary: fallback_summary(exit_code, bazel_wall_ms, &stderr, &stdout),
+                artifacts: Vec::new(),
+                canonical_arguments: None,
+                reducer_events: Vec::new(),
+                reducer_input_truncated: false,
+            }
+        });
+        let canonical_arguments = canonical_arguments.map(|mut arguments| {
+            let workspace = queued.request.workspace.to_string_lossy();
+            for argument in &mut arguments {
+                *argument = self.redactor.redact_bounded(
+                    &argument.replace(workspace.as_ref(), "<workspace>"),
+                    64 * 1024,
+                );
+            }
+            arguments
+        });
+        for artifact in &mut artifacts {
+            artifact.name = self.redactor.redact_bounded(&artifact.name, 1_000);
+            artifact.uri = self.redactor.redact_bounded(&artifact.uri, 1_000);
+        }
+        if queued.request.command.class() == CommandClass::Query && exit_code == Some(0) {
+            summary.headline = format!("Bazel query returned {query_row_count} rows");
+            summary.inspect_hint = (query_row_count > 0).then_some(InspectHint::QueryResults);
+            summary.query_result_count = Some(query_row_count);
+            summary.query_sample = query_sample;
+        } else if matches!(
+            queued.request.command.class(),
+            CommandClass::Informational | CommandClass::Unknown
+        ) && exit_code == Some(0)
+        {
+            let text = if stdout.is_empty() { &stderr } else { &stdout };
+            let excerpt = normalize_terminal_text(text);
+            if !excerpt.is_empty() {
+                summary.headline = bounded_text(&excerpt, 1_000);
+                if excerpt.len() > 1_000 {
+                    summary.truncated = true;
+                    summary.inspect_hint = Some(InspectHint::Log);
+                }
+            }
+        }
+        self.enrich_tests(paths, &queued.request.workspace, &mut summary, &artifacts)
+            .await;
+        if queued.request.command == BazelCommand::Coverage {
+            summary.coverage = self
+                .load_coverage(&queued.request.workspace, &artifacts)
+                .await;
+        }
+        let mut custom_headline = None;
+        let mut custom_notices = Vec::new();
+        if !self.reducers.is_empty() {
+            let context = self.reducer_context(
+                &queued.request,
+                exit_code,
+                bazel_wall_ms,
+                &stdout,
+                &stderr,
+                reducer_events,
+                reducer_input_truncated,
+                &summary,
+            );
+            let reducers = self.reducers.clone();
+            let (next_summary, report) = task::spawn_blocking(move || {
+                let mut next_summary = summary;
+                let report = reducers.apply(&context, &mut next_summary);
+                (next_summary, report)
+            })
+            .await?;
+            summary = next_summary;
+            if report.headline_applied {
+                custom_headline = Some(summary.headline.clone());
+            }
+            for name in report.applied {
+                let name = self.redactor.redact_bounded(&name, 128);
+                tracing::debug!(invocation_id = %queued.request.id, reducer = %name, "applied custom reducer");
+            }
+            for failure in report.failures {
+                let name = self.redactor.redact_bounded(&failure.name, 128);
+                let error = self.redactor.redact_bounded(&failure.error, 2 * 1024);
+                tracing::warn!(
+                    invocation_id = %queued.request.id,
+                    reducer = %name,
+                    %error,
+                    "custom reducer failed; native result retained"
+                );
+                custom_notices.push(custom_reducer_notice(format!(
+                    "Custom reducer {:?} failed; native reducer output was retained",
+                    name
+                )));
+            }
+            for collision in report.override_collisions {
+                let collision = self.redactor.redact_bounded(&collision, 512);
+                tracing::warn!(invocation_id = %queued.request.id, %collision, "custom reducer override collision");
+                custom_notices.push(custom_reducer_notice(collision));
+            }
+        }
+        finalize_with_custom_notices(&mut summary, custom_notices);
+        if let Some(headline) = custom_headline {
+            summary.headline = headline;
+        }
+        if !summary.success && summary.inspect_hint.is_none() {
+            let hint = if summary
+                .tests
+                .iter()
+                .any(|test| test.status != TestStatus::Passed && test.test_log_available)
             {
-                let terminal_state = if state == InvocationState::Succeeded {
-                    InvocationState::Failed
-                } else {
-                    state
-                };
-                let summary = bazel_mcp_types::InvocationSummary {
+                InspectHint::TestLog
+            } else {
+                InspectHint::Log
+            };
+            summary.inspect_hint = Some(hint);
+        }
+        self.sanitize_summary(queued.request.id, &queued.request.workspace, &mut summary);
+        let metrics = InvocationMetrics {
+            raw_output_bytes: capture::file_size(&paths.stdout)
+                .await
+                .saturating_add(capture::file_size(&paths.stderr).await),
+            bep_bytes: capture::file_size(&paths.bep).await,
+            bep_events: u64::try_from(bep_outcome.event_count).unwrap_or(u64::MAX),
+            queue_ms: exited.plan.queue_ms,
+            output_base_lock_wait_ms: exited.output_base_lock_wait_ms,
+            bazel_wall_ms,
+            reduction_ms: duration_millis(reduction_started.elapsed()),
+            ..Default::default()
+        };
+        Ok(ReducedOutcome {
+            id: queued.request.id,
+            completion: InvocationCompletion {
+                state: exited.state,
+                termination: exited.termination,
+                summary,
+                metrics,
+                canonical_arguments,
+                artifacts,
+            },
+        })
+    }
+
+    async fn commit_terminal(
+        &self,
+        commit: TerminalCommit,
+    ) -> Result<InvocationRecord, RunnerError> {
+        let fallback = commit.recover_without_evidence.then(|| {
+            (
+                commit.completion.state,
+                commit.completion.termination.clone(),
+                commit.completion.summary.clone(),
+            )
+        });
+        match self.finish_invocation(commit.id, commit.completion).await {
+            Ok(record) => Ok(record),
+            Err(error) => {
+                if let Ok(record) = self.store.get_invocation_header(commit.id).await
+                    && record.state.is_terminal()
+                    && record.summary.is_some()
+                {
+                    return Ok(record.into_record());
+                }
+                if matches!(&error, StoreError::Io(error) if error.kind() == std::io::ErrorKind::NotFound)
+                    && let Some((state, termination, summary)) = fallback
+                {
+                    return self
+                        .transition_invocation(commit.id, state, Some(termination), Some(summary))
+                        .await
+                        .map_err(Into::into);
+                }
+                Err(error.into())
+            }
+        }
+    }
+
+    async fn recover_terminal_failure(
+        &self,
+        context: TerminalContext,
+        error: RunnerError,
+    ) -> Result<InvocationRecord, RunnerError> {
+        let workspace = context.workspace.to_string_lossy();
+        let message = self.redactor.redact_bounded(
+            &error.to_string().replace(workspace.as_ref(), "<workspace>"),
+            1_000,
+        );
+        tracing::warn!(
+            invocation_id = %context.id,
+            error = %message,
+            "Bazel result post-processing failed"
+        );
+        if let Ok(record) = self.store.get_invocation_header(context.id).await
+            && record.state.is_terminal()
+            && record.summary.is_some()
+        {
+            return Ok(record.into_record());
+        }
+        let terminal_state = if context.state == InvocationState::Succeeded {
+            InvocationState::Failed
+        } else {
+            context.state
+        };
+        let commit = TerminalCommit {
+            id: context.id,
+            completion: InvocationCompletion {
+                state: terminal_state,
+                termination: context.termination,
+                summary: InvocationSummary {
                     success: false,
                     headline: format!("Could not finish processing Bazel results: {message}"),
-                    elapsed_ms: bazel_wall_ms,
+                    elapsed_ms: context.elapsed_ms,
                     truncated: true,
                     inspect_hint: Some(InspectHint::Log),
                     ..Default::default()
-                };
-                let _ = self
-                    .transition_invocation(
-                        queued.request.id,
-                        terminal_state,
-                        Some(termination),
-                        Some(summary),
-                    )
-                    .await;
-            }
-            if let Ok(record) = self.store.get_invocation_header(queued.request.id).await
-                && record.state.is_terminal()
-                && record.summary.is_some()
-            {
-                return Ok(record.into_record());
-            }
+                },
+                metrics: InvocationMetrics::default(),
+                canonical_arguments: None,
+                artifacts: Vec::new(),
+            },
+            recover_without_evidence: true,
+        };
+        match self.commit_terminal(commit).await {
+            Ok(record) => Ok(record),
+            Err(_) => Err(error),
         }
-        postprocess
     }
 
     fn sanitize_summary(

--- a/crates/bazel-mcp-store/src/coordination.rs
+++ b/crates/bazel-mcp-store/src/coordination.rs
@@ -1,0 +1,302 @@
+//! Cross-task and cross-process coordination for store mutations and changes.
+
+use std::{
+    collections::BTreeMap,
+    fs::{File, OpenOptions},
+    path::{Path, PathBuf},
+    sync::{
+        Arc, Weak,
+        atomic::{AtomicU64, Ordering},
+    },
+};
+
+use bazel_mcp_types::InvocationId;
+use tokio::sync::{Mutex, MutexGuard};
+
+use crate::StoreError;
+
+const CHANGE_POLL_INTERVAL_US: u64 = 1_000;
+
+pub(crate) struct LeaseManager {
+    mutation_locks: Mutex<BTreeMap<InvocationId, Weak<Mutex<()>>>>,
+    owner_leases: Mutex<BTreeMap<InvocationId, ProcessLock>>,
+}
+
+impl LeaseManager {
+    pub(crate) fn new() -> Self {
+        Self {
+            mutation_locks: Mutex::new(BTreeMap::new()),
+            owner_leases: Mutex::new(BTreeMap::new()),
+        }
+    }
+
+    pub(crate) async fn mutation_lock(&self, id: InvocationId) -> Arc<Mutex<()>> {
+        let mut locks = self.mutation_locks.lock().await;
+        locks.retain(|_, lock| lock.strong_count() > 0);
+        if let Some(lock) = locks.get(&id).and_then(Weak::upgrade) {
+            return lock;
+        }
+        let lock = Arc::new(Mutex::new(()));
+        locks.insert(id, Arc::downgrade(&lock));
+        lock
+    }
+
+    pub(crate) async fn acquire_owner(
+        &self,
+        cache_root: &Path,
+        id: InvocationId,
+    ) -> Result<ProcessLock, StoreError> {
+        match ProcessLock::try_acquire(owner_lock_path(cache_root, id)).await? {
+            Some(owner) => Ok(owner),
+            None => Err(StoreError::Io(std::io::Error::new(
+                std::io::ErrorKind::AlreadyExists,
+                format!("invocation {id} is already owned by another process"),
+            ))),
+        }
+    }
+
+    pub(crate) async fn retain_owner(&self, id: InvocationId, owner: ProcessLock) {
+        self.owner_leases.lock().await.insert(id, owner);
+    }
+
+    pub(crate) async fn release_owner(&self, id: InvocationId) {
+        self.owner_leases.lock().await.remove(&id);
+    }
+}
+
+pub(crate) struct ProcessLock {
+    _file: File,
+}
+
+impl ProcessLock {
+    pub(crate) async fn acquire(path: PathBuf) -> Result<Self, StoreError> {
+        let lock = tokio::task::spawn_blocking(move || {
+            let file = open_lock_file(&path)?;
+            file.lock()?;
+            Ok::<_, std::io::Error>(Self { _file: file })
+        })
+        .await??;
+        Ok(lock)
+    }
+
+    pub(crate) async fn try_acquire(path: PathBuf) -> Result<Option<Self>, StoreError> {
+        let lock = tokio::task::spawn_blocking(move || {
+            let file = open_lock_file(&path)?;
+            match file.try_lock() {
+                Ok(()) => Ok(Some(Self { _file: file })),
+                Err(std::fs::TryLockError::WouldBlock) => Ok(None),
+                Err(std::fs::TryLockError::Error(error)) => Err(error),
+            }
+        })
+        .await??;
+        Ok(lock)
+    }
+
+    pub(crate) fn try_acquire_blocking(path: &Path) -> Result<Option<Self>, StoreError> {
+        let file = open_lock_file(path)?;
+        match file.try_lock() {
+            Ok(()) => Ok(Some(Self { _file: file })),
+            Err(std::fs::TryLockError::WouldBlock) => Ok(None),
+            Err(std::fs::TryLockError::Error(error)) => Err(error.into()),
+        }
+    }
+}
+
+fn open_lock_file(path: &Path) -> Result<File, std::io::Error> {
+    let mut options = OpenOptions::new();
+    options.create(true).read(true).write(true).truncate(false);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        options.mode(0o600);
+    }
+    options.open(path)
+}
+
+pub(crate) fn owner_lock_path(cache_root: &Path, id: InvocationId) -> PathBuf {
+    cache_root.join("owners").join(format!("{id}.lock"))
+}
+
+pub(crate) fn mutation_lock_path(cache_root: &Path, id: InvocationId) -> PathBuf {
+    cache_root.join("mutations").join(format!("{id}.lock"))
+}
+
+pub(crate) struct ChangeCoordinator {
+    state: Mutex<ChangeState>,
+    next_check_us: AtomicU64,
+}
+
+impl ChangeCoordinator {
+    pub(crate) async fn open(cache_root: &Path) -> Result<Self, StoreError> {
+        let publisher = ChangePublisher::create(cache_root).await?;
+        cleanup_stale_change_publishers(cache_root)?;
+        let observed = read_changes(cache_root)?;
+        Ok(Self {
+            state: Mutex::new(ChangeState {
+                publisher,
+                observed,
+            }),
+            next_check_us: AtomicU64::new(0),
+        })
+    }
+
+    pub(crate) async fn publish(&self) -> Result<(), StoreError> {
+        let mut state = self.state.lock().await;
+        let (publisher, change) = state.publisher.publish()?;
+        state.observed.insert(publisher, change);
+        Ok(())
+    }
+
+    pub(crate) fn claim_check(&self, now_us: u64) -> bool {
+        let next = self.next_check_us.load(Ordering::Acquire);
+        now_us >= next
+            && self
+                .next_check_us
+                .compare_exchange(
+                    next,
+                    now_us.saturating_add(CHANGE_POLL_INTERVAL_US),
+                    Ordering::AcqRel,
+                    Ordering::Acquire,
+                )
+                .is_ok()
+    }
+
+    pub(crate) async fn begin_refresh(
+        &self,
+        cache_root: &Path,
+        force: bool,
+    ) -> Result<Option<ChangeRefresh<'_>>, StoreError> {
+        let guard = self.state.lock().await;
+        let changes = read_changes(cache_root)?;
+        if !force && changes == guard.observed {
+            return Ok(None);
+        }
+        Ok(Some(ChangeRefresh { guard, changes }))
+    }
+
+    #[cfg(test)]
+    pub(crate) async fn publisher_paths(&self, cache_root: &Path) -> (PathBuf, PathBuf) {
+        let state = self.state.lock().await;
+        (
+            state.publisher.marker.clone(),
+            cache_root
+                .join("changes")
+                .join(format!("{}.lock", state.publisher.id)),
+        )
+    }
+}
+
+pub(crate) struct ChangeRefresh<'a> {
+    guard: MutexGuard<'a, ChangeState>,
+    changes: BTreeMap<uuid::Uuid, uuid::Uuid>,
+}
+
+impl ChangeRefresh<'_> {
+    pub(crate) fn commit(mut self) {
+        self.guard.observed = self.changes;
+    }
+}
+
+struct ChangeState {
+    publisher: ChangePublisher,
+    observed: BTreeMap<uuid::Uuid, uuid::Uuid>,
+}
+
+struct ChangePublisher {
+    id: uuid::Uuid,
+    marker: PathBuf,
+    _lease: ProcessLock,
+}
+
+impl ChangePublisher {
+    async fn create(cache_root: &Path) -> Result<Self, StoreError> {
+        let id = uuid::Uuid::now_v7();
+        let change = uuid::Uuid::now_v7();
+        let directory = cache_root.join("changes");
+        let lease = ProcessLock::acquire(directory.join(format!("{id}.lock"))).await?;
+        let marker = directory.join(format!("{id}.{change}"));
+        create_private_marker(&marker)?;
+        Ok(Self {
+            id,
+            marker,
+            _lease: lease,
+        })
+    }
+
+    fn publish(&mut self) -> Result<(uuid::Uuid, uuid::Uuid), StoreError> {
+        let change = uuid::Uuid::now_v7();
+        let next = self.marker.with_file_name(format!("{}.{change}", self.id));
+        std::fs::rename(&self.marker, &next)?;
+        self.marker = next;
+        Ok((self.id, change))
+    }
+}
+
+fn create_private_marker(path: &Path) -> Result<(), StoreError> {
+    let mut options = OpenOptions::new();
+    options.create_new(true).write(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        options.mode(0o600);
+    }
+    drop(options.open(path)?);
+    Ok(())
+}
+
+fn parse_change_marker(name: &std::ffi::OsStr) -> Option<(uuid::Uuid, uuid::Uuid)> {
+    let (publisher, change) = name.to_str()?.split_once('.')?;
+    Some((publisher.parse().ok()?, change.parse().ok()?))
+}
+
+pub(crate) fn read_changes(
+    cache_root: &Path,
+) -> Result<BTreeMap<uuid::Uuid, uuid::Uuid>, StoreError> {
+    let mut changes = BTreeMap::new();
+    for entry in std::fs::read_dir(cache_root.join("changes"))? {
+        let entry = entry?;
+        if let Some((publisher, change)) = parse_change_marker(&entry.file_name()) {
+            changes.insert(publisher, change);
+        }
+    }
+    Ok(changes)
+}
+
+fn cleanup_stale_change_publishers(cache_root: &Path) -> Result<(), StoreError> {
+    let directory = cache_root.join("changes");
+    let mut stale = Vec::new();
+    for entry in std::fs::read_dir(&directory)? {
+        let entry = entry?;
+        let path = entry.path();
+        if path.extension().and_then(std::ffi::OsStr::to_str) != Some("lock") {
+            continue;
+        }
+        let Some(publisher) = path
+            .file_stem()
+            .and_then(std::ffi::OsStr::to_str)
+            .and_then(|value| value.parse::<uuid::Uuid>().ok())
+        else {
+            continue;
+        };
+        if let Some(lease) = ProcessLock::try_acquire_blocking(&path)? {
+            drop(lease);
+            stale.push((publisher, path));
+        }
+    }
+    let stale_ids = stale
+        .iter()
+        .map(|(publisher, _)| *publisher)
+        .collect::<std::collections::BTreeSet<_>>();
+    for entry in std::fs::read_dir(&directory)? {
+        let entry = entry?;
+        if let Some((publisher, _)) = parse_change_marker(&entry.file_name())
+            && stale_ids.contains(&publisher)
+        {
+            let _ = std::fs::remove_file(entry.path());
+        }
+    }
+    for (_, lock) in stale {
+        let _ = std::fs::remove_file(lock);
+    }
+    Ok(())
+}

--- a/crates/bazel-mcp-store/src/index_coordinator.rs
+++ b/crates/bazel-mcp-store/src/index_coordinator.rs
@@ -1,0 +1,35 @@
+//! In-memory index ownership and replacement coordination.
+
+use tokio::sync::{RwLock, RwLockReadGuard, RwLockWriteGuard};
+
+use crate::index::{Index, merge_pending_telemetry};
+
+pub(crate) struct IndexCoordinator {
+    state: RwLock<Index>,
+}
+
+impl IndexCoordinator {
+    pub(crate) fn new(index: Index) -> Self {
+        Self {
+            state: RwLock::new(index),
+        }
+    }
+
+    pub(crate) async fn read(&self) -> RwLockReadGuard<'_, Index> {
+        self.state.read().await
+    }
+
+    pub(crate) async fn write(&self) -> RwLockWriteGuard<'_, Index> {
+        self.state.write().await
+    }
+
+    /// Replace disk-derived state without losing telemetry that has not yet
+    /// reached a manifest.
+    pub(crate) async fn replace_from_disk(&self, mut refreshed: Index) {
+        {
+            let previous = self.state.read().await;
+            merge_pending_telemetry(&previous, &mut refreshed);
+        }
+        *self.state.write().await = refreshed;
+    }
+}

--- a/crates/bazel-mcp-store/src/lib.rs
+++ b/crates/bazel-mcp-store/src/lib.rs
@@ -1,15 +1,21 @@
 //! Database-free, crash-recoverable invocation evidence storage.
 
+mod coordination;
 mod cursor;
 mod deferred_repository;
 mod files;
 mod index;
+mod index_coordinator;
 mod invocation_repository;
 mod manifest;
+mod manifest_repository;
+mod metrics;
 mod query_paging;
 mod record;
+mod recovery;
 mod retention;
 mod storage;
+mod telemetry;
 
 pub use files::InvocationPaths;
 pub use record::{

--- a/crates/bazel-mcp-store/src/manifest_repository.rs
+++ b/crates/bazel-mcp-store/src/manifest_repository.rs
@@ -1,0 +1,113 @@
+//! Filesystem manifest repository and retained-byte accounting.
+
+use std::path::PathBuf;
+
+use bazel_mcp_types::InvocationId;
+
+use crate::{InvocationPaths, StoreError, files::write_bytes_atomic, manifest::DurableRecord};
+
+pub(crate) struct ManifestRepository {
+    cache_root: PathBuf,
+}
+
+impl ManifestRepository {
+    pub(crate) fn new(cache_root: PathBuf) -> Self {
+        Self { cache_root }
+    }
+
+    pub(crate) fn paths_for_id(&self, id: InvocationId) -> InvocationPaths {
+        InvocationPaths::new(&self.cache_root, id)
+    }
+
+    pub(crate) async fn persist(
+        &self,
+        paths: &InvocationPaths,
+        durable: &mut DurableRecord,
+        recount_payload: bool,
+    ) -> Result<PersistOutcome, StoreError> {
+        persist(paths, durable, recount_payload).await
+    }
+}
+
+pub(crate) struct PersistOutcome {
+    pub(crate) retained_bytes: u64,
+    pub(crate) manifest_bytes: u64,
+}
+
+pub(crate) async fn persist(
+    paths: &InvocationPaths,
+    durable: &mut DurableRecord,
+    recount_payload: bool,
+) -> Result<PersistOutcome, StoreError> {
+    if recount_payload {
+        durable.payload_bytes = evidence_payload_size(paths).await?;
+    }
+    let bytes = serde_json::to_vec(durable)?;
+    let manifest_bytes = u64::try_from(bytes.len()).unwrap_or(u64::MAX);
+    write_bytes_atomic(&paths.manifest, bytes).await?;
+    Ok(PersistOutcome {
+        retained_bytes: durable.payload_bytes.saturating_add(manifest_bytes),
+        manifest_bytes,
+    })
+}
+
+async fn evidence_payload_size(paths: &InvocationPaths) -> Result<u64, StoreError> {
+    evidence_size_for(paths, false).await
+}
+
+pub(crate) async fn evidence_size(paths: &InvocationPaths) -> Result<u64, StoreError> {
+    evidence_size_for(paths, true).await
+}
+
+async fn evidence_size_for(
+    paths: &InvocationPaths,
+    include_manifest: bool,
+) -> Result<u64, StoreError> {
+    let mut size = 0_u64;
+    let files = [
+        &paths.manifest,
+        &paths.details,
+        &paths.stdout,
+        &paths.stderr,
+        &paths.evidence,
+        &paths.bep,
+        &paths.artifacts,
+        &paths.test_logs_raw,
+        &paths.test_log_evidence,
+    ];
+    for path in files.into_iter().skip(usize::from(!include_manifest)) {
+        match tokio::fs::symlink_metadata(path).await {
+            Ok(metadata) if metadata.file_type().is_file() => {
+                size = size.saturating_add(metadata.len());
+            }
+            Ok(_) => {}
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+            Err(error) => return Err(error.into()),
+        }
+    }
+    Ok(size)
+}
+
+pub(crate) fn evidence_payload_size_blocking(paths: &InvocationPaths) -> Result<u64, StoreError> {
+    let mut size = 0_u64;
+    for path in [
+        &paths.details,
+        &paths.stdout,
+        &paths.stderr,
+        &paths.evidence,
+        &paths.bep,
+        &paths.artifacts,
+        &paths.test_logs_raw,
+        &paths.test_log_evidence,
+    ] {
+        match std::fs::symlink_metadata(path) {
+            Ok(metadata) if metadata.file_type().is_file() => {
+                size = size.saturating_add(metadata.len());
+            }
+            Ok(_) => {}
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+            Err(error) => return Err(error.into()),
+        }
+    }
+    Ok(size)
+}

--- a/crates/bazel-mcp-store/src/metrics.rs
+++ b/crates/bazel-mcp-store/src/metrics.rs
@@ -1,0 +1,90 @@
+//! Store I/O telemetry accumulation.
+
+use std::sync::atomic::{AtomicU64, Ordering};
+
+#[cfg(test)]
+use std::sync::atomic::AtomicBool;
+
+use crate::StoreIoStats;
+
+pub(crate) struct StoreMetrics {
+    manifest_commits: AtomicU64,
+    manifest_bytes_written: AtomicU64,
+    payload_recounts: AtomicU64,
+    gc_renames: AtomicU64,
+    gc_unlinks: AtomicU64,
+    gc_rename_us: AtomicU64,
+    gc_index_write_us: AtomicU64,
+    gc_unlink_us: AtomicU64,
+    #[cfg(test)]
+    fail_next_gc_unlink: AtomicBool,
+}
+
+impl StoreMetrics {
+    pub(crate) fn new() -> Self {
+        Self {
+            manifest_commits: AtomicU64::new(0),
+            manifest_bytes_written: AtomicU64::new(0),
+            payload_recounts: AtomicU64::new(0),
+            gc_renames: AtomicU64::new(0),
+            gc_unlinks: AtomicU64::new(0),
+            gc_rename_us: AtomicU64::new(0),
+            gc_index_write_us: AtomicU64::new(0),
+            gc_unlink_us: AtomicU64::new(0),
+            #[cfg(test)]
+            fail_next_gc_unlink: AtomicBool::new(false),
+        }
+    }
+
+    pub(crate) fn record_manifest_commit(&self, recount_payload: bool) {
+        self.manifest_commits.fetch_add(1, Ordering::Relaxed);
+        if recount_payload {
+            self.payload_recounts.fetch_add(1, Ordering::Relaxed);
+        }
+    }
+
+    pub(crate) fn record_manifest_bytes(&self, bytes: u64) {
+        self.manifest_bytes_written
+            .fetch_add(bytes, Ordering::Relaxed);
+    }
+
+    pub(crate) fn record_gc_rename(&self, elapsed_us: u64) {
+        self.gc_renames.fetch_add(1, Ordering::Relaxed);
+        self.gc_rename_us.fetch_add(elapsed_us, Ordering::Relaxed);
+    }
+
+    pub(crate) fn record_gc_index_write(&self, elapsed_us: u64) {
+        self.gc_index_write_us
+            .fetch_add(elapsed_us, Ordering::Relaxed);
+    }
+
+    pub(crate) fn record_gc_unlink(&self, elapsed_us: u64, succeeded: bool) {
+        if succeeded {
+            self.gc_unlinks.fetch_add(1, Ordering::Relaxed);
+        }
+        self.gc_unlink_us.fetch_add(elapsed_us, Ordering::Relaxed);
+    }
+
+    #[cfg(test)]
+    pub(crate) fn inject_gc_unlink_failure(&self) {
+        self.fail_next_gc_unlink.store(true, Ordering::Relaxed);
+    }
+
+    #[cfg(test)]
+    pub(crate) fn take_gc_unlink_failure(&self) -> bool {
+        self.fail_next_gc_unlink.swap(false, Ordering::Relaxed)
+    }
+
+    pub(crate) fn snapshot(&self) -> StoreIoStats {
+        StoreIoStats {
+            manifest_commits: self.manifest_commits.load(Ordering::Relaxed),
+            manifest_bytes_written: self.manifest_bytes_written.load(Ordering::Relaxed),
+            payload_recounts: self.payload_recounts.load(Ordering::Relaxed),
+            gc_renames: self.gc_renames.load(Ordering::Relaxed),
+            gc_unlinks: self.gc_unlinks.load(Ordering::Relaxed),
+            gc_rename_us: self.gc_rename_us.load(Ordering::Relaxed),
+            gc_index_write_us: self.gc_index_write_us.load(Ordering::Relaxed),
+            gc_unlink_us: self.gc_unlink_us.load(Ordering::Relaxed),
+        }
+    }
+}

--- a/crates/bazel-mcp-store/src/recovery.rs
+++ b/crates/bazel-mcp-store/src/recovery.rs
@@ -1,0 +1,293 @@
+//! Startup index reconstruction and interrupted-invocation recovery.
+
+use std::{
+    path::{Path, PathBuf},
+    time::{Duration, Instant},
+};
+
+use bazel_mcp_types::{
+    InspectHint, InvocationId, InvocationRecord, InvocationState, InvocationSummary, Termination,
+};
+
+use crate::{
+    InvocationPaths, StoreError, StoreStartupStats,
+    coordination::{ProcessLock, mutation_lock_path, owner_lock_path},
+    files::{remove_if_exists, write_json_atomic},
+    index::{Index, IndexEntry, insert as insert_index_entry, replace as replace_index_entry},
+    manifest::{decode as decode_durable, read as read_durable},
+    manifest_repository::{evidence_payload_size_blocking, persist},
+    record::{InvocationDetails, InvocationHeader},
+};
+
+pub(crate) struct RecoveryManager;
+
+impl RecoveryManager {
+    pub(crate) async fn clean_trash(cache_root: &Path) -> Result<(), StoreError> {
+        let trash = cache_root.join("trash");
+        let mut entries = tokio::fs::read_dir(&trash).await?;
+        while let Some(entry) = entries.next_entry().await? {
+            let metadata = tokio::fs::symlink_metadata(entry.path()).await?;
+            if metadata.is_dir() {
+                tokio::fs::remove_dir_all(entry.path()).await?;
+            } else {
+                tokio::fs::remove_file(entry.path()).await?;
+            }
+        }
+        Ok(())
+    }
+
+    pub(crate) async fn load_index(
+        cache_root: &Path,
+        cleanup_temporary: bool,
+    ) -> Result<(Index, StoreStartupStats), StoreError> {
+        let cache_root = cache_root.to_owned();
+        tokio::task::spawn_blocking(move || load_index_blocking(&cache_root, cleanup_temporary))
+            .await?
+    }
+
+    pub(crate) async fn recover_interrupted(
+        cache_root: &Path,
+        index: &mut Index,
+    ) -> Result<usize, StoreError> {
+        let recovered = Self::recover_ids(cache_root, nonterminal_ids(index)).await?;
+        let recovered_count = recovered.len();
+        for (id, entry) in recovered {
+            replace_index_entry(index, id, entry);
+        }
+        Ok(recovered_count)
+    }
+
+    pub(crate) async fn recover_ids(
+        cache_root: &Path,
+        ids: Vec<InvocationId>,
+    ) -> Result<Vec<(InvocationId, IndexEntry)>, StoreError> {
+        let mut recovered = Vec::new();
+        for id in ids {
+            let Some(owner) = ProcessLock::try_acquire(owner_lock_path(cache_root, id)).await?
+            else {
+                continue;
+            };
+            let mutation = ProcessLock::acquire(mutation_lock_path(cache_root, id)).await?;
+            let paths = InvocationPaths::new(cache_root, id);
+            let (mut durable, _) = match read_durable(&paths.manifest).await {
+                Ok(durable) => durable,
+                Err(StoreError::Io(error)) if error.kind() == std::io::ErrorKind::NotFound => {
+                    continue;
+                }
+                Err(error) => return Err(error),
+            };
+            if durable.invocation.state.is_terminal() {
+                let manifest_bytes = tokio::fs::metadata(&paths.manifest).await?.len();
+                let retained_bytes = durable.payload_bytes.saturating_add(manifest_bytes);
+                recovered.push((id, durable.index_entry(retained_bytes)));
+                continue;
+            }
+            let mut full_record = durable.invocation.clone().into_record();
+            full_record.state = InvocationState::Interrupted;
+            full_record.finished_at_ms = Some(bazel_mcp_types::unix_timestamp_ms());
+            full_record.termination = Some(Termination::Interrupted);
+            full_record.summary = Some(InvocationSummary {
+                success: false,
+                headline: "Invocation was interrupted when the previous server stopped".into(),
+                truncated: true,
+                inspect_hint: Some(InspectHint::Log),
+                ..InvocationSummary::default()
+            });
+            if let Some(deferred) = durable.deferred.as_mut() {
+                deferred.extend_terminal_expiry(
+                    full_record
+                        .finished_at_ms
+                        .unwrap_or_else(bazel_mcp_types::unix_timestamp_ms),
+                );
+            }
+            write_details(&paths, &full_record).await?;
+            durable.invocation = InvocationHeader::from_record(&full_record);
+            let outcome = persist(&paths, &mut durable, true).await?;
+            recovered.push((id, durable.index_entry(outcome.retained_bytes)));
+            drop(mutation);
+            drop(owner);
+        }
+        Ok(recovered)
+    }
+}
+
+pub(crate) fn nonterminal_ids(index: &Index) -> Vec<InvocationId> {
+    index
+        .entries
+        .iter()
+        .filter_map(|(id, entry)| (!entry.record.state.is_terminal()).then_some(*id))
+        .collect()
+}
+
+fn load_index_blocking(
+    cache_root: &Path,
+    cleanup_temporary: bool,
+) -> Result<(Index, StoreStartupStats), StoreError> {
+    let total_started = Instant::now();
+    let mut index = Index::default();
+    let mut stats = StoreStartupStats::default();
+    let invocations = cache_root.join("invocations");
+    for day in std::fs::read_dir(&invocations)? {
+        let day = day?;
+        if !day.file_type()?.is_dir() {
+            continue;
+        }
+        for shard in std::fs::read_dir(day.path())? {
+            let shard = shard?;
+            if !shard.file_type()?.is_dir() {
+                continue;
+            }
+            for directory in std::fs::read_dir(shard.path())? {
+                let directory = directory?;
+                if !directory.file_type()?.is_dir() {
+                    continue;
+                }
+                let name = directory.file_name().to_string_lossy().into_owned();
+                let id = parse_id(&name).ok_or_else(|| StoreError::CorruptRecord {
+                    path: directory.path(),
+                    message: "directory name is not an invocation UUID".into(),
+                })?;
+                let expected = InvocationPaths::new(cache_root, id);
+                if expected.directory != directory.path() {
+                    return Err(StoreError::CorruptRecord {
+                        path: directory.path(),
+                        message: "invocation is outside its UUIDv7 bucket or shard".into(),
+                    });
+                }
+                let read_started = Instant::now();
+                let bytes = std::fs::read(&expected.manifest);
+                stats.manifest_read_us = stats
+                    .manifest_read_us
+                    .saturating_add(elapsed_micros(read_started.elapsed()));
+                match bytes {
+                    Ok(bytes) => {
+                        index_manifest_bytes(&expected, id, &bytes, &mut index, &mut stats)?;
+                        if cleanup_temporary {
+                            cleanup_temporary_files(cache_root, id, &expected.directory)?;
+                        }
+                    }
+                    Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+                        if let Some(_cleanup) =
+                            ProcessLock::try_acquire_blocking(&mutation_lock_path(cache_root, id))?
+                        {
+                            match std::fs::read(&expected.manifest) {
+                                Ok(bytes) => index_manifest_bytes(
+                                    &expected, id, &bytes, &mut index, &mut stats,
+                                )?,
+                                Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+                                    match std::fs::remove_dir_all(directory.path()) {
+                                        Ok(()) => {}
+                                        Err(error)
+                                            if error.kind() == std::io::ErrorKind::NotFound => {}
+                                        Err(error) => return Err(error.into()),
+                                    }
+                                }
+                                Err(error) => return Err(error.into()),
+                            }
+                        }
+                    }
+                    Err(error) => return Err(error.into()),
+                }
+            }
+        }
+    }
+    let total_us = elapsed_micros(total_started.elapsed());
+    stats.directory_traversal_us = total_us.saturating_sub(
+        stats
+            .manifest_read_us
+            .saturating_add(stats.manifest_decode_us)
+            .saturating_add(stats.index_build_us),
+    );
+    Ok((index, stats))
+}
+
+fn index_manifest_bytes(
+    paths: &InvocationPaths,
+    id: InvocationId,
+    bytes: &[u8],
+    index: &mut Index,
+    stats: &mut StoreStartupStats,
+) -> Result<(), StoreError> {
+    let manifest_bytes = u64::try_from(bytes.len()).unwrap_or(u64::MAX);
+    let decode_started = Instant::now();
+    let mut durable = decode_durable(&paths.manifest, bytes)?;
+    stats.manifest_decode_us = stats
+        .manifest_decode_us
+        .saturating_add(elapsed_micros(decode_started.elapsed()));
+    if durable.invocation.request.id != id {
+        return Err(StoreError::CorruptRecord {
+            path: paths.manifest.clone(),
+            message: "record ID does not match directory".into(),
+        });
+    }
+    if !durable.invocation.state.is_terminal() {
+        durable.payload_bytes = evidence_payload_size_blocking(paths)?;
+    }
+    let retained_bytes = durable.payload_bytes.saturating_add(manifest_bytes);
+    let index_started = Instant::now();
+    insert_index_entry(index, id, durable.index_entry(retained_bytes));
+    stats.index_build_us = stats
+        .index_build_us
+        .saturating_add(elapsed_micros(index_started.elapsed()));
+    Ok(())
+}
+
+fn cleanup_temporary_files(
+    cache_root: &Path,
+    id: InvocationId,
+    directory: &Path,
+) -> Result<(), StoreError> {
+    let temporary = temporary_files(directory)?;
+    if !temporary.is_empty()
+        && let Some(_cleanup) =
+            ProcessLock::try_acquire_blocking(&mutation_lock_path(cache_root, id))?
+    {
+        for path in temporary {
+            let _ = std::fs::remove_file(path);
+        }
+    }
+    Ok(())
+}
+
+fn temporary_files(directory: &Path) -> Result<Vec<PathBuf>, StoreError> {
+    const NAMES: [&str; 6] = [
+        "manifest.tmp",
+        "details.tmp",
+        "artifacts.tmp",
+        "failure-evidence.tmp",
+        "failed-test-logs.tmp",
+        "failed-test-evidence.tmp",
+    ];
+    let mut temporary = Vec::new();
+    for entry in std::fs::read_dir(directory)? {
+        let entry = entry?;
+        if entry
+            .file_name()
+            .to_str()
+            .is_some_and(|name| NAMES.contains(&name))
+        {
+            temporary.push(entry.path());
+        }
+    }
+    Ok(temporary)
+}
+
+fn elapsed_micros(duration: Duration) -> u64 {
+    u64::try_from(duration.as_micros()).unwrap_or(u64::MAX)
+}
+
+fn parse_id(value: &str) -> Option<InvocationId> {
+    serde_json::from_str::<InvocationId>(&format!("\"{value}\"")).ok()
+}
+
+async fn write_details(
+    paths: &InvocationPaths,
+    record: &InvocationRecord,
+) -> Result<(), StoreError> {
+    let details = InvocationDetails::from_record(record);
+    if details.is_empty() {
+        remove_if_exists(&paths.details).await
+    } else {
+        write_json_atomic(&paths.details, &details).await
+    }
+}

--- a/crates/bazel-mcp-store/src/retention.rs
+++ b/crates/bazel-mcp-store/src/retention.rs
@@ -2,18 +2,18 @@
 
 use std::{
     collections::BTreeSet,
-    sync::atomic::Ordering,
     time::{Duration, Instant},
 };
 
 use bazel_mcp_types::InvocationId;
 
 use crate::{
+    coordination::{ProcessLock, mutation_lock_path, owner_lock_path},
     index::{remove as remove_index_entry, replace as replace_index_entry},
     manifest::read as read_durable,
+    manifest_repository::evidence_size,
     storage::{
-        ProcessLock, ReclaimOutcome, Store, StoreError, elapsed_us, evidence_size,
-        finish_staged_evidence, mutation_lock_path, owner_lock_path, rename_to_trash,
+        ReclaimOutcome, Store, StoreError, elapsed_us, finish_staged_evidence, rename_to_trash,
         retention_age_elapsed, stage_raw_evidence,
     },
 };
@@ -214,27 +214,22 @@ impl Store {
         let rename_started = Instant::now();
         if let Some(trash) = rename_to_trash(&self.cache_root, id).await? {
             self.inner
-                .gc_rename_us
-                .fetch_add(elapsed_us(rename_started.elapsed()), Ordering::Relaxed);
-            self.inner.gc_renames.fetch_add(1, Ordering::Relaxed);
+                .metrics
+                .record_gc_rename(elapsed_us(rename_started.elapsed()));
             {
                 let index_started = Instant::now();
                 let mut index = self.inner.index.write().await;
                 remove_index_entry(&mut index, id);
                 self.inner
-                    .gc_index_write_us
-                    .fetch_add(elapsed_us(index_started.elapsed()), Ordering::Relaxed);
+                    .metrics
+                    .record_gc_index_write(elapsed_us(index_started.elapsed()));
             }
             drop(_process_mutation);
             // Rename is the deletion commit. If unlinking fails, the index
             // stays removed and startup finishes this trash entry.
             let unlink_started = Instant::now();
             #[cfg(test)]
-            let unlink_result = if self
-                .inner
-                .fail_next_gc_unlink
-                .swap(false, Ordering::Relaxed)
-            {
+            let unlink_result = if self.inner.metrics.take_gc_unlink_failure() {
                 Err(std::io::Error::new(
                     std::io::ErrorKind::PermissionDenied,
                     "injected GC unlink failure",
@@ -244,12 +239,9 @@ impl Store {
             };
             #[cfg(not(test))]
             let unlink_result = tokio::fs::remove_dir_all(trash).await;
-            if unlink_result.is_ok() {
-                self.inner.gc_unlinks.fetch_add(1, Ordering::Relaxed);
-            }
             self.inner
-                .gc_unlink_us
-                .fetch_add(elapsed_us(unlink_started.elapsed()), Ordering::Relaxed);
+                .metrics
+                .record_gc_unlink(elapsed_us(unlink_started.elapsed()), unlink_result.is_ok());
             return Ok(ReclaimOutcome {
                 changed: true,
                 deleted: true,

--- a/crates/bazel-mcp-store/src/storage.rs
+++ b/crates/bazel-mcp-store/src/storage.rs
@@ -1,52 +1,48 @@
 use std::{
-    collections::BTreeMap,
-    fs::{File, OpenOptions},
     path::{Path, PathBuf},
-    sync::{
-        Arc, OnceLock, Weak,
-        atomic::{AtomicU64, Ordering},
-    },
+    sync::{Arc, OnceLock},
     time::{Duration, Instant},
 };
-
-#[cfg(test)]
-use std::sync::atomic::AtomicBool;
 
 #[cfg(test)]
 use bazel_mcp_types::{DeferredRetrieval, TargetResult};
 
 use bazel_mcp_types::{
-    Artifact, CoverageFile, DeferredResultRecord, Diagnostic, InspectHint, InvocationId,
-    InvocationMetrics, InvocationRecord, InvocationState, InvocationSummary, Page, PageRequest,
-    QueryRow, Termination, TestResult,
+    Artifact, CoverageFile, DeferredResultRecord, Diagnostic, InvocationId, InvocationMetrics,
+    InvocationRecord, InvocationState, InvocationSummary, Page, PageRequest, QueryRow, Termination,
+    TestResult,
 };
 use serde::de::DeserializeOwned;
 use thiserror::Error;
-use tokio::sync::{Mutex, RwLock};
+use tokio::sync::Mutex;
 
 use crate::{
     InvocationPaths,
+    coordination::{ChangeCoordinator, LeaseManager, ProcessLock, mutation_lock_path},
     cursor::FileCursor,
     files::{
-        create_private_directory, create_private_directory_all, remove_if_exists,
-        write_bytes_atomic, write_json_atomic,
+        create_private_directory, create_private_directory_all, remove_if_exists, write_json_atomic,
     },
     index::{
         Index, IndexEntry, ensure_exists, insert as insert_index_entry, mark_telemetry_flushed,
-        merge_index_telemetry, merge_pending_telemetry, merge_telemetry,
-        replace as replace_index_entry,
+        merge_index_telemetry, replace as replace_index_entry,
     },
-    manifest::{
-        CURRENT_SCHEMA_VERSION, DurableRecord, decode as decode_durable, read as read_durable,
-    },
+    index_coordinator::IndexCoordinator,
+    manifest::{CURRENT_SCHEMA_VERSION, DurableRecord, read as read_durable},
+    manifest_repository::ManifestRepository,
+    metrics::StoreMetrics,
     query_paging::{QueryFilePage, count_query_file, page_query_file, page_records},
     record::{HydratedInvocation, InvocationDetails, InvocationHeader},
+    recovery::{RecoveryManager, nonterminal_ids},
 };
 
 #[cfg(test)]
-use crate::{query_paging::QUERY_LINE_LIMIT, record::InvocationSummaryHeader};
-
-const CHANGE_POLL_INTERVAL_US: u64 = 1_000;
+use crate::{
+    coordination::{owner_lock_path, read_changes},
+    manifest_repository::persist as persist_manifest,
+    query_paging::QUERY_LINE_LIMIT,
+    record::InvocationSummaryHeader,
+};
 
 #[derive(Debug, Error)]
 pub enum StoreError {
@@ -77,21 +73,11 @@ pub struct Store {
 }
 
 pub(crate) struct StoreInner {
-    pub(crate) index: RwLock<Index>,
-    mutation_locks: Mutex<BTreeMap<InvocationId, Weak<Mutex<()>>>>,
-    owner_leases: Mutex<BTreeMap<InvocationId, ProcessLock>>,
-    change_state: Mutex<ChangeState>,
-    next_change_check_us: AtomicU64,
-    manifest_commits: AtomicU64,
-    manifest_bytes_written: AtomicU64,
-    payload_recounts: AtomicU64,
-    pub(crate) gc_renames: AtomicU64,
-    pub(crate) gc_unlinks: AtomicU64,
-    pub(crate) gc_rename_us: AtomicU64,
-    pub(crate) gc_index_write_us: AtomicU64,
-    pub(crate) gc_unlink_us: AtomicU64,
-    #[cfg(test)]
-    pub(crate) fail_next_gc_unlink: AtomicBool,
+    pub(crate) index: IndexCoordinator,
+    pub(crate) manifests: ManifestRepository,
+    pub(crate) leases: LeaseManager,
+    pub(crate) changes: ChangeCoordinator,
+    pub(crate) metrics: StoreMetrics,
     startup_stats: StoreStartupStats,
 }
 
@@ -143,37 +129,22 @@ impl Store {
         create_private_directory_all(&cache_root.join("changes")).await?;
 
         let _maintenance = ProcessLock::acquire(cache_root.join("MAINTENANCE")).await?;
-        let mut change_publisher = ChangePublisher::create(&cache_root).await?;
-        cleanup_stale_change_publishers(&cache_root)?;
-        recover_trash(&cache_root).await?;
-        let (mut index, startup_stats) = load_index(&cache_root, true).await?;
-        let recovered = recover_interrupted(&cache_root, &mut index).await?;
+        let changes = ChangeCoordinator::open(&cache_root).await?;
+        RecoveryManager::clean_trash(&cache_root).await?;
+        let (mut index, startup_stats) = RecoveryManager::load_index(&cache_root, true).await?;
+        let recovered = RecoveryManager::recover_interrupted(&cache_root, &mut index).await?;
         if recovered != 0 {
-            change_publisher.publish()?;
+            changes.publish().await?;
         }
-        let observed_changes = read_changes(&cache_root)?;
 
         Ok(Self {
-            cache_root,
+            cache_root: cache_root.clone(),
             inner: Arc::new(StoreInner {
-                index: RwLock::new(index),
-                mutation_locks: Mutex::new(BTreeMap::new()),
-                owner_leases: Mutex::new(BTreeMap::new()),
-                change_state: Mutex::new(ChangeState {
-                    publisher: change_publisher,
-                    observed: observed_changes,
-                }),
-                next_change_check_us: AtomicU64::new(0),
-                manifest_commits: AtomicU64::new(0),
-                manifest_bytes_written: AtomicU64::new(0),
-                payload_recounts: AtomicU64::new(0),
-                gc_renames: AtomicU64::new(0),
-                gc_unlinks: AtomicU64::new(0),
-                gc_rename_us: AtomicU64::new(0),
-                gc_index_write_us: AtomicU64::new(0),
-                gc_unlink_us: AtomicU64::new(0),
-                #[cfg(test)]
-                fail_next_gc_unlink: AtomicBool::new(false),
+                index: IndexCoordinator::new(index),
+                manifests: ManifestRepository::new(cache_root.clone()),
+                leases: LeaseManager::new(),
+                changes,
+                metrics: StoreMetrics::new(),
                 startup_stats,
             }),
         })
@@ -181,36 +152,23 @@ impl Store {
 
     #[must_use]
     pub fn paths_for(&self, record: &InvocationRecord) -> InvocationPaths {
-        InvocationPaths::new(&self.cache_root, record.request.id)
+        self.inner.manifests.paths_for_id(record.request.id)
     }
 
     pub(crate) fn paths_for_id(&self, id: InvocationId) -> InvocationPaths {
-        InvocationPaths::new(&self.cache_root, id)
+        self.inner.manifests.paths_for_id(id)
     }
 
     pub(crate) async fn mutation_lock(&self, id: InvocationId) -> Arc<Mutex<()>> {
-        let mut locks = self.inner.mutation_locks.lock().await;
-        locks.retain(|_, lock| lock.strong_count() > 0);
-        if let Some(lock) = locks.get(&id).and_then(Weak::upgrade) {
-            return lock;
-        }
-        let lock = Arc::new(Mutex::new(()));
-        locks.insert(id, Arc::downgrade(&lock));
-        lock
+        self.inner.leases.mutation_lock(id).await
     }
 
     async fn acquire_owner(&self, id: InvocationId) -> Result<ProcessLock, StoreError> {
-        match ProcessLock::try_acquire(owner_lock_path(&self.cache_root, id)).await? {
-            Some(owner) => Ok(owner),
-            None => Err(StoreError::Io(std::io::Error::new(
-                std::io::ErrorKind::AlreadyExists,
-                format!("invocation {id} is already owned by another process"),
-            ))),
-        }
+        self.inner.leases.acquire_owner(&self.cache_root, id).await
     }
 
     async fn release_owner(&self, id: InvocationId) {
-        self.inner.owner_leases.lock().await.remove(&id);
+        self.inner.leases.release_owner(id).await;
     }
 
     pub(crate) async fn recover_orphaned_invocations(&self) -> Result<usize, StoreError> {
@@ -218,7 +176,7 @@ impl Store {
             let index = self.inner.index.read().await;
             nonterminal_ids(&index)
         };
-        let recovered = recover_interrupted_ids(&self.cache_root, ids).await?;
+        let recovered = RecoveryManager::recover_ids(&self.cache_root, ids).await?;
         if !recovered.is_empty() {
             let recovered_count = recovered.len();
             {
@@ -234,10 +192,7 @@ impl Store {
     }
 
     pub(crate) async fn publish_change(&self) -> Result<(), StoreError> {
-        let mut state = self.inner.change_state.lock().await;
-        let (publisher, change) = state.publisher.publish()?;
-        state.observed.insert(publisher, change);
-        Ok(())
+        self.inner.changes.publish().await
     }
 
     pub(crate) async fn refresh_index_if_stale(&self) -> Result<(), StoreError> {
@@ -252,50 +207,27 @@ impl Store {
     }
 
     fn claim_change_check(&self) -> bool {
-        let now = monotonic_us();
-        let next = self.inner.next_change_check_us.load(Ordering::Acquire);
-        if now < next {
-            return false;
-        }
-        self.inner
-            .next_change_check_us
-            .compare_exchange(
-                next,
-                now.saturating_add(CHANGE_POLL_INTERVAL_US),
-                Ordering::AcqRel,
-                Ordering::Acquire,
-            )
-            .is_ok()
+        self.inner.changes.claim_check(monotonic_us())
     }
 
     pub(crate) async fn refresh_index(&self, force: bool) -> Result<(), StoreError> {
-        let mut state = self.inner.change_state.lock().await;
-        let changes = read_changes(&self.cache_root)?;
-        if !force && changes == state.observed {
+        let Some(refresh) = self
+            .inner
+            .changes
+            .begin_refresh(&self.cache_root, force)
+            .await?
+        else {
             return Ok(());
-        }
-        let (mut refreshed, _) = load_index(&self.cache_root, false).await?;
-        {
-            let previous = self.inner.index.read().await;
-            merge_pending_telemetry(&previous, &mut refreshed);
-        }
-        *self.inner.index.write().await = refreshed;
-        state.observed = changes;
+        };
+        let (refreshed, _) = RecoveryManager::load_index(&self.cache_root, false).await?;
+        self.inner.index.replace_from_disk(refreshed).await;
+        refresh.commit();
         Ok(())
     }
 
     #[must_use]
     pub fn io_stats(&self) -> StoreIoStats {
-        StoreIoStats {
-            manifest_commits: self.inner.manifest_commits.load(Ordering::Relaxed),
-            manifest_bytes_written: self.inner.manifest_bytes_written.load(Ordering::Relaxed),
-            payload_recounts: self.inner.payload_recounts.load(Ordering::Relaxed),
-            gc_renames: self.inner.gc_renames.load(Ordering::Relaxed),
-            gc_unlinks: self.inner.gc_unlinks.load(Ordering::Relaxed),
-            gc_rename_us: self.inner.gc_rename_us.load(Ordering::Relaxed),
-            gc_index_write_us: self.inner.gc_index_write_us.load(Ordering::Relaxed),
-            gc_unlink_us: self.inner.gc_unlink_us.load(Ordering::Relaxed),
-        }
+        self.inner.metrics.snapshot()
     }
 
     #[must_use]
@@ -309,14 +241,15 @@ impl Store {
         durable: &mut DurableRecord,
         recount_payload: bool,
     ) -> Result<u64, StoreError> {
-        self.inner.manifest_commits.fetch_add(1, Ordering::Relaxed);
-        if recount_payload {
-            self.inner.payload_recounts.fetch_add(1, Ordering::Relaxed);
-        }
-        let outcome = persist_durable(paths, durable, recount_payload).await?;
+        self.inner.metrics.record_manifest_commit(recount_payload);
+        let outcome = self
+            .inner
+            .manifests
+            .persist(paths, durable, recount_payload)
+            .await?;
         self.inner
-            .manifest_bytes_written
-            .fetch_add(outcome.manifest_bytes, Ordering::Relaxed);
+            .metrics
+            .record_manifest_bytes(outcome.manifest_bytes);
         Ok(outcome.retained_bytes)
     }
 
@@ -375,7 +308,7 @@ impl Store {
         insert_index_entry(&mut index, id, durable.index_entry(retained_bytes));
         drop(index);
         if let Some(owner) = owner {
-            self.inner.owner_leases.lock().await.insert(id, owner);
+            self.inner.leases.retain_owner(id, owner).await;
         }
         Ok(paths)
     }
@@ -513,141 +446,6 @@ impl Store {
         drop(index);
         self.release_owner(id).await;
         Ok(result)
-    }
-
-    pub async fn record_model_visible_result(
-        &self,
-        id: InvocationId,
-        bytes: u64,
-        inspection: bool,
-    ) -> Result<(), StoreError> {
-        self.refresh_index_if_stale().await?;
-        let schedule = {
-            let mut index = self.inner.index.write().await;
-            let entry = index.entries.get_mut(&id).ok_or(StoreError::NotFound(id))?;
-            let metrics = &mut entry.record.metrics;
-            metrics.model_visible_bytes = metrics.model_visible_bytes.saturating_add(bytes);
-            if inspection {
-                metrics.inspect_calls = metrics.inspect_calls.saturating_add(1);
-            }
-            entry.telemetry_generation = entry.telemetry_generation.saturating_add(1);
-            if entry.telemetry_flush_scheduled {
-                false
-            } else {
-                entry.telemetry_flush_scheduled = true;
-                true
-            }
-        };
-        if schedule {
-            self.schedule_telemetry_flush(id);
-        }
-        Ok(())
-    }
-
-    pub async fn record_progress_notifications(
-        &self,
-        id: InvocationId,
-        count: u64,
-    ) -> Result<(), StoreError> {
-        self.refresh_index_if_stale().await?;
-        let schedule = {
-            let mut index = self.inner.index.write().await;
-            let entry = index.entries.get_mut(&id).ok_or(StoreError::NotFound(id))?;
-            let metrics = &mut entry.record.metrics;
-            metrics.progress_notifications = metrics.progress_notifications.saturating_add(count);
-            entry.telemetry_generation = entry.telemetry_generation.saturating_add(1);
-            if entry.telemetry_flush_scheduled {
-                false
-            } else {
-                entry.telemetry_flush_scheduled = true;
-                true
-            }
-        };
-        if schedule {
-            self.schedule_telemetry_flush(id);
-        }
-        Ok(())
-    }
-
-    pub async fn flush_pending_telemetry(&self) -> Result<usize, StoreError> {
-        let ids = {
-            let index = self.inner.index.read().await;
-            index
-                .entries
-                .iter()
-                .filter_map(|(id, entry)| entry.telemetry_flush_scheduled.then_some(*id))
-                .collect::<Vec<_>>()
-        };
-        for id in &ids {
-            while !self.flush_telemetry_once(*id).await? {}
-        }
-        Ok(ids.len())
-    }
-
-    fn schedule_telemetry_flush(&self, id: InvocationId) {
-        let inner = Arc::downgrade(&self.inner);
-        let cache_root = self.cache_root.clone();
-        tokio::spawn(async move {
-            loop {
-                tokio::time::sleep(Duration::from_millis(250)).await;
-                let Some(inner) = inner.upgrade() else {
-                    return;
-                };
-                let store = Store {
-                    cache_root: cache_root.clone(),
-                    inner,
-                };
-                match store.flush_telemetry_once(id).await {
-                    Ok(true) => return,
-                    Ok(false) => {}
-                    Err(_) => {
-                        if let Some(entry) = store.inner.index.write().await.entries.get_mut(&id) {
-                            entry.telemetry_flush_scheduled = false;
-                        }
-                        return;
-                    }
-                }
-            }
-        });
-    }
-
-    async fn flush_telemetry_once(&self, id: InvocationId) -> Result<bool, StoreError> {
-        self.refresh_index_if_stale().await?;
-        let mutation_lock = self.mutation_lock(id).await;
-        let _guard = mutation_lock.lock().await;
-        let (metrics, generation) = {
-            let index = self.inner.index.read().await;
-            let Some(entry) = index.entries.get(&id) else {
-                return Ok(true);
-            };
-            if !entry.telemetry_flush_scheduled {
-                return Ok(true);
-            }
-            (entry.record.metrics.clone(), entry.telemetry_generation)
-        };
-        let _process_mutation =
-            ProcessLock::acquire(mutation_lock_path(&self.cache_root, id)).await?;
-        let paths = self.paths_for_id(id);
-        let (mut durable, _) = read_durable(&paths.manifest).await?;
-        merge_telemetry(&metrics, &mut durable.invocation.metrics);
-        let retained_bytes = self.persist_durable(&paths, &mut durable, false).await?;
-        self.publish_change().await?;
-        let mut index = self.inner.index.write().await;
-        let (previous, clean) = {
-            let Some(entry) = index.entries.get_mut(&id) else {
-                return Ok(true);
-            };
-            let previous = entry.retained_bytes;
-            entry.retained_bytes = retained_bytes;
-            let clean = entry.telemetry_generation == generation;
-            if clean {
-                entry.telemetry_flush_scheduled = false;
-            }
-            (previous, clean)
-        };
-        index.retained_bytes = index.retained_bytes.saturating_sub(previous);
-        index.retained_bytes = index.retained_bytes.saturating_add(retained_bytes);
-        Ok(clean)
     }
 
     pub async fn update_cancellation_reason(
@@ -926,348 +724,9 @@ pub(crate) fn elapsed_us(duration: Duration) -> u64 {
     u64::try_from(duration.as_micros()).unwrap_or(u64::MAX)
 }
 
-async fn persist_durable(
-    paths: &InvocationPaths,
-    durable: &mut DurableRecord,
-    recount_payload: bool,
-) -> Result<PersistOutcome, StoreError> {
-    if recount_payload {
-        durable.payload_bytes = evidence_payload_size(paths).await?;
-    }
-    let bytes = serde_json::to_vec(durable)?;
-    let manifest_bytes = u64::try_from(bytes.len()).unwrap_or(u64::MAX);
-    write_bytes_atomic(&paths.manifest, bytes).await?;
-    Ok(PersistOutcome {
-        retained_bytes: durable.payload_bytes.saturating_add(manifest_bytes),
-        manifest_bytes,
-    })
-}
-
-struct PersistOutcome {
-    retained_bytes: u64,
-    manifest_bytes: u64,
-}
-
-async fn evidence_payload_size(paths: &InvocationPaths) -> Result<u64, StoreError> {
-    let mut size = 0_u64;
-    for path in [
-        &paths.details,
-        &paths.stdout,
-        &paths.stderr,
-        &paths.evidence,
-        &paths.bep,
-        &paths.artifacts,
-        &paths.test_logs_raw,
-        &paths.test_log_evidence,
-    ] {
-        match tokio::fs::symlink_metadata(path).await {
-            Ok(metadata) if metadata.file_type().is_file() => {
-                size = size.saturating_add(metadata.len());
-            }
-            Ok(_) => {}
-            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
-            Err(error) => return Err(error.into()),
-        }
-    }
-    Ok(size)
-}
-
-pub(crate) async fn evidence_size(paths: &InvocationPaths) -> Result<u64, StoreError> {
-    let mut size = 0_u64;
-    for path in [
-        &paths.manifest,
-        &paths.details,
-        &paths.stdout,
-        &paths.stderr,
-        &paths.evidence,
-        &paths.bep,
-        &paths.artifacts,
-        &paths.test_logs_raw,
-        &paths.test_log_evidence,
-    ] {
-        match tokio::fs::symlink_metadata(path).await {
-            Ok(metadata) if metadata.file_type().is_file() => {
-                size = size.saturating_add(metadata.len());
-            }
-            Ok(_) => {}
-            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
-            Err(error) => return Err(error.into()),
-        }
-    }
-    Ok(size)
-}
-
-async fn recover_trash(cache_root: &Path) -> Result<(), StoreError> {
-    let trash = cache_root.join("trash");
-    let mut entries = tokio::fs::read_dir(&trash).await?;
-    while let Some(entry) = entries.next_entry().await? {
-        let metadata = tokio::fs::symlink_metadata(entry.path()).await?;
-        if metadata.is_dir() {
-            tokio::fs::remove_dir_all(entry.path()).await?;
-        } else {
-            tokio::fs::remove_file(entry.path()).await?;
-        }
-    }
-    Ok(())
-}
-
-async fn load_index(
-    cache_root: &Path,
-    cleanup_temporary: bool,
-) -> Result<(Index, StoreStartupStats), StoreError> {
-    let cache_root = cache_root.to_owned();
-    tokio::task::spawn_blocking(move || load_index_blocking(&cache_root, cleanup_temporary)).await?
-}
-
-fn load_index_blocking(
-    cache_root: &Path,
-    cleanup_temporary: bool,
-) -> Result<(Index, StoreStartupStats), StoreError> {
-    let total_started = Instant::now();
-    let mut index = Index::default();
-    let mut stats = StoreStartupStats::default();
-    let invocations = cache_root.join("invocations");
-    for day in std::fs::read_dir(&invocations)? {
-        let day = day?;
-        if !day.file_type()?.is_dir() {
-            continue;
-        }
-        for shard in std::fs::read_dir(day.path())? {
-            let shard = shard?;
-            if !shard.file_type()?.is_dir() {
-                continue;
-            }
-            for directory in std::fs::read_dir(shard.path())? {
-                let directory = directory?;
-                if !directory.file_type()?.is_dir() {
-                    continue;
-                }
-                let name = directory.file_name().to_string_lossy().into_owned();
-                let id = parse_id(&name).ok_or_else(|| StoreError::CorruptRecord {
-                    path: directory.path(),
-                    message: "directory name is not an invocation UUID".into(),
-                })?;
-                let expected = InvocationPaths::new(cache_root, id);
-                if expected.directory != directory.path() {
-                    return Err(StoreError::CorruptRecord {
-                        path: directory.path(),
-                        message: "invocation is outside its UUIDv7 bucket or shard".into(),
-                    });
-                }
-                let read_started = Instant::now();
-                let bytes = std::fs::read(&expected.manifest);
-                stats.manifest_read_us = stats
-                    .manifest_read_us
-                    .saturating_add(elapsed_micros(read_started.elapsed()));
-                match bytes {
-                    Ok(bytes) => {
-                        index_manifest_bytes(&expected, id, &bytes, &mut index, &mut stats)?;
-                        if cleanup_temporary {
-                            let temporary = temporary_files(&expected.directory)?;
-                            if !temporary.is_empty()
-                                && let Some(_cleanup) = ProcessLock::try_acquire_blocking(
-                                    &mutation_lock_path(cache_root, id),
-                                )?
-                            {
-                                for path in temporary {
-                                    let _ = std::fs::remove_file(path);
-                                }
-                            }
-                        }
-                    }
-                    Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
-                        // Creation is committed by manifest.json. A directory without
-                        // it is an uncommitted crash remnant.
-                        if let Some(_cleanup) =
-                            ProcessLock::try_acquire_blocking(&mutation_lock_path(cache_root, id))?
-                        {
-                            match std::fs::read(&expected.manifest) {
-                                Ok(bytes) => index_manifest_bytes(
-                                    &expected, id, &bytes, &mut index, &mut stats,
-                                )?,
-                                Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
-                                    match std::fs::remove_dir_all(directory.path()) {
-                                        Ok(()) => {}
-                                        Err(error)
-                                            if error.kind() == std::io::ErrorKind::NotFound => {}
-                                        Err(error) => return Err(error.into()),
-                                    }
-                                }
-                                Err(error) => return Err(error.into()),
-                            }
-                        }
-                    }
-                    Err(error) => return Err(error.into()),
-                }
-            }
-        }
-    }
-    let total_us = elapsed_micros(total_started.elapsed());
-    stats.directory_traversal_us = total_us.saturating_sub(
-        stats
-            .manifest_read_us
-            .saturating_add(stats.manifest_decode_us)
-            .saturating_add(stats.index_build_us),
-    );
-    Ok((index, stats))
-}
-
-fn index_manifest_bytes(
-    paths: &InvocationPaths,
-    id: InvocationId,
-    bytes: &[u8],
-    index: &mut Index,
-    stats: &mut StoreStartupStats,
-) -> Result<(), StoreError> {
-    let manifest_bytes = u64::try_from(bytes.len()).unwrap_or(u64::MAX);
-    let decode_started = Instant::now();
-    let mut durable = decode_durable(&paths.manifest, bytes)?;
-    stats.manifest_decode_us = stats
-        .manifest_decode_us
-        .saturating_add(elapsed_micros(decode_started.elapsed()));
-    if durable.invocation.request.id != id {
-        return Err(StoreError::CorruptRecord {
-            path: paths.manifest.clone(),
-            message: "record ID does not match directory".into(),
-        });
-    }
-    // Terminal records commit byte accounting after every evidence-producing
-    // operation. Only a nonterminal record can have grown since its last commit.
-    if !durable.invocation.state.is_terminal() {
-        durable.payload_bytes = evidence_payload_size_blocking(paths)?;
-    }
-    let retained_bytes = durable.payload_bytes.saturating_add(manifest_bytes);
-    let index_started = Instant::now();
-    insert_index_entry(index, id, durable.index_entry(retained_bytes));
-    stats.index_build_us = stats
-        .index_build_us
-        .saturating_add(elapsed_micros(index_started.elapsed()));
-    Ok(())
-}
-
-fn temporary_files(directory: &Path) -> Result<Vec<PathBuf>, StoreError> {
-    const NAMES: [&str; 6] = [
-        "manifest.tmp",
-        "details.tmp",
-        "artifacts.tmp",
-        "failure-evidence.tmp",
-        "failed-test-logs.tmp",
-        "failed-test-evidence.tmp",
-    ];
-    let mut temporary = Vec::new();
-    for entry in std::fs::read_dir(directory)? {
-        let entry = entry?;
-        if entry
-            .file_name()
-            .to_str()
-            .is_some_and(|name| NAMES.contains(&name))
-        {
-            temporary.push(entry.path());
-        }
-    }
-    Ok(temporary)
-}
-
-fn elapsed_micros(duration: Duration) -> u64 {
-    u64::try_from(duration.as_micros()).unwrap_or(u64::MAX)
-}
-
 fn monotonic_us() -> u64 {
     static START: OnceLock<Instant> = OnceLock::new();
-    elapsed_micros(START.get_or_init(Instant::now).elapsed())
-}
-
-fn evidence_payload_size_blocking(paths: &InvocationPaths) -> Result<u64, StoreError> {
-    let mut size = 0_u64;
-    for path in [
-        &paths.details,
-        &paths.stdout,
-        &paths.stderr,
-        &paths.evidence,
-        &paths.bep,
-        &paths.artifacts,
-        &paths.test_logs_raw,
-        &paths.test_log_evidence,
-    ] {
-        match std::fs::symlink_metadata(path) {
-            Ok(metadata) if metadata.file_type().is_file() => {
-                size = size.saturating_add(metadata.len());
-            }
-            Ok(_) => {}
-            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
-            Err(error) => return Err(error.into()),
-        }
-    }
-    Ok(size)
-}
-
-async fn recover_interrupted(cache_root: &Path, index: &mut Index) -> Result<usize, StoreError> {
-    let recovered = recover_interrupted_ids(cache_root, nonterminal_ids(index)).await?;
-    let recovered_count = recovered.len();
-    for (id, entry) in recovered {
-        replace_index_entry(index, id, entry);
-    }
-    Ok(recovered_count)
-}
-
-fn nonterminal_ids(index: &Index) -> Vec<InvocationId> {
-    index
-        .entries
-        .iter()
-        .filter_map(|(id, entry)| (!entry.record.state.is_terminal()).then_some(*id))
-        .collect()
-}
-
-async fn recover_interrupted_ids(
-    cache_root: &Path,
-    ids: Vec<InvocationId>,
-) -> Result<Vec<(InvocationId, IndexEntry)>, StoreError> {
-    let mut recovered = Vec::new();
-    for id in ids {
-        let Some(owner) = ProcessLock::try_acquire(owner_lock_path(cache_root, id)).await? else {
-            continue;
-        };
-        let mutation = ProcessLock::acquire(mutation_lock_path(cache_root, id)).await?;
-        let paths = InvocationPaths::new(cache_root, id);
-        let (mut durable, _) = match read_durable(&paths.manifest).await {
-            Ok(durable) => durable,
-            Err(StoreError::Io(error)) if error.kind() == std::io::ErrorKind::NotFound => {
-                continue;
-            }
-            Err(error) => return Err(error),
-        };
-        if durable.invocation.state.is_terminal() {
-            let manifest_bytes = tokio::fs::metadata(&paths.manifest).await?.len();
-            let retained_bytes = durable.payload_bytes.saturating_add(manifest_bytes);
-            recovered.push((id, durable.index_entry(retained_bytes)));
-            continue;
-        }
-        let mut full_record = durable.invocation.clone().into_record();
-        full_record.state = InvocationState::Interrupted;
-        full_record.finished_at_ms = Some(bazel_mcp_types::unix_timestamp_ms());
-        full_record.termination = Some(Termination::Interrupted);
-        full_record.summary = Some(InvocationSummary {
-            success: false,
-            headline: "Invocation was interrupted when the previous server stopped".into(),
-            truncated: true,
-            inspect_hint: Some(InspectHint::Log),
-            ..InvocationSummary::default()
-        });
-        if let Some(deferred) = durable.deferred.as_mut() {
-            deferred.extend_terminal_expiry(
-                full_record
-                    .finished_at_ms
-                    .unwrap_or_else(bazel_mcp_types::unix_timestamp_ms),
-            );
-        }
-        write_details(&paths, &full_record).await?;
-        durable.invocation = InvocationHeader::from_record(&full_record);
-        let outcome = persist_durable(&paths, &mut durable, true).await?;
-        recovered.push((id, durable.index_entry(outcome.retained_bytes)));
-        drop(mutation);
-        drop(owner);
-    }
-    Ok(recovered)
+    elapsed_us(START.get_or_init(Instant::now).elapsed())
 }
 
 pub(crate) fn retention_age_elapsed(finished_at_ms: i64, cutoff_ms: i64) -> bool {
@@ -1391,172 +850,6 @@ fn transition_lost_evidence(
 
 fn error_is_not_found(error: &StoreError) -> bool {
     matches!(error, StoreError::Io(error) if error.kind() == std::io::ErrorKind::NotFound)
-}
-
-fn parse_id(value: &str) -> Option<InvocationId> {
-    serde_json::from_str::<InvocationId>(&format!("\"{value}\"")).ok()
-}
-
-pub(crate) struct ProcessLock {
-    _file: File,
-}
-
-impl ProcessLock {
-    pub(crate) async fn acquire(path: PathBuf) -> Result<Self, StoreError> {
-        let lock = tokio::task::spawn_blocking(move || {
-            let file = open_lock_file(&path)?;
-            file.lock()?;
-            Ok::<_, std::io::Error>(Self { _file: file })
-        })
-        .await??;
-        Ok(lock)
-    }
-
-    pub(crate) async fn try_acquire(path: PathBuf) -> Result<Option<Self>, StoreError> {
-        let lock = tokio::task::spawn_blocking(move || {
-            let file = open_lock_file(&path)?;
-            match file.try_lock() {
-                Ok(()) => Ok(Some(Self { _file: file })),
-                Err(std::fs::TryLockError::WouldBlock) => Ok(None),
-                Err(std::fs::TryLockError::Error(error)) => Err(error),
-            }
-        })
-        .await??;
-        Ok(lock)
-    }
-
-    fn try_acquire_blocking(path: &Path) -> Result<Option<Self>, StoreError> {
-        let file = open_lock_file(path)?;
-        match file.try_lock() {
-            Ok(()) => Ok(Some(Self { _file: file })),
-            Err(std::fs::TryLockError::WouldBlock) => Ok(None),
-            Err(std::fs::TryLockError::Error(error)) => Err(error.into()),
-        }
-    }
-}
-
-fn open_lock_file(path: &Path) -> Result<File, std::io::Error> {
-    let mut options = OpenOptions::new();
-    options.create(true).read(true).write(true).truncate(false);
-    #[cfg(unix)]
-    {
-        use std::os::unix::fs::OpenOptionsExt;
-        options.mode(0o600);
-    }
-    options.open(path)
-}
-
-pub(crate) fn owner_lock_path(cache_root: &Path, id: InvocationId) -> PathBuf {
-    cache_root.join("owners").join(format!("{id}.lock"))
-}
-
-pub(crate) fn mutation_lock_path(cache_root: &Path, id: InvocationId) -> PathBuf {
-    cache_root.join("mutations").join(format!("{id}.lock"))
-}
-
-struct ChangeState {
-    publisher: ChangePublisher,
-    observed: BTreeMap<uuid::Uuid, uuid::Uuid>,
-}
-
-struct ChangePublisher {
-    id: uuid::Uuid,
-    marker: PathBuf,
-    _lease: ProcessLock,
-}
-
-impl ChangePublisher {
-    async fn create(cache_root: &Path) -> Result<Self, StoreError> {
-        let id = uuid::Uuid::now_v7();
-        let change = uuid::Uuid::now_v7();
-        let directory = cache_root.join("changes");
-        let lease = ProcessLock::acquire(directory.join(format!("{id}.lock"))).await?;
-        let marker = directory.join(format!("{id}.{change}"));
-        create_private_marker(&marker)?;
-        Ok(Self {
-            id,
-            marker,
-            _lease: lease,
-        })
-    }
-
-    fn publish(&mut self) -> Result<(uuid::Uuid, uuid::Uuid), StoreError> {
-        let change = uuid::Uuid::now_v7();
-        let next = self.marker.with_file_name(format!("{}.{change}", self.id));
-        std::fs::rename(&self.marker, &next)?;
-        self.marker = next;
-        Ok((self.id, change))
-    }
-}
-
-fn create_private_marker(path: &Path) -> Result<(), StoreError> {
-    let mut options = OpenOptions::new();
-    options.create_new(true).write(true);
-    #[cfg(unix)]
-    {
-        use std::os::unix::fs::OpenOptionsExt;
-        options.mode(0o600);
-    }
-    drop(options.open(path)?);
-    Ok(())
-}
-
-fn parse_change_marker(name: &std::ffi::OsStr) -> Option<(uuid::Uuid, uuid::Uuid)> {
-    let (publisher, change) = name.to_str()?.split_once('.')?;
-    Some((publisher.parse().ok()?, change.parse().ok()?))
-}
-
-fn read_changes(cache_root: &Path) -> Result<BTreeMap<uuid::Uuid, uuid::Uuid>, StoreError> {
-    let mut changes = BTreeMap::new();
-    for entry in std::fs::read_dir(cache_root.join("changes"))? {
-        let entry = entry?;
-        if let Some((publisher, change)) = parse_change_marker(&entry.file_name()) {
-            changes.insert(publisher, change);
-        }
-    }
-    Ok(changes)
-}
-
-fn cleanup_stale_change_publishers(cache_root: &Path) -> Result<(), StoreError> {
-    let directory = cache_root.join("changes");
-    let mut stale = Vec::new();
-    for entry in std::fs::read_dir(&directory)? {
-        let entry = entry?;
-        let path = entry.path();
-        if path.extension().and_then(std::ffi::OsStr::to_str) != Some("lock") {
-            continue;
-        }
-        let Some(publisher) = path
-            .file_stem()
-            .and_then(std::ffi::OsStr::to_str)
-            .and_then(|value| value.parse::<uuid::Uuid>().ok())
-        else {
-            continue;
-        };
-        if let Some(lease) = ProcessLock::try_acquire_blocking(&path)? {
-            drop(lease);
-            stale.push((publisher, path));
-        }
-    }
-    if stale.is_empty() {
-        return Ok(());
-    }
-    let stale_ids = stale
-        .iter()
-        .map(|(publisher, _)| *publisher)
-        .collect::<std::collections::BTreeSet<_>>();
-    for entry in std::fs::read_dir(&directory)? {
-        let entry = entry?;
-        if let Some((publisher, _)) = parse_change_marker(&entry.file_name())
-            && stale_ids.contains(&publisher)
-        {
-            let _ = std::fs::remove_file(entry.path());
-        }
-    }
-    for (_, lock) in stale {
-        let _ = std::fs::remove_file(lock);
-    }
-    Ok(())
 }
 
 #[cfg(test)]
@@ -1691,15 +984,7 @@ mod tests {
         let record = record(&root.path().join("worktree-a"));
         let id = record.request.id;
         writer.create_invocation(&record).await.unwrap();
-        let (marker, lease) = {
-            let state = writer.inner.change_state.lock().await;
-            (
-                state.publisher.marker.clone(),
-                root.path()
-                    .join("changes")
-                    .join(format!("{}.lock", state.publisher.id)),
-            )
-        };
+        let (marker, lease) = writer.inner.changes.publisher_paths(root.path()).await;
         drop(writer);
 
         assert!(marker.exists());
@@ -1817,7 +1102,7 @@ mod tests {
         durable.invocation.termination = Some(Termination::Exit { code: 0 });
         durable.invocation.summary =
             Some(InvocationSummaryHeader::from(&InvocationSummary::default()));
-        persist_durable(&paths, &mut durable, true).await.unwrap();
+        persist_manifest(&paths, &mut durable, true).await.unwrap();
         assert_eq!(read_changes(root.path()).unwrap(), changes);
         drop(writer);
 
@@ -2347,13 +1632,11 @@ mod tests {
                 directory.display()
             );
         }
-        let change_state = store.inner.change_state.lock().await;
+        let (change_marker, change_lease) = store.inner.changes.publisher_paths(&cache_root).await;
         for file in [
             cache_root.join("MAINTENANCE"),
-            cache_root
-                .join("changes")
-                .join(format!("{}.lock", change_state.publisher.id)),
-            change_state.publisher.marker.clone(),
+            change_lease,
+            change_marker,
             owner_lock_path(&cache_root, record.request.id),
             mutation_lock_path(&cache_root, record.request.id),
             paths.manifest.clone(),
@@ -2924,10 +2207,7 @@ mod tests {
         let id = record.request.id;
         store.create_invocation(&record).await.unwrap();
         succeed(&store, id).await;
-        store
-            .inner
-            .fail_next_gc_unlink
-            .store(true, Ordering::Relaxed);
+        store.inner.metrics.inject_gc_unlink_failure();
 
         assert_eq!(
             store

--- a/crates/bazel-mcp-store/src/telemetry.rs
+++ b/crates/bazel-mcp-store/src/telemetry.rs
@@ -1,0 +1,159 @@
+//! Coalesced invocation telemetry accumulation and manifest flushing.
+
+use std::{sync::Arc, time::Duration};
+
+use bazel_mcp_types::InvocationId;
+
+use crate::{
+    Store, StoreError,
+    coordination::{ProcessLock, mutation_lock_path},
+    index::{IndexEntry, merge_telemetry},
+    manifest::read as read_durable,
+};
+
+struct TelemetryAccumulator;
+
+impl TelemetryAccumulator {
+    fn record_model_visible(entry: &mut IndexEntry, bytes: u64, inspection: bool) -> bool {
+        let metrics = &mut entry.record.metrics;
+        metrics.model_visible_bytes = metrics.model_visible_bytes.saturating_add(bytes);
+        if inspection {
+            metrics.inspect_calls = metrics.inspect_calls.saturating_add(1);
+        }
+        Self::mark_dirty(entry)
+    }
+
+    fn record_progress(entry: &mut IndexEntry, count: u64) -> bool {
+        let metrics = &mut entry.record.metrics;
+        metrics.progress_notifications = metrics.progress_notifications.saturating_add(count);
+        Self::mark_dirty(entry)
+    }
+
+    fn mark_dirty(entry: &mut IndexEntry) -> bool {
+        entry.telemetry_generation = entry.telemetry_generation.saturating_add(1);
+        if entry.telemetry_flush_scheduled {
+            false
+        } else {
+            entry.telemetry_flush_scheduled = true;
+            true
+        }
+    }
+}
+
+impl Store {
+    pub async fn record_model_visible_result(
+        &self,
+        id: InvocationId,
+        bytes: u64,
+        inspection: bool,
+    ) -> Result<(), StoreError> {
+        self.refresh_index_if_stale().await?;
+        let schedule = {
+            let mut index = self.inner.index.write().await;
+            let entry = index.entries.get_mut(&id).ok_or(StoreError::NotFound(id))?;
+            TelemetryAccumulator::record_model_visible(entry, bytes, inspection)
+        };
+        if schedule {
+            self.schedule_telemetry_flush(id);
+        }
+        Ok(())
+    }
+
+    pub async fn record_progress_notifications(
+        &self,
+        id: InvocationId,
+        count: u64,
+    ) -> Result<(), StoreError> {
+        self.refresh_index_if_stale().await?;
+        let schedule = {
+            let mut index = self.inner.index.write().await;
+            let entry = index.entries.get_mut(&id).ok_or(StoreError::NotFound(id))?;
+            TelemetryAccumulator::record_progress(entry, count)
+        };
+        if schedule {
+            self.schedule_telemetry_flush(id);
+        }
+        Ok(())
+    }
+
+    pub async fn flush_pending_telemetry(&self) -> Result<usize, StoreError> {
+        let ids = {
+            let index = self.inner.index.read().await;
+            index
+                .entries
+                .iter()
+                .filter_map(|(id, entry)| entry.telemetry_flush_scheduled.then_some(*id))
+                .collect::<Vec<_>>()
+        };
+        for id in &ids {
+            while !self.flush_telemetry_once(*id).await? {}
+        }
+        Ok(ids.len())
+    }
+
+    fn schedule_telemetry_flush(&self, id: InvocationId) {
+        let inner = Arc::downgrade(&self.inner);
+        let cache_root = self.cache_root.clone();
+        tokio::spawn(async move {
+            loop {
+                tokio::time::sleep(Duration::from_millis(250)).await;
+                let Some(inner) = inner.upgrade() else {
+                    return;
+                };
+                let store = Store {
+                    cache_root: cache_root.clone(),
+                    inner,
+                };
+                match store.flush_telemetry_once(id).await {
+                    Ok(true) => return,
+                    Ok(false) => {}
+                    Err(_) => {
+                        if let Some(entry) = store.inner.index.write().await.entries.get_mut(&id) {
+                            entry.telemetry_flush_scheduled = false;
+                        }
+                        return;
+                    }
+                }
+            }
+        });
+    }
+
+    async fn flush_telemetry_once(&self, id: InvocationId) -> Result<bool, StoreError> {
+        self.refresh_index_if_stale().await?;
+        let mutation_lock = self.mutation_lock(id).await;
+        let _guard = mutation_lock.lock().await;
+        let (metrics, generation) = {
+            let index = self.inner.index.read().await;
+            let Some(entry) = index.entries.get(&id) else {
+                return Ok(true);
+            };
+            if !entry.telemetry_flush_scheduled {
+                return Ok(true);
+            }
+            (entry.record.metrics.clone(), entry.telemetry_generation)
+        };
+        let _process_mutation =
+            ProcessLock::acquire(mutation_lock_path(&self.cache_root, id)).await?;
+        let paths = self.paths_for_id(id);
+        let (mut durable, _) = read_durable(&paths.manifest).await?;
+        merge_telemetry(&metrics, &mut durable.invocation.metrics);
+        let retained_bytes = self.persist_durable(&paths, &mut durable, false).await?;
+        self.publish_change().await?;
+        let mut index = self.inner.index.write().await;
+        let (previous, clean) = {
+            let Some(entry) = index.entries.get_mut(&id) else {
+                return Ok(true);
+            };
+            let previous = entry.retained_bytes;
+            entry.retained_bytes = retained_bytes;
+            let clean = entry.telemetry_generation == generation;
+            if clean {
+                entry.telemetry_flush_scheduled = false;
+            }
+            (previous, clean)
+        };
+        index.retained_bytes = index.retained_bytes.saturating_sub(previous);
+        index.retained_bytes = index.retained_bytes.saturating_add(retained_bytes);
+        Ok(clean)
+    }
+}


### PR DESCRIPTION
## Summary

- model invocation execution as explicit `ExecutionPlan`, `RunningInvocation`, `CapturedEvidence`, `ReducedOutcome`, and `TerminalCommit` phases
- route completion and recovery through one terminal commit boundary while preserving process-group cancellation and durable-first evidence capture
- split store responsibilities into manifest, index, lease/change coordination, telemetry/metrics, and recovery components
- reduce `storage.rs` by moving invariant-owning mechanisms behind dedicated types rather than only moving helper functions

## Why

The runner and store had accumulated orchestration megafunctions with many independent invariants. This made lifecycle changes hard to reason about and allowed preparation, capture, reduction, persistence, locking, telemetry, and recovery concerns to reach across one another.

The new phase and component boundaries make state transitions explicit and give each invariant a single owner without changing the wire protocol or on-disk schema.

## Validation

- `make test`
- `make check`
- runner unit and process integration tests: 29 + 36 passed
- store tests: 44 passed
- identical reduced storage benchmark:
  - whole run: 2229.5 ms baseline, 2241.2 ms after (+0.52%)
  - repeat after run: 2220.8 ms (-0.39% vs baseline)
  - GC remained effectively flat

Startup microbenchmarks were noisy across repeated runs, so this change does not claim a startup improvement.

## Invariants preserved

- Bazel is spawned directly without a shell
- process-group cancellation and drop cleanup remain intact
- raw BEP/log evidence is persisted before reduction and redaction
- model-visible budgets and redaction remain downstream of durable evidence
- store format remains database-free and schema-compatible
- cross-process locks, change publication, telemetry coalescing, and interrupted-invocation recovery retain their existing tests

## Not run locally

- Bazel-backed build and version-matrix targets; the session did not expose a Bazel MCP tool, and repository policy prohibits invoking Bazel directly
