### PR TITLE
feat(runner): add optional Aspect CLI executor

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,14 +110,16 @@ The server exposes three tools:
 
 | Tool | Purpose |
 | --- | --- |
-| `bazel.run` | Run an allowed Bazel command and return a bounded summary. |
+| `bazel.run` | Run an allowed Bazel or configured Aspect command and return a bounded summary. |
 | `bazel.inspect` | Read filtered diagnostics, tests, coverage, artifacts, query results, or logs from an invocation. |
 | `bazel.cancel` | Cancel a queued or running invocation. |
 
 `bazel.run` supports `build`, `test`, `coverage`, `query`, `cquery`, `aquery`,
-and selected informational commands. Successful results are limited to 2 KiB
-and unsuccessful results to 8 KiB. Follow-up `bazel.inspect` calls are also
-bounded and paginated, so an agent only retrieves the evidence it needs.
+and selected informational commands. Operators may also route explicitly
+allowed commands such as `lint` through Aspect CLI. Successful results are
+limited to 2 KiB and unsuccessful results to 8 KiB. Follow-up `bazel.inspect`
+calls are also bounded and paginated, so an agent only retrieves the evidence
+it needs.
 
 Failure results rank concrete root causes before aggregated action failures.
 Equivalent fanout failures are represented once with `target: null` and a
@@ -381,7 +383,7 @@ guidance.
 
 The built-in defaults cover personal local use. For workspace restrictions,
 retention limits, timeouts, command policy, result encoding, BEP transport,
-custom redaction, or custom reducers, start with
+optional Aspect CLI routing, custom redaction, or custom reducers, start with
 [`examples/config.toml`](examples/config.toml).
 
 BEP capture defaults to the private binary-file (`tail`) path so existing

--- a/crates/bazel-mcp-bes/src/lib.rs
+++ b/crates/bazel-mcp-bes/src/lib.rs
@@ -10,4 +10,6 @@ pub mod proto {
     buffa::include_proto!("google.devtools.build.v1");
 }
 
-pub use server::{BesCapture, BesError, BesServer, BesStreamEvent, CaptureStats};
+pub use server::{
+    BesCapture, BesError, BesServer, BesStreamEvent, CAPTURE_ID_HEADER, CaptureStats,
+};

--- a/crates/bazel-mcp-bes/src/server.rs
+++ b/crates/bazel-mcp-bes/src/server.rs
@@ -33,6 +33,7 @@ use crate::{
 };
 
 const SERVICE_NAME: &str = "google.devtools.build.v1.PublishBuildEvent";
+pub const CAPTURE_ID_HEADER: &str = "x-bazel-mcp-invocation-id";
 const LIFECYCLE_PATH: &str = "/google.devtools.build.v1.PublishBuildEvent/PublishLifecycleEvent";
 const BUILD_TOOL_STREAM_PATH: &str =
     "/google.devtools.build.v1.PublishBuildEvent/PublishBuildToolEventStream";
@@ -310,9 +311,18 @@ where
                         request: Request<Streaming<PublishBuildToolEventStreamRequestOwnedView>>,
                     ) -> Self::Future {
                         let captures = self.captures.clone();
+                        let capture_id = match capture_id_from_metadata(request.metadata()) {
+                            Ok(capture_id) => capture_id,
+                            Err(status) => return Box::pin(async move { Err(status) }),
+                        };
                         Box::pin(async move {
                             let (responses, receiver) = tokio::sync::mpsc::channel(32);
-                            tokio::spawn(ingest_stream(captures, request.into_inner(), responses));
+                            tokio::spawn(ingest_stream(
+                                captures,
+                                request.into_inner(),
+                                responses,
+                                capture_id,
+                            ));
                             Ok(Response::new(ReceiverStream::new(receiver)))
                         })
                     }
@@ -347,18 +357,23 @@ async fn ingest_stream(
     captures: Captures,
     mut input: Streaming<PublishBuildToolEventStreamRequestOwnedView>,
     responses: tokio::sync::mpsc::Sender<Result<PublishBuildToolEventStreamResponse, Status>>,
+    capture_id: Option<String>,
 ) {
     let Some(first) = recv_request(&mut input, &responses).await else {
         return;
     };
-    let state_result = {
-        match request_invocation_id(&first) {
+    let state_result = match capture_id {
+        Some(capture_id) => match captures.lock() {
+            Ok(captures) => Ok(captures.get(&capture_id).cloned()),
+            Err(_) => Err(Status::internal("BES capture registry lock was poisoned")),
+        },
+        None => match request_invocation_id(&first) {
             Ok(invocation_id) => match captures.lock() {
                 Ok(captures) => Ok(captures.get(invocation_id).cloned()),
                 Err(_) => Err(Status::internal("BES capture registry lock was poisoned")),
             },
             Err(error) => Err(error),
-        }
+        },
     };
     let state = match state_result {
         Ok(state) => state,
@@ -386,6 +401,23 @@ async fn ingest_stream(
         let _ = responses.send(Err(Status::internal(error.clone()))).await;
     }
     complete(&state, result);
+}
+
+fn capture_id_from_metadata(
+    metadata: &tonic::metadata::MetadataMap,
+) -> Result<Option<String>, Status> {
+    let Some(value) = metadata.get(CAPTURE_ID_HEADER) else {
+        return Ok(None);
+    };
+    let value = value
+        .to_str()
+        .map_err(|_| Status::invalid_argument("BES capture metadata was not valid ASCII"))?;
+    if value.is_empty() || value.len() > MAX_STREAM_ID_FIELD_BYTES {
+        return Err(Status::invalid_argument(
+            "BES capture metadata omitted a valid invocation id",
+        ));
+    }
+    Ok(Some(value.to_owned()))
 }
 
 async fn capture_stream(
@@ -947,6 +979,88 @@ mod tests {
             .await
             .expect("stop-and-wait client deadlocked")
             .unwrap();
+        let stats = capture.finish(Duration::from_secs(1)).await.unwrap();
+        assert_eq!(stats.event_count, 1);
+        sink.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn routes_a_stream_by_capture_metadata_when_the_client_owns_its_invocation_id() {
+        let server = BesServer::start().await.unwrap();
+        let capture_id = "019f6b1e-dbf1-7090-9290-aspect-capture";
+        let mut capture = server.register(capture_id).unwrap();
+        let mut events = capture.take_events().unwrap();
+        let sink = tokio::spawn(async move {
+            while let Some(event) = events.recv().await {
+                let finished = event.is_finished();
+                event.acknowledge(Ok(()));
+                if finished {
+                    break;
+                }
+            }
+        });
+        let stream_id = StreamId {
+            build_id: "aspect-build".to_owned(),
+            invocation_id: "aspect-generated-invocation-id".to_owned(),
+            component: 3,
+        };
+        let requests = vec![
+            stream_request(
+                stream_id.clone(),
+                1,
+                Event::BazelEvent(Box::new(Any {
+                    type_url: "type.googleapis.com/build_event_stream.BuildEvent".to_owned(),
+                    value: bazel_mcp_bep::proto::BuildEvent::default().encode_to_vec(),
+                })),
+            ),
+            stream_request(
+                stream_id,
+                2,
+                Event::ComponentStreamFinished(Box::new(BuildComponentStreamFinished {
+                    r#type: 1,
+                })),
+            ),
+        ];
+        let uri = server.endpoint().replacen("grpc://", "http://", 1);
+        let channel = Endpoint::from_shared(uri).unwrap().connect().await.unwrap();
+        let mut client = ClientGrpc::new(channel);
+        client.ready().await.unwrap();
+        let mut request = Request::new(tokio_stream::iter(requests));
+        request
+            .metadata_mut()
+            .insert(CAPTURE_ID_HEADER, capture_id.parse().unwrap());
+
+        let response = client
+            .streaming(
+                request,
+                PathAndQuery::from_static(BUILD_TOOL_STREAM_PATH),
+                BuffaCodec::<
+                    PublishBuildToolEventStreamResponseOwnedView,
+                    PublishBuildToolEventStreamRequest,
+                >::default(),
+            )
+            .await
+            .unwrap();
+        let mut acknowledgements = response.into_inner();
+        assert_eq!(
+            acknowledgements
+                .message()
+                .await
+                .unwrap()
+                .unwrap()
+                .sequence_number(),
+            1
+        );
+        assert_eq!(
+            acknowledgements
+                .message()
+                .await
+                .unwrap()
+                .unwrap()
+                .sequence_number(),
+            2
+        );
+
         let stats = capture.finish(Duration::from_secs(1)).await.unwrap();
         assert_eq!(stats.event_count, 1);
         sink.await.unwrap();

--- a/crates/bazel-mcp-policy/src/executable.rs
+++ b/crates/bazel-mcp-policy/src/executable.rs
@@ -21,6 +21,30 @@ pub fn resolve_bazel_executable(
     Err(PolicyError::ExecutableNotFound(workspace.to_owned()))
 }
 
+/// Resolve the Aspect CLI launcher used for configured Aspect commands.
+///
+/// Unlike Bazel discovery, Aspect does not use a workspace-local wrapper. An
+/// explicit path wins; otherwise the `aspect` executable is resolved from the
+/// server process's `PATH`.
+pub fn resolve_aspect_executable(configured: Option<&Path>) -> Result<PathBuf, PolicyError> {
+    if let Some(path) = configured {
+        return executable(path)
+            .ok_or_else(|| PolicyError::AspectExecutableNotFound(path.to_owned()));
+    }
+    let path = std::env::var_os("PATH");
+    let current_dir = std::env::current_dir()
+        .map_err(|_| PolicyError::AspectExecutableNotFound(PathBuf::from("aspect")))?;
+    resolve_aspect_on_path(path.as_deref(), &current_dir)
+}
+
+fn resolve_aspect_on_path(
+    path: Option<&std::ffi::OsStr>,
+    current_dir: &Path,
+) -> Result<PathBuf, PolicyError> {
+    which::which_in("aspect", path, current_dir)
+        .map_err(|_| PolicyError::AspectExecutableNotFound(PathBuf::from("aspect")))
+}
+
 fn executable(path: &Path) -> Option<PathBuf> {
     let metadata = path.metadata().ok()?;
     if !metadata.is_file() {
@@ -56,5 +80,33 @@ mod tests {
         assert_eq!(executable(&wrapper), None);
         fs::set_permissions(&wrapper, fs::Permissions::from_mode(0o700)).unwrap();
         assert_eq!(executable(&wrapper), Some(wrapper));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn resolves_an_explicit_aspect_executable() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let root = tempdir().unwrap();
+        let aspect = root.path().join("aspect");
+        fs::write(&aspect, "#!/bin/sh\n").unwrap();
+        fs::set_permissions(&aspect, fs::Permissions::from_mode(0o700)).unwrap();
+        assert_eq!(resolve_aspect_executable(Some(&aspect)).unwrap(), aspect);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn resolves_aspect_from_the_search_path_when_not_configured() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let root = tempdir().unwrap();
+        let aspect = root.path().join("aspect");
+        fs::write(&aspect, "#!/bin/sh\n").unwrap();
+        fs::set_permissions(&aspect, fs::Permissions::from_mode(0o700)).unwrap();
+
+        assert_eq!(
+            resolve_aspect_on_path(Some(root.path().as_os_str()), root.path()).unwrap(),
+            aspect
+        );
     }
 }

--- a/crates/bazel-mcp-policy/src/flags.rs
+++ b/crates/bazel-mcp-policy/src/flags.rs
@@ -61,6 +61,71 @@ pub fn validate_arguments(arguments: &[String]) -> Result<(), PolicyError> {
     Ok(())
 }
 
+/// Validate the wrapper-specific portion of an Aspect CLI task invocation.
+///
+/// Aspect deliberately exposes Bazel passthrough flags, so server-owned Bazel
+/// flags must also be protected when nested under `--bazel-flag`. The local BES
+/// backend and task identity are injected by the runner and cannot be supplied
+/// by the caller.
+pub fn validate_aspect_arguments(
+    command: &BazelCommand,
+    arguments: &[String],
+    allow_workspace_mutation: bool,
+) -> Result<(), PolicyError> {
+    for argument in arguments {
+        if ["--task:id", "--task:timing-summary"]
+            .iter()
+            .any(|flag| argument == flag || argument.starts_with(&format!("{flag}=")))
+        {
+            return Err(PolicyError::AspectReservedArgument(argument.to_owned()));
+        }
+        if argument == "--bazel-startup-flag" || argument.starts_with("--bazel-startup-flag=") {
+            return Err(PolicyError::AspectReservedArgument(
+                "--bazel-startup-flag (use startup_arguments instead)".to_owned(),
+            ));
+        }
+        if argument == "--bazel-flag" {
+            return Err(PolicyError::AspectReservedArgument(
+                "--bazel-flag requires the --bazel-flag=... form".to_owned(),
+            ));
+        }
+        if let Some(nested) = argument.strip_prefix("--bazel-flag=") {
+            if let Some(flag) = RESERVED_FLAGS
+                .iter()
+                .find(|flag| nested == **flag || nested.starts_with(&format!("{flag}=")))
+            {
+                return Err(PolicyError::ReservedFlag((*flag).to_owned()));
+            }
+            if ["--bes_backend", "--bes_upload_mode"]
+                .iter()
+                .any(|flag| nested == *flag || nested.starts_with(&format!("{flag}=")))
+            {
+                return Err(PolicyError::AspectReservedArgument(nested.to_owned()));
+            }
+        }
+        if argument == "--bes-header" {
+            return Err(PolicyError::AspectReservedArgument(
+                "--bes-header requires the --bes-header=... form".to_owned(),
+            ));
+        }
+        if let Some(header) = argument.strip_prefix("--bes-header=") {
+            let (name, _) = header.split_once('=').unwrap_or((header, ""));
+            if name.eq_ignore_ascii_case("x-bazel-mcp-invocation-id") {
+                return Err(PolicyError::AspectReservedArgument(
+                    "--bes-header=x-bazel-mcp-invocation-id=...".to_owned(),
+                ));
+            }
+        }
+        if command.as_str() == "lint"
+            && !allow_workspace_mutation
+            && (argument == "--fix" || argument.starts_with("--fix="))
+        {
+            return Err(PolicyError::AspectWorkspaceMutationDenied);
+        }
+    }
+    Ok(())
+}
+
 pub fn validate_query_arguments(
     command: &BazelCommand,
     arguments: &[String],
@@ -240,5 +305,44 @@ mod tests {
         assert!(
             validate_query_arguments(&BazelCommand::Build, &["--output=proto".to_owned()]).is_ok()
         );
+    }
+
+    #[test]
+    fn protects_aspect_identity_capture_and_lint_mutation() {
+        let lint = BazelCommand::Custom("lint".to_owned());
+        assert!(validate_aspect_arguments(&lint, &["//...".into()], false).is_ok());
+        assert!(matches!(
+            validate_aspect_arguments(&lint, &["--fix".into()], false),
+            Err(PolicyError::AspectWorkspaceMutationDenied)
+        ));
+        assert!(validate_aspect_arguments(&lint, &["--fix".into()], true).is_ok());
+        assert!(matches!(
+            validate_aspect_arguments(
+                &lint,
+                &["--bazel-flag=--invocation_id=caller".into()],
+                false,
+            ),
+            Err(PolicyError::ReservedFlag(_))
+        ));
+        assert!(matches!(
+            validate_aspect_arguments(&lint, &["--task:id=caller".into()], false),
+            Err(PolicyError::AspectReservedArgument(_))
+        ));
+        assert!(matches!(
+            validate_aspect_arguments(
+                &lint,
+                &["--bazel-startup-flag=--output_base=/tmp/other".into()],
+                false,
+            ),
+            Err(PolicyError::AspectReservedArgument(_))
+        ));
+        assert!(matches!(
+            validate_aspect_arguments(
+                &lint,
+                &["--bes-header=x-bazel-mcp-invocation-id=other".into()],
+                false,
+            ),
+            Err(PolicyError::AspectReservedArgument(_))
+        ));
     }
 }

--- a/crates/bazel-mcp-policy/src/lib.rs
+++ b/crates/bazel-mcp-policy/src/lib.rs
@@ -11,9 +11,10 @@ mod workspace;
 pub use command::validate_command;
 pub use config::{PolicyConfig, RawPolicyConfig};
 pub use environment::filtered_environment;
-pub use executable::resolve_bazel_executable;
+pub use executable::{resolve_aspect_executable, resolve_bazel_executable};
 pub use flags::{
-    INTERNAL_BEP_FLAG, effective_output_base, validate_arguments, validate_query_arguments,
+    INTERNAL_BEP_FLAG, effective_output_base, validate_arguments, validate_aspect_arguments,
+    validate_query_arguments,
 };
 pub use redaction::Redactor;
 pub use workspace::validate_workspace;
@@ -52,6 +53,12 @@ pub enum PolicyError {
     RepeatedOutputBase,
     #[error("could not resolve a Bazel executable for {0}")]
     ExecutableNotFound(PathBuf),
+    #[error("could not resolve the Aspect CLI executable: {0}")]
+    AspectExecutableNotFound(PathBuf),
+    #[error("Aspect command argument overrides a server-owned setting: {0}")]
+    AspectReservedArgument(String),
+    #[error("Aspect lint --fix is disabled; set aspect.allow_workspace_mutation = true to opt in")]
+    AspectWorkspaceMutationDenied,
     #[error("invalid redaction expression {pattern:?}: {source}")]
     InvalidRedaction {
         pattern: String,

--- a/crates/bazel-mcp-runner/src/driver.rs
+++ b/crates/bazel-mcp-runner/src/driver.rs
@@ -1,0 +1,147 @@
+use std::{collections::BTreeSet, path::PathBuf};
+
+use bazel_mcp_types::{BazelCommand, CommandClass};
+use serde::{Deserialize, Serialize};
+
+/// Serializable Aspect CLI settings owned by the runner.
+#[derive(Clone, Debug, Default, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(default, deny_unknown_fields)]
+pub struct RawAspectConfig {
+    pub executable: Option<PathBuf>,
+    pub commands: BTreeSet<String>,
+    pub allow_workspace_mutation: bool,
+}
+
+/// Optional Aspect CLI command routing.
+///
+/// Commands not listed here continue to use the direct Bazel driver. Keeping
+/// routing separate from `allowed_commands` preserves policy as an independent
+/// authorization decision.
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub struct AspectConfig {
+    pub executable: Option<PathBuf>,
+    pub commands: BTreeSet<String>,
+    pub allow_workspace_mutation: bool,
+}
+
+impl From<RawAspectConfig> for AspectConfig {
+    fn from(raw: RawAspectConfig) -> Self {
+        Self {
+            executable: raw.executable,
+            commands: raw.commands,
+            allow_workspace_mutation: raw.allow_workspace_mutation,
+        }
+    }
+}
+
+impl From<AspectConfig> for RawAspectConfig {
+    fn from(config: AspectConfig) -> Self {
+        Self {
+            executable: config.executable,
+            commands: config.commands,
+            allow_workspace_mutation: config.allow_workspace_mutation,
+        }
+    }
+}
+
+impl AspectConfig {
+    #[must_use]
+    pub fn enabled(&self) -> bool {
+        !self.commands.is_empty()
+    }
+
+    #[must_use]
+    pub fn routes(&self, command: &BazelCommand) -> bool {
+        self.commands.contains(command.as_str())
+    }
+
+    #[must_use]
+    pub(crate) fn has_invalid_command(&self) -> bool {
+        self.commands.iter().any(|command| {
+            command.is_empty()
+                || command.starts_with('-')
+                || command.chars().any(char::is_whitespace)
+        })
+    }
+}
+
+#[derive(Clone, Debug)]
+pub(crate) enum ExecutionDriver {
+    Bazel {
+        executable: PathBuf,
+    },
+    Aspect {
+        executable: PathBuf,
+        bazel_executable: PathBuf,
+    },
+}
+
+impl ExecutionDriver {
+    #[must_use]
+    pub(crate) const fn is_aspect(&self) -> bool {
+        matches!(self, Self::Aspect { .. })
+    }
+
+    #[must_use]
+    pub(crate) fn executable(&self) -> &std::path::Path {
+        match self {
+            Self::Bazel { executable } | Self::Aspect { executable, .. } => executable,
+        }
+    }
+
+    #[must_use]
+    pub(crate) fn command_class(&self, command: &BazelCommand) -> CommandClass {
+        if self.is_aspect() && matches!(command.as_str(), "build" | "test" | "lint") {
+            CommandClass::BuildLike
+        } else {
+            command.class()
+        }
+    }
+
+    #[must_use]
+    pub(crate) fn bazel_executable(&self) -> &std::path::Path {
+        match self {
+            Self::Bazel { executable }
+            | Self::Aspect {
+                bazel_executable: executable,
+                ..
+            } => executable,
+        }
+    }
+
+    #[must_use]
+    pub(crate) const fn display_name(&self) -> &'static str {
+        match self {
+            Self::Bazel { .. } => "Bazel",
+            Self::Aspect { .. } => "Aspect CLI",
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn aspect_lint_is_build_like_without_reclassifying_direct_custom_commands() {
+        let lint = BazelCommand::Custom("lint".to_owned());
+        let direct = ExecutionDriver::Bazel {
+            executable: "bazel".into(),
+        };
+        let aspect = ExecutionDriver::Aspect {
+            executable: "aspect".into(),
+            bazel_executable: "bazel".into(),
+        };
+        assert_eq!(direct.command_class(&lint), CommandClass::Unknown);
+        assert_eq!(aspect.command_class(&lint), CommandClass::BuildLike);
+    }
+
+    #[test]
+    fn aspect_routes_must_be_command_names_not_wrapper_arguments() {
+        let mut config = AspectConfig::default();
+        config.commands.insert("--help".to_owned());
+        assert!(config.has_invalid_command());
+        config.commands = ["lint".to_owned()].into();
+        assert!(!config.has_invalid_command());
+    }
+}

--- a/crates/bazel-mcp-runner/src/execution.rs
+++ b/crates/bazel-mcp-runner/src/execution.rs
@@ -12,6 +12,7 @@ use std::{
 use std::io;
 
 use bazel_mcp_bep::StreamOutcome;
+use bazel_mcp_bes::CAPTURE_ID_HEADER;
 use bazel_mcp_policy::filtered_environment;
 use bazel_mcp_reducer::{
     BepAccumulator, Budget, REDUCER_API_VERSION, ReducerContext, StreamReductionOutput,
@@ -32,6 +33,7 @@ use tokio_util::sync::CancellationToken;
 use crate::{
     cancel::{ProcessGroupGuard, terminate_child},
     capture,
+    driver::ExecutionDriver,
     inspection::should_persist_failure_evidence,
     output_base_lock::{NativeOutputBaseWaitObserver, OutputBaseWaitStatus},
     service::{
@@ -50,7 +52,7 @@ use crate::service::RunnerConfig;
 struct ExecutionPlan {
     request: InvocationRequest,
     paths: InvocationPaths,
-    executable: PathBuf,
+    driver: ExecutionDriver,
     cancellation: CancellationToken,
     explicit_output_base: Option<PathBuf>,
     output_base_wait: Arc<OutputBaseWaitStatus>,
@@ -127,7 +129,7 @@ impl ExecutionPlan {
         service: &InvocationService,
         queued: &InvocationRecord,
         paths: &InvocationPaths,
-        executable: &Path,
+        driver: &ExecutionDriver,
         cancellation: CancellationToken,
         explicit_output_base: Option<&Path>,
         output_base_wait: Arc<OutputBaseWaitStatus>,
@@ -150,7 +152,7 @@ impl ExecutionPlan {
         Self {
             request: queued.request.clone(),
             paths: paths.clone(),
-            executable: executable.to_owned(),
+            driver: driver.clone(),
             cancellation,
             explicit_output_base: explicit_output_base.map(Path::to_owned),
             output_base_wait,
@@ -253,7 +255,7 @@ impl InvocationService {
         &self,
         queued: &InvocationRecord,
         paths: &InvocationPaths,
-        executable: &Path,
+        driver: &ExecutionDriver,
         cancellation: CancellationToken,
         explicit_output_base: Option<&Path>,
         output_base_wait: Arc<OutputBaseWaitStatus>,
@@ -262,7 +264,7 @@ impl InvocationService {
             self,
             queued,
             paths,
-            executable,
+            driver,
             cancellation,
             explicit_output_base,
             output_base_wait,
@@ -302,7 +304,13 @@ impl InvocationService {
     async fn start_execution(&self, plan: ExecutionPlan) -> Result<StartExecution, RunnerError> {
         let queued = &plan;
         let paths = &plan.paths;
-        let executable = plan.executable.as_path();
+        let driver = plan.driver.clone();
+        let command_class = driver.command_class(&queued.request.command);
+        let bep_transport = if driver.is_aspect() {
+            BepTransport::Bes
+        } else {
+            self.config.bep_transport
+        };
         let cancellation = plan.cancellation.clone();
         let explicit_output_base = plan.explicit_output_base.as_deref();
         let output_base_wait = plan.output_base_wait.clone();
@@ -342,12 +350,13 @@ impl InvocationService {
         )
         .await;
         #[cfg(unix)]
-        let mut prepared_fifo = if queued.request.command.class() == CommandClass::BuildLike
-            && self.config.bep_transport == BepTransport::Fifo
+        let mut prepared_fifo = if command_class == CommandClass::BuildLike
+            && !driver.is_aspect()
+            && bep_transport == BepTransport::Fifo
         {
             match capture::PreparedFifoBepCapture::prepare(&paths.bep) {
                 Ok(prepared) => match probe_bazel_server_pid(
-                    executable,
+                    driver.bazel_executable(),
                     &queued.request.workspace,
                     &queued.request.startup_arguments,
                     &self.config,
@@ -378,8 +387,9 @@ impl InvocationService {
             None
         };
         #[cfg(not(unix))]
-        if queued.request.command.class() == CommandClass::BuildLike
-            && self.config.bep_transport == BepTransport::Fifo
+        if command_class == CommandClass::BuildLike
+            && !driver.is_aspect()
+            && bep_transport == BepTransport::Fifo
         {
             tracing::debug!(
                 invocation_id = %queued.request.id,
@@ -392,7 +402,9 @@ impl InvocationService {
             )));
         }
         let extension_limits = plan.extension_limits;
-        let bes_bep = if queued.request.command.class() == CommandClass::BuildLike {
+        let bes_bep = if command_class == CommandClass::BuildLike
+            && bep_transport == BepTransport::Bes
+        {
             match &self.bes {
                 Some(server) => Some(capture::LiveBepCapture::Bes(capture::BesBepCapture::start(
                     server.register(queued.request.id.to_string())?,
@@ -404,69 +416,130 @@ impl InvocationService {
         } else {
             None
         };
-        let mut command = Command::new(executable);
+        let mut command = Command::new(driver.executable());
         command
             .current_dir(&queued.request.workspace)
             .env_clear()
             .envs(filtered_environment(&self.config.policy));
-        if let Some(output_user_root) = &self.config.output_user_root {
-            command
-                .arg(format!("--output_user_root={}", output_user_root.display()))
-                .arg(format!(
-                    "--max_idle_secs={}",
-                    self.config.isolated_bazel_server_idle_timeout.as_secs()
-                ));
-        }
-        command
-            .args(&queued.request.startup_arguments)
-            .arg(queued.request.command.as_str());
-        if queued.request.command.class() == CommandClass::BuildLike {
-            command.arg(format!("--invocation_id={}", queued.request.id));
-            match self.config.bep_transport {
-                BepTransport::Tail => {
+        match &driver {
+            ExecutionDriver::Bazel { .. } => {
+                if let Some(output_user_root) = &self.config.output_user_root {
                     command
-                        .arg(format!("--build_event_binary_file={}", paths.bep.display()))
-                        .arg("--build_event_binary_file_path_conversion=false");
+                        .arg(format!("--output_user_root={}", output_user_root.display()))
+                        .arg(format!(
+                            "--max_idle_secs={}",
+                            self.config.isolated_bazel_server_idle_timeout.as_secs()
+                        ));
                 }
-                BepTransport::Fifo => {
-                    #[cfg(unix)]
-                    let output = prepared_fifo
-                        .as_ref()
-                        .map_or(paths.bep.as_path(), |(prepared, _)| prepared.path());
-                    #[cfg(not(unix))]
-                    let output = paths.bep.as_path();
+                command
+                    .args(&queued.request.startup_arguments)
+                    .arg(queued.request.command.as_str());
+                if command_class == CommandClass::BuildLike {
+                    command.arg(format!("--invocation_id={}", queued.request.id));
+                    match bep_transport {
+                        BepTransport::Tail => {
+                            command
+                                .arg(format!("--build_event_binary_file={}", paths.bep.display()))
+                                .arg("--build_event_binary_file_path_conversion=false");
+                        }
+                        BepTransport::Fifo => {
+                            #[cfg(unix)]
+                            let output = prepared_fifo
+                                .as_ref()
+                                .map_or(paths.bep.as_path(), |(prepared, _)| prepared.path());
+                            #[cfg(not(unix))]
+                            let output = paths.bep.as_path();
+                            command
+                                .arg(format!("--build_event_binary_file={}", output.display()))
+                                .arg("--build_event_binary_file_path_conversion=false");
+                        }
+                        BepTransport::Bes => {
+                            let endpoint = self
+                                .bes
+                                .as_ref()
+                                .ok_or(RunnerError::InvalidConfiguration(
+                                    "BES transport was not initialized",
+                                ))?
+                                .endpoint();
+                            command
+                                .arg(format!("--bes_backend={endpoint}"))
+                                .arg("--bes_upload_mode=wait_for_upload_complete");
+                        }
+                    }
+                    command.args([
+                        "--tool_tag=bazel-mcp",
+                        "--color=no",
+                        "--curses=no",
+                        "--show_progress=false",
+                        "--show_result=0",
+                    ]);
+                    if matches!(
+                        queued.request.command,
+                        BazelCommand::Test | BazelCommand::Coverage
+                    ) {
+                        command.args(["--test_output=errors", "--test_summary=none"]);
+                    }
+                }
+                command.args(&queued.request.arguments);
+            }
+            ExecutionDriver::Aspect {
+                bazel_executable, ..
+            } => {
+                command
+                    .env("BAZEL_REAL", bazel_executable)
+                    .arg(format!("--task:id={}", queued.request.id))
+                    .arg("--task:timing-summary=none")
+                    .arg(queued.request.command.as_str());
+                if let Some(output_user_root) = &self.config.output_user_root {
                     command
-                        .arg(format!("--build_event_binary_file={}", output.display()))
-                        .arg("--build_event_binary_file_path_conversion=false");
+                        .arg(format!(
+                            "--bazel-startup-flag=--output_user_root={}",
+                            output_user_root.display()
+                        ))
+                        .arg(format!(
+                            "--bazel-startup-flag=--max_idle_secs={}",
+                            self.config.isolated_bazel_server_idle_timeout.as_secs()
+                        ));
                 }
-                BepTransport::Bes => {
+                for argument in &queued.request.startup_arguments {
+                    command.arg(format!("--bazel-startup-flag={argument}"));
+                }
+                if command_class == CommandClass::BuildLike {
+                    for argument in [
+                        format!("--invocation_id={}", queued.request.id),
+                        "--tool_tag=bazel-mcp".to_owned(),
+                        "--color=no".to_owned(),
+                        "--curses=no".to_owned(),
+                        "--show_progress=false".to_owned(),
+                        "--show_result=0".to_owned(),
+                    ] {
+                        command.arg(format!("--bazel-flag={argument}"));
+                    }
+                    if matches!(
+                        queued.request.command,
+                        BazelCommand::Test | BazelCommand::Coverage
+                    ) {
+                        command
+                            .arg("--bazel-flag=--test_output=errors")
+                            .arg("--bazel-flag=--test_summary=none");
+                    }
                     let endpoint = self
                         .bes
                         .as_ref()
                         .ok_or(RunnerError::InvalidConfiguration(
-                            "BES transport was not initialized",
+                            "Aspect capture BES was not initialized",
                         ))?
                         .endpoint();
                     command
-                        .arg(format!("--bes_backend={endpoint}"))
-                        .arg("--bes_upload_mode=wait_for_upload_complete");
+                        .arg(format!("--bes-backend={endpoint}"))
+                        .arg(format!(
+                            "--bes-header={CAPTURE_ID_HEADER}={}",
+                            queued.request.id
+                        ));
                 }
-            }
-            command.args([
-                "--tool_tag=bazel-mcp",
-                "--color=no",
-                "--curses=no",
-                "--show_progress=false",
-                "--show_result=0",
-            ]);
-            if matches!(
-                queued.request.command,
-                BazelCommand::Test | BazelCommand::Coverage
-            ) {
-                command.args(["--test_output=errors", "--test_summary=none"]);
+                command.args(&queued.request.arguments);
             }
         }
-        command.args(&queued.request.arguments);
         command.stdout(stdout).stderr(stderr).kill_on_drop(true);
         #[cfg(unix)]
         {
@@ -480,7 +553,7 @@ impl InvocationService {
                 let message = self.redactor.redact_bounded(&error.to_string(), 1_000);
                 let summary = InvocationSummary {
                     success: false,
-                    headline: format!("Could not start Bazel: {message}"),
+                    headline: format!("Could not start {}: {message}", driver.display_name()),
                     ..Default::default()
                 };
                 return Ok(StartExecution::Terminal(Box::new(TerminalCommit::failure(
@@ -537,25 +610,25 @@ impl InvocationService {
         }
         #[cfg(unix)]
         let incremental_bep = fifo_bep.or(bes_bep).or_else(|| {
-            (queued.request.command.class() == CommandClass::BuildLike
-                && self.config.bep_transport != BepTransport::Bes)
-                .then(|| {
+            (command_class == CommandClass::BuildLike && bep_transport != BepTransport::Bes).then(
+                || {
                     capture::LiveBepCapture::Tail(capture::IncrementalBepCapture::start(
                         paths.bep.clone(),
                         extension_limits,
                     ))
-                })
+                },
+            )
         });
         #[cfg(not(unix))]
         let incremental_bep = bes_bep.or_else(|| {
-            (queued.request.command.class() == CommandClass::BuildLike
-                && self.config.bep_transport != BepTransport::Bes)
-                .then(|| {
+            (command_class == CommandClass::BuildLike && bep_transport != BepTransport::Bes).then(
+                || {
                     capture::LiveBepCapture::Tail(capture::IncrementalBepCapture::start(
                         paths.bep.clone(),
                         extension_limits,
                     ))
-                })
+                },
+            )
         });
         Ok(StartExecution::Running(Box::new(RunningInvocation {
             plan,
@@ -622,6 +695,7 @@ impl InvocationService {
     ) -> Result<CapturedEvidence, RunnerError> {
         let queued = &exited.plan;
         let paths = &exited.plan.paths;
+        let command_class = queued.driver.command_class(&queued.request.command);
         let status = &exited.status;
         let reduction_started = Instant::now();
         let incremental_reduction = match exited.live_bep.take() {
@@ -639,28 +713,27 @@ impl InvocationService {
             }
             None => None,
         };
-        let (query_row_count, query_sample) =
-            if queued.request.command.class() == CommandClass::Query {
-                let query_row_count = self.store.count_query_rows(queued.request.id).await?;
-                let redactor = self.redactor.clone();
-                let page = self
-                    .store
-                    .page_query_rows_mapped_into(
-                        queued.request.id,
-                        None,
-                        PageRequest {
-                            scan_limit: 3,
-                            ..PageRequest::new(None, 3)
-                        },
-                        move |value, output| {
-                            redactor.redact_bounded_into(value, 4 * 1024, output);
-                        },
-                    )
-                    .await?;
-                (query_row_count, page.items)
-            } else {
-                (0, Vec::new())
-            };
+        let (query_row_count, query_sample) = if command_class == CommandClass::Query {
+            let query_row_count = self.store.count_query_rows(queued.request.id).await?;
+            let redactor = self.redactor.clone();
+            let page = self
+                .store
+                .page_query_rows_mapped_into(
+                    queued.request.id,
+                    None,
+                    PageRequest {
+                        scan_limit: 3,
+                        ..PageRequest::new(None, 3)
+                    },
+                    move |value, output| {
+                        redactor.redact_bounded_into(value, 4 * 1024, output);
+                    },
+                )
+                .await?;
+            (query_row_count, page.items)
+        } else {
+            (0, Vec::new())
+        };
         let (bep, bep_outcome) = match incremental_reduction {
             Some(reduction) => (reduction.accumulator, reduction.outcome),
             None => capture::reduce_bep(paths.bep.clone(), exited.plan.extension_limits).await?,
@@ -718,6 +791,7 @@ impl InvocationService {
         } = captured;
         let queued = &exited.plan;
         let paths = &exited.plan.paths;
+        let command_class = queued.driver.command_class(&queued.request.command);
         let exit_code = exited.status.as_ref().and_then(ExitStatus::code);
         let bazel_wall_ms = exited.bazel_wall_ms;
         let reduced = catch_unwind(AssertUnwindSafe(|| {
@@ -768,13 +842,13 @@ impl InvocationService {
             artifact.name = self.redactor.redact_bounded(&artifact.name, 1_000);
             artifact.uri = self.redactor.redact_bounded(&artifact.uri, 1_000);
         }
-        if queued.request.command.class() == CommandClass::Query && exit_code == Some(0) {
+        if command_class == CommandClass::Query && exit_code == Some(0) {
             summary.headline = format!("Bazel query returned {query_row_count} rows");
             summary.inspect_hint = (query_row_count > 0).then_some(InspectHint::QueryResults);
             summary.query_result_count = Some(query_row_count);
             summary.query_sample = query_sample;
         } else if matches!(
-            queued.request.command.class(),
+            command_class,
             CommandClass::Informational | CommandClass::Unknown
         ) && exit_code == Some(0)
         {
@@ -846,6 +920,27 @@ impl InvocationService {
         finalize_with_custom_notices(&mut summary, custom_notices);
         if let Some(headline) = custom_headline {
             summary.headline = headline;
+        } else if queued.driver.is_aspect() {
+            if !summary.success
+                && let Some(first) = summary.diagnostics.first()
+            {
+                summary.headline = format!(
+                    "Aspect {} failed: {}",
+                    queued.request.command, first.message
+                );
+            } else if summary.success && command_class == CommandClass::BuildLike {
+                summary.headline = format!(
+                    "Aspect {} completed successfully in {bazel_wall_ms} ms",
+                    queued.request.command
+                );
+            } else if !summary.success
+                && (summary.headline.is_empty() || summary.headline.starts_with("Bazel "))
+            {
+                summary.headline = format!(
+                    "Aspect {} failed with exit code {exit_code:?}",
+                    queued.request.command
+                );
+            }
         }
         if !summary.success && summary.inspect_hint.is_none() {
             let hint = if summary

--- a/crates/bazel-mcp-runner/src/lib.rs
+++ b/crates/bazel-mcp-runner/src/lib.rs
@@ -3,6 +3,7 @@
 mod artifacts;
 mod cancel;
 mod capture;
+mod driver;
 mod evidence;
 mod execution;
 mod inspection;
@@ -14,6 +15,7 @@ mod version;
 
 pub use bazel_mcp_reducer::{RawStarlarkConfig, StarlarkLimits, StarlarkReducerConfig};
 pub use bazel_mcp_types::{InspectResult, InspectView};
+pub use driver::{AspectConfig, RawAspectConfig};
 pub use inspection::InspectRequest;
 #[doc(hidden)]
 pub use service::RunnerTestSupport;

--- a/crates/bazel-mcp-runner/src/service.rs
+++ b/crates/bazel-mcp-runner/src/service.rs
@@ -9,8 +9,8 @@ use std::{
 use bazel_mcp_bes::{BesError, BesServer};
 use bazel_mcp_policy::{
     PolicyConfig, PolicyError, Redactor, effective_output_base, filtered_environment,
-    resolve_bazel_executable, validate_arguments, validate_command, validate_query_arguments,
-    validate_workspace,
+    resolve_aspect_executable, resolve_bazel_executable, validate_arguments,
+    validate_aspect_arguments, validate_command, validate_query_arguments, validate_workspace,
 };
 use bazel_mcp_reducer::{
     RawStarlarkConfig, ReducerPipeline, StarlarkReducerConfig, load_starlark_reducers,
@@ -27,6 +27,7 @@ use tokio::sync::{Mutex, OnceCell, OwnedSemaphorePermit};
 use tokio_util::sync::CancellationToken;
 
 use crate::{
+    driver::{AspectConfig, ExecutionDriver, RawAspectConfig},
     execution::cancelled_summary,
     output_base_lock::{
         OutputBaseLockAcquisition, OutputBaseWaitStatus, acquire as acquire_output_base_lock,
@@ -80,6 +81,7 @@ pub struct RawRunnerConfig {
     pub version_check_timeout_seconds: u64,
     pub maximum_pending_invocations: usize,
     pub bep_transport: BepTransport,
+    pub aspect: RawAspectConfig,
     pub starlark: RawStarlarkConfig,
 }
 
@@ -99,6 +101,7 @@ impl Default for RawRunnerConfig {
             version_check_timeout_seconds: config.version_check_timeout.as_secs(),
             maximum_pending_invocations: config.maximum_pending_invocations,
             bep_transport: config.bep_transport,
+            aspect: config.aspect.into(),
             starlark: RawStarlarkConfig::default(),
         }
     }
@@ -120,6 +123,7 @@ pub struct RunnerConfig {
     pub maximum_pending_invocations: usize,
     pub output_base_lock_root: PathBuf,
     pub bep_transport: BepTransport,
+    pub aspect: AspectConfig,
     pub starlark_reducers: StarlarkReducerConfig,
 }
 
@@ -140,6 +144,7 @@ impl Default for RunnerConfig {
             maximum_pending_invocations: 256,
             output_base_lock_root: default_output_base_lock_root(),
             bep_transport: BepTransport::Tail,
+            aspect: AspectConfig::default(),
             starlark_reducers: StarlarkReducerConfig::default(),
         }
     }
@@ -187,6 +192,19 @@ impl RunnerConfig {
                 "output-base lock root must not be empty",
             ));
         }
+        if self.aspect.has_invalid_command() {
+            return Err(RunnerError::InvalidConfiguration(
+                "Aspect routes must be non-empty command names without whitespace or a leading dash",
+            ));
+        }
+        if self.aspect.commands.iter().any(|command| {
+            !self.policy.allowed_commands.contains(command)
+                || self.policy.denied_commands.contains(command)
+        }) {
+            return Err(RunnerError::InvalidConfiguration(
+                "every Aspect route must also be allowed by command policy",
+            ));
+        }
         if !self.allow_unsupported_bazel_versions && self.supported_bazel_major_versions.is_empty()
         {
             return Err(RunnerError::InvalidConfiguration(
@@ -201,6 +219,7 @@ impl TryFrom<(RawRunnerConfig, PolicyConfig)> for RunnerConfig {
     type Error = RunnerError;
 
     fn try_from((raw, policy): (RawRunnerConfig, PolicyConfig)) -> Result<Self, Self::Error> {
+        let aspect = AspectConfig::from(raw.aspect);
         let starlark_reducers = StarlarkReducerConfig::try_from(raw.starlark)
             .map_err(|error| RunnerError::ReducerConfiguration(error.to_string()))?;
         let config = Self {
@@ -224,6 +243,7 @@ impl TryFrom<(RawRunnerConfig, PolicyConfig)> for RunnerConfig {
             maximum_pending_invocations: raw.maximum_pending_invocations,
             output_base_lock_root: default_output_base_lock_root(),
             bep_transport: raw.bep_transport,
+            aspect,
             starlark_reducers,
         };
         config.validate()?;
@@ -309,7 +329,7 @@ struct PreparedSubmission {
     lock_key: PathBuf,
     explicit_output_base: Option<PathBuf>,
     output_base_wait: Arc<OutputBaseWaitStatus>,
-    executable: PathBuf,
+    driver: ExecutionDriver,
     cancellation: CancellationToken,
     _pending_permit: OwnedSemaphorePermit,
     deferred: bool,
@@ -378,16 +398,16 @@ pub struct CancelResult {
 
 impl InvocationService {
     pub fn new(store: Store, config: RunnerConfig) -> Result<Self, RunnerError> {
-        if config.bep_transport == BepTransport::Bes {
+        if config.bep_transport == BepTransport::Bes || config.aspect.enabled() {
             return Err(RunnerError::InvalidConfiguration(
-                "BES transport requires asynchronous InvocationService::start",
+                "BES or Aspect capture requires asynchronous InvocationService::start",
             ));
         }
         Self::new_with_bes(store, config, None)
     }
 
     pub async fn start(store: Store, config: RunnerConfig) -> Result<Self, RunnerError> {
-        let bes = if config.bep_transport == BepTransport::Bes {
+        let bes = if config.bep_transport == BepTransport::Bes || config.aspect.enabled() {
             Some(BesServer::start().await?)
         } else {
             None
@@ -607,8 +627,18 @@ impl InvocationService {
         validate_command(&self.config.policy, &request.command)?;
         validate_arguments(&request.startup_arguments)?;
         validate_arguments(&request.arguments)?;
-        validate_query_arguments(&request.command, &request.arguments)?;
-        if self.config.bep_transport == BepTransport::Bes
+        let uses_aspect = self.config.aspect.routes(&request.command);
+        if uses_aspect {
+            validate_aspect_arguments(
+                &request.command,
+                &request.arguments,
+                self.config.aspect.allow_workspace_mutation,
+            )?;
+        } else {
+            validate_query_arguments(&request.command, &request.arguments)?;
+        }
+        if !uses_aspect
+            && self.config.bep_transport == BepTransport::Bes
             && request
                 .arguments
                 .iter()
@@ -616,7 +646,8 @@ impl InvocationService {
         {
             return Err(RunnerError::BesBackendConflict);
         }
-        if self.config.bep_transport == BepTransport::Bes
+        if !uses_aspect
+            && self.config.bep_transport == BepTransport::Bes
             && request
                 .arguments
                 .iter()
@@ -635,8 +666,19 @@ impl InvocationService {
         let lock_key = explicit_output_base
             .clone()
             .unwrap_or_else(|| workspace.clone());
-        let executable = resolve_bazel_executable(&workspace, &self.config.policy)?;
-        self.validate_bazel_version(&executable, &workspace).await?;
+        let bazel_executable = resolve_bazel_executable(&workspace, &self.config.policy)?;
+        self.validate_bazel_version(&bazel_executable, &workspace)
+            .await?;
+        let driver = if uses_aspect {
+            ExecutionDriver::Aspect {
+                executable: resolve_aspect_executable(self.config.aspect.executable.as_deref())?,
+                bazel_executable,
+            }
+        } else {
+            ExecutionDriver::Bazel {
+                executable: bazel_executable,
+            }
+        };
         if cancellation.is_cancelled() {
             return Err(RunnerError::CancelledBeforeAcceptance);
         }
@@ -677,7 +719,7 @@ impl InvocationService {
             lock_key,
             explicit_output_base,
             output_base_wait,
-            executable,
+            driver,
             cancellation,
             _pending_permit: pending_permit,
             deferred: deferred.is_some(),
@@ -694,7 +736,7 @@ impl InvocationService {
             lock_key,
             explicit_output_base,
             output_base_wait,
-            executable,
+            driver,
             cancellation,
             _pending_permit,
             deferred: _,
@@ -785,7 +827,7 @@ impl InvocationService {
                 .execute(
                     &queued,
                     &paths,
-                    &executable,
+                    &driver,
                     cancellation.clone(),
                     explicit_output_base.as_deref(),
                     output_base_wait,
@@ -1159,6 +1201,7 @@ mod tests {
             expected.supported_bazel_major_versions
         );
         assert_eq!(actual.bep_transport, expected.bep_transport);
+        assert_eq!(actual.aspect, expected.aspect);
         assert_eq!(actual.starlark_reducers, expected.starlark_reducers);
     }
 

--- a/crates/bazel-mcp-runner/tests/process.rs
+++ b/crates/bazel-mcp-runner/tests/process.rs
@@ -188,6 +188,100 @@ async fn configured_service(
     .unwrap()
 }
 
+#[tokio::test]
+async fn routes_configured_lint_through_aspect_and_keeps_query_on_bazel() {
+    let root = tempfile::tempdir().unwrap();
+    let workspace = root.path().join("workspace");
+    tokio::fs::create_dir(&workspace).await.unwrap();
+    let aspect = root.path().join("fake-aspect");
+    let aspect_log = root.path().join("aspect-args.log");
+    let bazel_log = root.path().join("bazel-args.log");
+    let aspect_script = format!(
+        "#!/bin/sh\nprintf '%s\\n' \"$BAZEL_REAL\" \"$@\" > '{}'\necho '🚨 src/app.ts:8:3 · eslint · no-console — unexpected console statement' >&2\nexit 1\n",
+        aspect_log.display()
+    );
+    tokio::fs::write(&aspect, aspect_script).await.unwrap();
+    tokio::fs::set_permissions(&aspect, std::fs::Permissions::from_mode(0o700))
+        .await
+        .unwrap();
+    let bazel_script = format!(
+        "#!/bin/sh\nif [ \"${{1:-}}\" = --version ]; then echo 'bazel 9.1.0'; exit 0; fi\nprintf '%s\\n' \"$@\" > '{}'\necho '//pkg:target'\n",
+        bazel_log.display()
+    );
+    let configured_bazel = root.path().join("configured-fake-bazel");
+    let output_user_root = root.path().join("output-user-root");
+    let service = configured_service(&root, &workspace, &bazel_script, |config| {
+        config.policy.allowed_commands.insert("lint".to_owned());
+        config.aspect.executable = Some(aspect.clone());
+        config.aspect.commands.insert("lint".to_owned());
+        config.output_user_root = Some(output_user_root.clone());
+    })
+    .await;
+
+    let mut lint_request = InvocationRequest::new(
+        workspace.clone(),
+        BazelCommand::Custom("lint".to_owned()),
+        vec!["//...".to_owned(), "--config=ci".to_owned()],
+    );
+    lint_request.startup_arguments = vec!["--host_jvm_args=-Xmx1g".to_owned()];
+    let lint_id = lint_request.id;
+    let lint = service.run(lint_request).await.unwrap();
+
+    assert_eq!(lint.state, InvocationState::Failed);
+    let summary = lint.summary.unwrap();
+    assert_eq!(summary.diagnostics.len(), 1);
+    assert_eq!(
+        summary.diagnostics[0].message,
+        "eslint [no-console]: unexpected console statement"
+    );
+    assert!(summary.headline.starts_with("Aspect lint failed:"));
+    let aspect_args = tokio::fs::read_to_string(&aspect_log).await.unwrap();
+    let aspect_args = aspect_args.lines().collect::<Vec<_>>();
+    assert_eq!(aspect_args[0], configured_bazel.to_string_lossy());
+    assert!(aspect_args.contains(&format!("--task:id={lint_id}").as_str()));
+    assert!(aspect_args.contains(&"--task:timing-summary=none"));
+    assert!(aspect_args.contains(&"lint"));
+    assert!(
+        aspect_args.contains(
+            &format!(
+                "--bazel-startup-flag=--output_user_root={}",
+                output_user_root.display()
+            )
+            .as_str()
+        )
+    );
+    assert!(aspect_args.contains(&"--bazel-startup-flag=--host_jvm_args=-Xmx1g"));
+    assert!(aspect_args.contains(&format!("--bazel-flag=--invocation_id={lint_id}").as_str()));
+    assert!(
+        aspect_args
+            .iter()
+            .any(|argument| argument.starts_with("--bes-backend=grpc://"))
+    );
+    assert!(
+        aspect_args.contains(&format!("--bes-header=x-bazel-mcp-invocation-id={lint_id}").as_str())
+    );
+    assert!(aspect_args.contains(&"//..."));
+    assert!(aspect_args.contains(&"--config=ci"));
+    assert!(
+        !aspect_args
+            .iter()
+            .any(|argument| argument.starts_with("--build_event_binary_file"))
+    );
+
+    let query = service
+        .run(InvocationRequest::new(
+            workspace,
+            BazelCommand::Query,
+            vec!["//...".to_owned()],
+        ))
+        .await
+        .unwrap();
+    assert_eq!(query.state, InvocationState::Succeeded);
+    let bazel_args = tokio::fs::read_to_string(bazel_log).await.unwrap();
+    assert!(bazel_args.lines().any(|argument| argument == "query"));
+    assert!(!bazel_args.lines().any(|argument| argument == "lint"));
+}
+
 async fn shared_executable_service(
     root: &TempDir,
     workspace: &Path,

--- a/crates/bazel-mcp-server/src/config.rs
+++ b/crates/bazel-mcp-server/src/config.rs
@@ -15,7 +15,7 @@ use serde::{Deserialize, Deserializer, Serialize, de::Error as _};
 use bazel_mcp_runner::BepTransport;
 
 pub use bazel_mcp_policy::RawPolicyConfig;
-pub use bazel_mcp_runner::{RawRunnerConfig, RawStarlarkConfig};
+pub use bazel_mcp_runner::{RawAspectConfig, RawRunnerConfig, RawStarlarkConfig};
 pub use bazel_mcp_store::{RawRetentionConfig, RetentionConfig};
 
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq, Serialize, Deserialize)]
@@ -237,6 +237,9 @@ impl ValidatedServerConfig {
         }
         if let Some(executable) = &raw.policy.bazel_executable {
             raw.policy.bazel_executable = Some(canonicalize_with_missing_tail(executable)?);
+        }
+        if let Some(executable) = &raw.runner.aspect.executable {
+            raw.runner.aspect.executable = Some(canonicalize_with_missing_tail(executable)?);
         }
         for root in &raw.policy.allowed_roots {
             if raw.cache_root.starts_with(root) {
@@ -664,6 +667,44 @@ mod tests {
     }
 
     #[test]
+    fn loads_aspect_routes_and_canonicalizes_an_explicit_executable() {
+        let root = tempdir().unwrap();
+        let workspace = root.path().join("workspace");
+        fs::create_dir(&workspace).unwrap();
+        let executable = root.path().join("bin/aspect");
+        let path = write_config(
+            root.path(),
+            &workspace,
+            &format!(
+                "allowed_commands = [\"build\", \"lint\"]\n[aspect]\nexecutable = {executable:?}\ncommands = [\"lint\"]\nallow_workspace_mutation = true\n"
+            ),
+        );
+
+        let config = ValidatedServerConfig::load(&cli(path)).unwrap();
+
+        assert_eq!(
+            config.runner.aspect.executable,
+            Some(canonicalize_with_missing_tail(&executable).unwrap())
+        );
+        assert_eq!(config.runner.aspect.commands, ["lint".to_owned()].into());
+        assert!(config.runner.aspect.allow_workspace_mutation);
+    }
+
+    #[test]
+    fn rejects_aspect_routes_not_allowed_by_command_policy() {
+        let root = tempdir().unwrap();
+        let workspace = root.path().join("workspace");
+        fs::create_dir(&workspace).unwrap();
+        let path = write_config(root.path(), &workspace, "[aspect]\ncommands = [\"lint\"]\n");
+
+        let error = ValidatedServerConfig::load(&cli(path)).unwrap_err();
+        assert!(
+            format!("{error:#}")
+                .contains("every Aspect route must also be allowed by command policy")
+        );
+    }
+
+    #[test]
     fn validates_task_lifecycle_settings_for_every_policy() {
         let root = tempdir().unwrap();
         let workspace = root.path().join("workspace");
@@ -699,7 +740,7 @@ mod tests {
     }
 
     #[test]
-    fn rejects_unknown_top_level_and_starlark_settings() {
+    fn rejects_unknown_top_level_starlark_and_aspect_settings() {
         let root = tempdir().unwrap();
         let workspace = root.path().join("workspace");
         fs::create_dir(&workspace).unwrap();
@@ -715,6 +756,10 @@ mod tests {
         );
         let error = ValidatedServerConfig::load(&cli(starlark)).unwrap_err();
         assert!(format!("{error:#}").contains("unknown field `max_tick_count`"));
+
+        let aspect = write_config(root.path(), &workspace, "[aspect]\ncommandz = [\"lint\"]\n");
+        let error = ValidatedServerConfig::load(&cli(aspect)).unwrap_err();
+        assert!(format!("{error:#}").contains("unknown field `commandz`"));
     }
 
     #[test]

--- a/crates/bazel-mcp-server/src/handler.rs
+++ b/crates/bazel-mcp-server/src/handler.rs
@@ -54,9 +54,9 @@ pub struct RunParams {
     /// Bazel startup arguments placed before the command.
     #[serde(default)]
     pub startup_args: Vec<String>,
-    /// Bazel command such as build, test, coverage, query, cquery, or aquery.
+    /// Bazel command or a configured Aspect command such as lint.
     pub command: String,
-    /// Arguments placed after the Bazel command.
+    /// Arguments placed after the selected command.
     #[serde(default)]
     pub args: Vec<String>,
     /// Optional timeout in seconds.
@@ -139,7 +139,7 @@ impl BazelMcpServer {
 impl BazelMcpServer {
     #[tool(
         name = "bazel.run",
-        description = "Execute one Bazel command silently and return a bounded actionable summary."
+        description = "Execute one allowed Bazel or configured Aspect command silently and return a bounded actionable summary."
     )]
     async fn bazel_run(
         &self,

--- a/crates/bazel-mcp-server/src/lib.rs
+++ b/crates/bazel-mcp-server/src/lib.rs
@@ -8,9 +8,9 @@ mod tasks;
 
 pub use bazel_mcp_runner::BepTransport;
 pub use config::{
-    Cli, McpConfig, McpExecutionPolicy, RawMcpConfig, RawPolicyConfig, RawRetentionConfig,
-    RawRunnerConfig, RawServerConfig, RawStarlarkConfig, ResultEncoding, RetentionConfig,
-    ValidatedServerConfig,
+    Cli, McpConfig, McpExecutionPolicy, RawAspectConfig, RawMcpConfig, RawPolicyConfig,
+    RawRetentionConfig, RawRunnerConfig, RawServerConfig, RawStarlarkConfig, ResultEncoding,
+    RetentionConfig, ValidatedServerConfig,
 };
 pub use handler::BazelMcpServer;
 

--- a/crates/diagnostic-reducer/src/diagnostics/aspect.rs
+++ b/crates/diagnostic-reducer/src/diagnostics/aspect.rs
@@ -1,0 +1,103 @@
+use crate::{Diagnostic, DiagnosticClass, Location, Severity};
+
+/// Parse the stable, one-line diagnostic format emitted by `aspect lint`.
+///
+/// Example: `🚨 src/app.ts:8:3 · eslint · no-console — unexpected console statement`
+#[must_use]
+pub(super) fn parse_diagnostic(line: &str) -> Option<Diagnostic> {
+    let line = line.trim();
+    let (severity, remainder) = if let Some(remainder) = line.strip_prefix("🚨 ") {
+        (Severity::Error, remainder)
+    } else if let Some(remainder) = line.strip_prefix("⚠️ ").or_else(|| line.strip_prefix("⚠ "))
+    {
+        (Severity::Warning, remainder)
+    } else {
+        let remainder = line
+            .strip_prefix("ℹ️ ")
+            .or_else(|| line.strip_prefix("ℹ "))?;
+        (Severity::Note, remainder)
+    };
+    let (fields, message) = remainder.split_once(" — ")?;
+    let mut fields = fields.split(" · ").map(str::trim);
+    let location = parse_location(fields.next()?)?;
+    let tool = fields.next().filter(|value| !value.is_empty());
+    let rule = fields.next().filter(|value| !value.is_empty());
+    let message = message.trim();
+    if message.is_empty() {
+        return None;
+    }
+    let message = match (tool, rule) {
+        (Some(tool), Some(rule)) => format!("{tool} [{rule}]: {message}"),
+        (Some(tool), None) => format!("{tool}: {message}"),
+        (None, Some(rule)) => format!("[{rule}]: {message}"),
+        (None, None) => message.to_owned(),
+    };
+    Some(Diagnostic {
+        severity,
+        class: DiagnosticClass::Compiler,
+        code: rule.map(str::to_owned),
+        message,
+        location: Some(location),
+        provenance: None,
+        repetition_count: 1,
+    })
+}
+
+fn parse_location(value: &str) -> Option<Location> {
+    let (prefix, final_number) = value.trim().rsplit_once(':')?;
+    let final_number = final_number.parse::<u32>().ok()?;
+    if let Some((path, line)) = prefix.rsplit_once(':')
+        && let Ok(line) = line.parse::<u32>()
+        && !path.is_empty()
+    {
+        return Some(Location {
+            path: path.to_owned(),
+            line: Some(line),
+            column: Some(final_number),
+        });
+    }
+    (!prefix.is_empty()).then(|| Location {
+        path: prefix.to_owned(),
+        line: Some(final_number),
+        column: None,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_aspect_lint_error_with_tool_rule_and_location() {
+        let diagnostic = parse_diagnostic(
+            "🚨 src/app.ts:8:3 · eslint · no-console — unexpected console statement",
+        )
+        .unwrap();
+
+        assert_eq!(diagnostic.severity, Severity::Error);
+        assert_eq!(diagnostic.code.as_deref(), Some("no-console"));
+        assert_eq!(
+            diagnostic.message,
+            "eslint [no-console]: unexpected console statement"
+        );
+        assert_eq!(
+            diagnostic.location,
+            Some(Location {
+                path: "src/app.ts".to_owned(),
+                line: Some(8),
+                column: Some(3),
+            })
+        );
+    }
+
+    #[test]
+    fn parses_warning_with_a_line_only_location_and_rejects_unmarked_text() {
+        let diagnostic =
+            parse_diagnostic("⚠️ scripts/check.sh:12 · shellcheck · SC2086 — quote this value")
+                .unwrap();
+
+        assert_eq!(diagnostic.severity, Severity::Warning);
+        assert_eq!(diagnostic.location.unwrap().column, None);
+        assert!(parse_diagnostic("scripts/check.sh:12: ordinary output").is_none());
+    }
+}

--- a/crates/diagnostic-reducer/src/diagnostics/mod.rs
+++ b/crates/diagnostic-reducer/src/diagnostics/mod.rs
@@ -1,4 +1,5 @@
 mod arbitration;
+mod aspect;
 mod common;
 mod cpp;
 mod go;
@@ -90,6 +91,11 @@ const TEXT_DIAGNOSTIC_REDUCERS: &[TextDiagnosticReducer] = &[
 ];
 
 const LINE_DIAGNOSTIC_REDUCERS: &[LineDiagnosticReducer] = &[
+    LineDiagnosticReducer {
+        name: "aspect-lint",
+        enabled: always,
+        parse: aspect::parse_diagnostic,
+    },
     LineDiagnosticReducer {
         name: "go-strict-dependency",
         enabled: strict_dependencies_only,
@@ -243,6 +249,7 @@ mod tests {
                 .map(|reducer| reducer.name)
                 .collect::<Vec<_>>(),
             [
+                "aspect-lint",
                 "go-strict-dependency",
                 "cpp",
                 "typescript",

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -22,8 +22,9 @@ The default path is used only when the file already exists. Command-line
 `--allow-root` values are added to roots read from the file, and `--cache-root`
 overrides the configured cache directory.
 
-Unknown top-level settings and unknown keys in the `[starlark]` table are
-rejected so misspelled controls cannot silently fall back to defaults.
+Unknown top-level settings and unknown keys in the `[aspect]` and `[starlark]`
+tables are rejected so misspelled controls cannot silently fall back to
+defaults.
 
 Start with the repository's [example configuration](../examples/config.toml):
 
@@ -68,6 +69,40 @@ Set an explicit executable to bypass discovery:
 ```toml
 bazel_executable = "/usr/local/bin/bazelisk"
 ```
+
+### Route commands through Aspect CLI
+
+Aspect support is disabled by default. To run `aspect lint` for a `lint`
+request, add the command to both the normal command allowlist and the Aspect
+route list:
+
+```toml
+allowed_commands = [
+  "aquery", "build", "coverage", "cquery", "help", "info", "lint", "mod",
+  "query", "test", "version",
+]
+
+[aspect]
+commands = ["lint"]
+# executable = "/opt/homebrew/bin/aspect"
+allow_workspace_mutation = false
+```
+
+When `aspect.executable` is omitted, the server resolves `aspect` from its
+`PATH`. The underlying Bazel executable still follows the normal discovery
+rules and is passed to Aspect through `BAZEL_REAL`; commands not listed in
+`aspect.commands` continue to invoke Bazel directly.
+
+For build-like Aspect commands (`build`, `test`, and `lint`), bazel-mcp starts
+its loopback BES even when `bep_transport = "tail"`. Aspect keeps ownership of
+its internal BEP stream and forwards a copy to the private local capture. Any
+additional Aspect `--bes-backend` argument remains available for a remote sink.
+Startup arguments use the ordinary `startup_args` request field; callers cannot
+inject Aspect's `--bazel-startup-flag`, task identity, or local capture header.
+
+`aspect lint --fix` is rejected unless `allow_workspace_mutation = true`.
+Configured Aspect tasks are operator-trusted code and may have other side
+effects that bazel-mcp cannot infer from their names.
 
 ### Pass environment variables
 
@@ -195,6 +230,9 @@ the native result and add a bounded note. See the
 | `cache_root` | Platform user cache under `bazel-mcp` | Shared directory for metadata, logs, and BEP evidence. Multiple server processes may use the same root concurrently. |
 | `bep_transport` | `tail` | BEP ingestion path: portable private binary file (`tail`), opt-in POSIX named pipe with file fallback (`fifo`), or loopback Build Event Service (`bes`). |
 | `bazel_executable` | unset | Explicit Bazel or Bazelisk executable. |
+| `aspect.commands` | `[]` | Commands routed through Aspect CLI. Each must also be present in `allowed_commands`. |
+| `aspect.executable` | unset | Explicit Aspect CLI executable. When unset and Aspect routing is enabled, resolves `aspect` from `PATH`. |
+| `aspect.allow_workspace_mutation` | `false` | Permit known mutation arguments such as `aspect lint --fix`; configured tasks themselves remain operator-trusted. |
 | `output_user_root` | unset | Isolated Bazel output user root managed by the server. |
 | `allowed_commands` | build, test, coverage, query commands, and selected informational commands | Commands eligible to run. |
 | `denied_commands` | `clean`, `fetch`, `mobile-install`, `run`, `shutdown`, `sync` | Commands rejected even if also present in `allowed_commands`. |

--- a/examples/config.toml
+++ b/examples/config.toml
@@ -32,6 +32,14 @@ maximum_pending_invocations = 256
 # Applied only when output_user_root isolates the server from the user's daemon.
 isolated_bazel_server_idle_seconds = 60
 
+# Aspect CLI routing is opt-in. A routed command must also appear in the
+# top-level allowed_commands list. When executable is omitted, bazel-mcp finds
+# `aspect` on PATH. For example, add "lint" to allowed_commands and commands.
+[aspect]
+commands = []
+# executable = "/opt/homebrew/bin/aspect"
+allow_workspace_mutation = false
+
 # Custom reducers are opt-in and are never loaded from a Bazel workspace
 # automatically. Relative paths are resolved from this configuration file.
 [starlark]

--- a/specs/001-product-requirements.md
+++ b/specs/001-product-requirements.md
@@ -183,7 +183,8 @@ separate `fetch_*`, `find_*`, or per-command tools for equivalent data.
 
 #### Purpose
 
-Execute one Bazel invocation and return its bounded result.
+Execute one Bazel invocation, or one explicitly configured Aspect CLI command,
+and return its bounded result.
 
 #### Input
 
@@ -206,7 +207,9 @@ Execute one Bazel invocation and return its bounded result.
 | `timeout_seconds` | No | Integer | Uses the server default when omitted; bounded by server policy. |
 
 The server MUST pass arguments directly to a child process. It MUST NOT join or
-evaluate them as shell text.
+evaluate them as shell text. Commands listed in the operator's Aspect route
+configuration invoke Aspect CLI; all other allowed commands invoke Bazel
+directly.
 
 #### Execution behavior
 
@@ -390,6 +393,13 @@ For each workspace, the server resolves the executable in this order:
 
 The caller cannot supply an arbitrary executable path through `bazel.run`.
 Resolution is recorded in invocation metadata.
+
+Aspect CLI routing is optional and command-specific. An explicit Aspect
+executable is validated when configured; otherwise `aspect` is resolved from
+the server process's `PATH`. The underlying Bazel executable still follows the
+resolution order above and is supplied to Aspect without changing the request
+schema. Routed build-like commands forward BEP to bazel-mcp's loopback BES so
+the Aspect-owned stream can retain its own invocation identity.
 
 ## 10. Command policy and adapters
 

--- a/specs/002-project-architecture.md
+++ b/specs/002-project-architecture.md
@@ -452,10 +452,14 @@ Responsibilities:
   cross-process advisory lock for every invocation, and enforce the global
   limit.
 - Generate UUIDv7 invocation IDs.
-- Assemble validated Bazel argv without a shell.
-- Spawn the wrapper/Bazel client in a process group.
+- Select the direct Bazel driver or the optional command-specific Aspect CLI
+  driver after policy validation.
+- Assemble validated Bazel or Aspect argv without a shell.
+- Spawn the selected client in a process group.
 - Capture stdout, stderr, and BEP without returning them to the caller.
-- Start and register the optional loopback BES transport before spawning Bazel.
+- Start and register the optional loopback BES transport before spawning Bazel,
+  and whenever Aspect routing is enabled so Aspect may forward its owned BEP
+  stream to private capture metadata.
 - Enforce timeout and graceful cancellation escalation.
 - Await async store operations directly; run CPU-heavy BEP/reducer work and
   blocking filesystem work via bounded `spawn_blocking` tasks.
@@ -472,6 +476,7 @@ crates/bazel-mcp-runner/
 ├── src/
 │   ├── cancel.rs
 │   ├── capture.rs
+│   ├── driver.rs
 │   ├── inspect.rs
 │   ├── lib.rs
 │   ├── process.rs
@@ -865,6 +870,7 @@ Configuration covers:
 - global concurrency and timeouts
 - response encoding and byte budgets
 - BEP transport (`tail` by default, or explicit loopback `bes`)
+- optional Aspect CLI executable, routed commands, and mutation opt-in
 - redaction rules
 - explicit Starlark reducer files and resource limits
 - logging destination and level

--- a/website/src/components/LandingPage.astro
+++ b/website/src/components/LandingPage.astro
@@ -16,8 +16,8 @@ const tools = [
     name: 'bazel.run',
     tag: 'EXECUTE',
     description:
-      'Run an allowed Bazel command and receive a bounded, root-cause-first result.',
-    detail: 'Build · test · coverage · query',
+      'Run an allowed Bazel or configured Aspect command and receive a bounded, root-cause-first result.',
+    detail: 'Build · test · lint · query',
   },
   {
     name: 'bazel.inspect',

--- a/website/src/content/docs/concepts/how-it-works.md
+++ b/website/src/content/docs/concepts/how-it-works.md
@@ -9,10 +9,11 @@ available as evidence**.
 ## The evidence lifecycle
 
 1. **The client submits structured arguments.** The server accepts a workspace,
-   an allowed Bazel command, and an argument array. It never constructs a shell
+   an allowed command and an argument array. It never constructs a shell
    command.
-2. **Bazel runs locally.** Existing workspace credentials, toolchains, remote
-   execution settings, and caches continue to apply.
+2. **Bazel or a configured Aspect command runs locally.** Existing workspace
+   credentials, toolchains, remote execution settings, and caches continue to
+   apply.
 3. **Evidence is captured privately.** Output and Build Event Protocol data are
    retained under the local invocation cache.
 4. **Deterministic reducers find the useful result.** Concrete root causes,
@@ -25,7 +26,7 @@ available as evidence**.
 agent request
      │
      ▼
-policy ──► local Bazel process ──► private evidence
+policy ──► local Bazel/Aspect process ──► private evidence
                                       │
                                       ▼
                                deterministic reducer

--- a/website/src/content/docs/tools/index.md
+++ b/website/src/content/docs/tools/index.md
@@ -8,7 +8,8 @@ when negotiated, use MCP protocol methods rather than additional tools.
 
 ## `bazel.run`
 
-Run an allowed Bazel command and receive a bounded result.
+Run an allowed Bazel command, or an operator-configured Aspect CLI command, and
+receive a bounded result.
 
 ```json
 {
@@ -20,8 +21,9 @@ Run an allowed Bazel command and receive a bounded result.
 
 Supported command classes include `build`, `test`, `coverage`, `query`,
 `cquery`, `aquery`, and selected informational commands. The exact policy is
-configurable. Request arguments remain an array and are never concatenated into
-a shell command.
+configurable. Operators can opt specific commands such as `lint` into Aspect
+CLI routing without adding another MCP tool. Request arguments remain an array
+and are never concatenated into a shell command.
 
 The result includes the invocation lifecycle state, command outcome, a bounded
 headline and diagnostics, and an `invocation_id` when evidence can be inspected.


### PR DESCRIPTION
## Summary

- add opt-in, command-specific Aspect CLI routing while leaving ordinary Bazel commands unchanged
- resolve an explicit Aspect executable when configured, or fall back to `aspect` on `PATH`
- pass the discovered Bazel executable through `BAZEL_REAL` and translate startup and Bazel flags without invoking a shell
- forward Aspect-owned BEP streams to the private loopback BES using capture metadata
- reduce `aspect lint` output into structured diagnostics and document the configuration

## Why

Some useful repository workflows, notably `aspect lint`, are Aspect CLI commands rather than Bazel commands. Treating Aspect as a global Bazel executable replacement would change query behavior, flag semantics, and BEP ownership. This adds an explicit per-command driver boundary instead, preserving the existing three-tool MCP surface and direct Bazel behavior for every command that is not routed.

## Configuration

```toml
allowed_commands = ["build", "test", "query", "lint"]

[aspect]
commands = ["lint"]
# executable = "/opt/homebrew/bin/aspect"
allow_workspace_mutation = false
```

When `aspect.executable` is omitted, the server resolves `aspect` from `PATH`. Routed commands must also be present in `allowed_commands`.

## Safety and compatibility

- caller arguments cannot override the Aspect task identity, private capture header, server-owned Bazel flags, or output-base coordination
- `aspect lint --fix` requires an explicit workspace-mutation opt-in
- direct Bazel queries and other non-routed commands retain their existing execution and capture behavior
- the MCP server still exposes exactly `bazel.run`, `bazel.inspect`, and `bazel.cancel`

## Validation

- `make test`
- `make check`
- `npm run check --prefix website`
- `npm run build --prefix website`
- `npm run check:links --prefix website`
- process-level routing test covering Aspect argv/environment/BES injection, lint reduction, and direct-Bazel query fallback

A live Aspect binary smoke test was not run because `aspect` is not installed on the development host; executable resolution and the complete process boundary are covered with deterministic tests.
