### PR TITLE
feat: add Bazel run support

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,11 +146,32 @@ The server exposes three tools:
 | `bazel.cancel` | Cancel a queued or running invocation. |
 
 `bazel.run` supports `build`, `test`, `coverage`, `query`, `cquery`, `aquery`,
-and selected informational commands. Operators may also route explicitly
-allowed commands such as `lint` through Aspect CLI. Successful results are
-limited to 2 KiB and unsuccessful results to 8 KiB. Follow-up `bazel.inspect`
-calls are also bounded and paginated, so an agent only retrieves the evidence
-it needs.
+selected informational commands, and an opt-in form of the Bazel `run`
+command. Operators may also route explicitly allowed commands such as `lint`
+through Aspect CLI. Successful results are limited to 2 KiB and unsuccessful
+results to 8 KiB. Follow-up `bazel.inspect` calls are also bounded and
+paginated, so an agent only retrieves the evidence it needs.
+
+The Bazel `run` command is denied by default. Once enabled by server policy, it
+accepts one explicit `target` and a separate sensitive `program_args` list:
+
+```json
+{
+  "workspace": "/src/project",
+  "command": "run",
+  "args": ["--config=dev"],
+  "target": "//cmd/example",
+  "program_args": ["--format=json", "input.txt"],
+  "timeout_seconds": 300
+}
+```
+
+The server owns the `--` boundary, omits run residue from BEP projections,
+stores program-argument placeholders instead of values, and connects stdin to
+null. This mode is intended for finite, non-interactive Unix programs. It does
+not provide a PTY or background-service lifecycle. Bazel `run` always uses the
+direct Bazel driver rather than Aspect CLI. See
+[configuration](docs/configuration.md#enable-bazel-run) for the opt-in policy.
 
 Failure results rank concrete root causes before aggregated action failures.
 Equivalent fanout failures are represented once with `target: null` and a

--- a/crates/bazel-mcp-benchmark/src/bin/storage-benchmark.rs
+++ b/crates/bazel-mcp-benchmark/src/bin/storage-benchmark.rs
@@ -650,6 +650,7 @@ async fn create_terminal_invocation(
                     headline: "benchmark invocation succeeded".to_owned(),
                     ..InvocationSummary::default()
                 },
+                run: None,
                 metrics: Default::default(),
                 canonical_arguments: Some(vec![
                     "build".into(),
@@ -807,6 +808,7 @@ async fn benchmark_terminal(query_count_and_finalize_ms: f64) -> anyhow::Result<
                     headline: "representative build succeeded".to_owned(),
                     ..InvocationSummary::default()
                 },
+                run: None,
                 metrics: Default::default(),
                 canonical_arguments: Some(vec!["build".into(), "//benchmark:build".into()]),
                 artifacts: Vec::new(),
@@ -843,6 +845,7 @@ async fn benchmark_terminal(query_count_and_finalize_ms: f64) -> anyhow::Result<
                     tests,
                     ..InvocationSummary::default()
                 },
+                run: None,
                 metrics: Default::default(),
                 canonical_arguments: Some(vec!["test".into(), "//benchmark:all".into()]),
                 artifacts: Vec::new(),

--- a/crates/bazel-mcp-bep/proto/build_event_stream_subset.proto
+++ b/crates/bazel-mcp-bep/proto/build_event_stream_subset.proto
@@ -169,6 +169,12 @@ message BuildFinished {
   bytes failure_detail = 6;
 }
 
+// Intentionally retain only the launch decision. Bazel's complete message also
+// carries the executable argv and environment, which can contain secrets.
+message ExecRequestConstructed {
+  bool should_exec = 5;
+}
+
 message BuildEvent {
   bytes id = 1;
   repeated bytes children = 2;
@@ -197,7 +203,7 @@ message BuildEvent {
     bytes build_metadata = 26;
     bytes convenience_symlinks_identified = 27;
     bytes target_summary = 28;
-    bytes exec_request = 29;
+    ExecRequestConstructed exec_request = 29;
     bytes test_progress = 30;
   }
 }

--- a/crates/bazel-mcp-policy/src/flags.rs
+++ b/crates/bazel-mcp-policy/src/flags.rs
@@ -24,12 +24,37 @@ const RESERVED_FLAGS: &[&str] = &[
     "--invocation_id",
     "--show_progress",
     "--show_result",
+    "--subcommands",
+    "--nosubcommands",
+    "-s",
+    "--run",
+    "--norun",
+    "--script_path",
+    "--omit_run_args",
+    "--noomit_run_args",
+    "--experimental_run_bep_event_include_residue",
+    "--noexperimental_run_bep_event_include_residue",
+    "--run_under",
+    "--run_env",
     "--test_output",
     "--test_summary",
     "--tool_tag",
 ];
 
 pub fn validate_arguments(arguments: &[String]) -> Result<(), PolicyError> {
+    validate_argument_shape(arguments)?;
+    for argument in arguments {
+        if let Some(flag) = RESERVED_FLAGS
+            .iter()
+            .find(|flag| argument == **flag || argument.starts_with(&format!("{flag}=")))
+        {
+            return Err(PolicyError::ReservedFlag((*flag).to_owned()));
+        }
+    }
+    Ok(())
+}
+
+fn validate_argument_shape(arguments: &[String]) -> Result<(), PolicyError> {
     if arguments.len() > MAX_ARGUMENT_COUNT {
         return Err(PolicyError::TooManyArguments {
             maximum_count: MAX_ARGUMENT_COUNT,
@@ -50,12 +75,6 @@ pub fn validate_arguments(arguments: &[String]) -> Result<(), PolicyError> {
             return Err(PolicyError::ArgumentsTooLarge {
                 maximum_bytes: MAX_ARGUMENTS_BYTES,
             });
-        }
-        if let Some(flag) = RESERVED_FLAGS
-            .iter()
-            .find(|flag| argument == **flag || argument.starts_with(&format!("{flag}=")))
-        {
-            return Err(PolicyError::ReservedFlag((*flag).to_owned()));
         }
     }
     Ok(())
@@ -124,6 +143,49 @@ pub fn validate_aspect_arguments(
         }
     }
     Ok(())
+}
+
+/// Validates the fields that are meaningful only for `bazel run`.
+///
+/// Bazel command options must use their flag or `--flag=value` form. This keeps
+/// an untrusted positional value from being interpreted as a second run target
+/// or silently crossing the program-argument boundary.
+pub fn validate_run_arguments(
+    command: &BazelCommand,
+    arguments: &[String],
+    target: Option<&str>,
+    program_arguments: &[String],
+) -> Result<(), PolicyError> {
+    if command != &BazelCommand::Run {
+        if target.is_some() || !program_arguments.is_empty() {
+            return Err(PolicyError::RunFieldsOnNonRunCommand);
+        }
+        return Ok(());
+    }
+
+    #[cfg(not(unix))]
+    {
+        let _ = (arguments, target, program_arguments);
+        Err(PolicyError::RunUnsupportedPlatform)
+    }
+
+    #[cfg(unix)]
+    {
+        let target = target
+            .filter(|target| !target.trim().is_empty())
+            .ok_or(PolicyError::RunTargetRequired)?;
+        validate_argument_shape(&[target.to_owned()])?;
+        if target.starts_with('-') || target == "--" {
+            return Err(PolicyError::InvalidRunTarget);
+        }
+        if arguments
+            .iter()
+            .any(|argument| argument == "--" || !argument.starts_with('-'))
+        {
+            return Err(PolicyError::RunArgumentsMustBeFlags);
+        }
+        validate_argument_shape(program_arguments)
+    }
 }
 
 pub fn validate_query_arguments(
@@ -343,6 +405,36 @@ mod tests {
                 false,
             ),
             Err(PolicyError::AspectReservedArgument(_))
+        ));
+    }
+
+    #[test]
+    fn validates_run_only_fields_and_argument_boundary() {
+        assert!(
+            validate_run_arguments(
+                &BazelCommand::Run,
+                &["--config=dev".to_owned()],
+                Some("//cmd:example"),
+                &["--format=json".to_owned(), "input.txt".to_owned()],
+            )
+            .is_ok()
+        );
+        assert!(matches!(
+            validate_run_arguments(&BazelCommand::Run, &[], None, &[]),
+            Err(PolicyError::RunTargetRequired)
+        ));
+        assert!(matches!(
+            validate_run_arguments(
+                &BazelCommand::Run,
+                &["//other:target".to_owned()],
+                Some("//cmd:example"),
+                &[],
+            ),
+            Err(PolicyError::RunArgumentsMustBeFlags)
+        ));
+        assert!(matches!(
+            validate_run_arguments(&BazelCommand::Build, &[], Some("//cmd:example"), &[],),
+            Err(PolicyError::RunFieldsOnNonRunCommand)
         ));
     }
 }

--- a/crates/bazel-mcp-policy/src/lib.rs
+++ b/crates/bazel-mcp-policy/src/lib.rs
@@ -16,7 +16,7 @@ pub use executable::{
 };
 pub use flags::{
     INTERNAL_BEP_FLAG, effective_output_base, validate_arguments, validate_aspect_arguments,
-    validate_query_arguments,
+    validate_query_arguments, validate_run_arguments,
 };
 pub use redaction::Redactor;
 pub use workspace::validate_workspace;
@@ -41,6 +41,16 @@ pub enum PolicyError {
     ReservedFlag(String),
     #[error("argument contains a NUL byte")]
     InvalidArgument,
+    #[error("bazel run requires exactly one non-empty target")]
+    RunTargetRequired,
+    #[error("bazel run target must not look like a command option")]
+    InvalidRunTarget,
+    #[error("bazel run command arguments must be flags; use --flag=value for valued options")]
+    RunArgumentsMustBeFlags,
+    #[error("target and program_args are only valid when command is run")]
+    RunFieldsOnNonRunCommand,
+    #[error("bazel run is currently supported only on Unix platforms")]
+    RunUnsupportedPlatform,
     #[error("argument exceeds the {maximum_bytes}-byte limit")]
     ArgumentTooLong { maximum_bytes: usize },
     #[error("argument list exceeds the {maximum_count}-item limit")]

--- a/crates/bazel-mcp-reducer/src/build.rs
+++ b/crates/bazel-mcp-reducer/src/build.rs
@@ -36,6 +36,7 @@ pub struct BepAccumulator {
     artifact_roots: Vec<String>,
     direct_artifacts: Vec<Artifact>,
     canonical_arguments: Option<Vec<String>>,
+    run_bep_outcome: RunBepOutcome,
     retained_items: usize,
     retained_bytes: usize,
     truncated: bool,
@@ -55,6 +56,13 @@ pub struct StreamReductionOutput {
     pub canonical_arguments: Option<Vec<String>>,
     pub reducer_events: Vec<ReducerEvent>,
     pub reducer_input_truncated: bool,
+    pub run_bep_outcome: RunBepOutcome,
+}
+
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub struct RunBepOutcome {
+    pub build_success: Option<bool>,
+    pub exec_request_should_execute: Option<bool>,
 }
 
 struct ExtensionEventCollector {
@@ -251,6 +259,12 @@ impl BepAccumulator {
                     self.canonical_arguments = Some(std::mem::take(&mut arguments));
                 }
             }
+            Some(build_event::Payload::Finished(finished)) => {
+                self.run_bep_outcome.build_success = Some(finished.overall_success);
+            }
+            Some(build_event::Payload::ExecRequest(exec_request)) => {
+                self.run_bep_outcome.exec_request_should_execute = Some(exec_request.should_exec);
+            }
             _ => {}
         }
     }
@@ -327,6 +341,7 @@ impl BepAccumulator {
             canonical_arguments: self.canonical_arguments,
             reducer_events,
             reducer_input_truncated,
+            run_bep_outcome: self.run_bep_outcome,
         }
     }
 

--- a/crates/bazel-mcp-reducer/src/lib.rs
+++ b/crates/bazel-mcp-reducer/src/lib.rs
@@ -12,8 +12,8 @@ mod test_evidence;
 
 pub use budget::{Budget, Budgeted};
 pub use build::{
-    BepAccumulator, ReductionInput, StreamReductionOutput, extract_canonical_arguments,
-    finalize_diagnostics, reduce_artifacts, reduce_invocation,
+    BepAccumulator, ReductionInput, RunBepOutcome, StreamReductionOutput,
+    extract_canonical_arguments, finalize_diagnostics, reduce_artifacts, reduce_invocation,
 };
 pub use coverage::{CoverageError, parse_lcov, parse_lcov_reader};
 pub use diagnostic_reducer::{TestFailureAccumulator, TestFailureEvidence};

--- a/crates/bazel-mcp-runner/src/execution.rs
+++ b/crates/bazel-mcp-runner/src/execution.rs
@@ -15,14 +15,14 @@ use bazel_mcp_bep::StreamOutcome;
 use bazel_mcp_bes::CAPTURE_ID_HEADER;
 use bazel_mcp_policy::filtered_environment;
 use bazel_mcp_reducer::{
-    BepAccumulator, Budget, REDUCER_API_VERSION, ReducerContext, StreamReductionOutput,
-    finalize_diagnostics, normalize_terminal_text,
+    BepAccumulator, Budget, REDUCER_API_VERSION, ReducerContext, RunBepOutcome,
+    StreamReductionOutput, finalize_diagnostics, normalize_terminal_text,
 };
 use bazel_mcp_store::{InvocationCompletion, InvocationPaths, StoreError};
 use bazel_mcp_types::{
     BazelCommand, CommandClass, Diagnostic, DiagnosticCategory, InspectHint, InvocationId,
     InvocationMetrics, InvocationRecord, InvocationRequest, InvocationState, InvocationSummary,
-    PageRequest, QueryRow, Severity, Termination, TestStatus,
+    PageRequest, QueryRow, RunOutcome, RunSummary, Severity, Termination, TestStatus,
 };
 use tokio::{
     process::{Child, Command},
@@ -220,6 +220,7 @@ impl TerminalCommit {
                 state: InvocationState::Failed,
                 termination,
                 summary,
+                run: None,
                 metrics: InvocationMetrics {
                     queue_ms,
                     ..Default::default()
@@ -238,6 +239,7 @@ impl TerminalCommit {
                 state: InvocationState::Cancelled,
                 termination: Termination::Cancelled,
                 summary: cancelled_summary(),
+                run: None,
                 metrics: InvocationMetrics {
                     queue_ms,
                     ..Default::default()
@@ -350,7 +352,7 @@ impl InvocationService {
         )
         .await;
         #[cfg(unix)]
-        let mut prepared_fifo = if command_class == CommandClass::BuildLike
+        let mut prepared_fifo = if captures_bep(command_class)
             && !driver.is_aspect()
             && bep_transport == BepTransport::Fifo
         {
@@ -387,9 +389,7 @@ impl InvocationService {
             None
         };
         #[cfg(not(unix))]
-        if command_class == CommandClass::BuildLike
-            && !driver.is_aspect()
-            && bep_transport == BepTransport::Fifo
+        if captures_bep(command_class) && !driver.is_aspect() && bep_transport == BepTransport::Fifo
         {
             tracing::debug!(
                 invocation_id = %queued.request.id,
@@ -402,9 +402,7 @@ impl InvocationService {
             )));
         }
         let extension_limits = plan.extension_limits;
-        let bes_bep = if command_class == CommandClass::BuildLike
-            && bep_transport == BepTransport::Bes
-        {
+        let bes_bep = if captures_bep(command_class) && bep_transport == BepTransport::Bes {
             match &self.bes {
                 Some(server) => Some(capture::LiveBepCapture::Bes(capture::BesBepCapture::start(
                     server.register(queued.request.id.to_string())?,
@@ -434,7 +432,7 @@ impl InvocationService {
                 command
                     .args(&queued.request.startup_arguments)
                     .arg(queued.request.command.as_str());
-                if command_class == CommandClass::BuildLike {
+                if captures_bep(command_class) {
                     command.arg(format!("--invocation_id={}", queued.request.id));
                     match bep_transport {
                         BepTransport::Tail => {
@@ -479,8 +477,30 @@ impl InvocationService {
                     ) {
                         command.args(["--test_output=errors", "--test_summary=none"]);
                     }
+                    if queued.request.command == BazelCommand::Run {
+                        // Command-line values override bazelrc defaults. Keep execution
+                        // enabled while preventing terminal and BEP residue disclosure.
+                        command.args([
+                            "--run=true",
+                            "--omit_run_args=true",
+                            "--noexperimental_run_bep_event_include_residue",
+                            "--subcommands=false",
+                        ]);
+                    }
                 }
                 command.args(&queued.request.arguments);
+                if queued.request.command == BazelCommand::Run {
+                    command
+                        .arg(
+                            queued
+                                .request
+                                .target
+                                .as_deref()
+                                .expect("validated run target"),
+                        )
+                        .arg("--")
+                        .args(&queued.request.program_arguments);
+                }
             }
             ExecutionDriver::Aspect {
                 bazel_executable, ..
@@ -540,7 +560,11 @@ impl InvocationService {
                 command.args(&queued.request.arguments);
             }
         }
-        command.stdout(stdout).stderr(stderr).kill_on_drop(true);
+        command
+            .stdin(std::process::Stdio::null())
+            .stdout(stdout)
+            .stderr(stderr)
+            .kill_on_drop(true);
         #[cfg(unix)]
         {
             use std::os::unix::process::CommandExt;
@@ -610,25 +634,21 @@ impl InvocationService {
         }
         #[cfg(unix)]
         let incremental_bep = fifo_bep.or(bes_bep).or_else(|| {
-            (command_class == CommandClass::BuildLike && bep_transport != BepTransport::Bes).then(
-                || {
-                    capture::LiveBepCapture::Tail(capture::IncrementalBepCapture::start(
-                        paths.bep.clone(),
-                        extension_limits,
-                    ))
-                },
-            )
+            (captures_bep(command_class) && bep_transport != BepTransport::Bes).then(|| {
+                capture::LiveBepCapture::Tail(capture::IncrementalBepCapture::start(
+                    paths.bep.clone(),
+                    extension_limits,
+                ))
+            })
         });
         #[cfg(not(unix))]
         let incremental_bep = bes_bep.or_else(|| {
-            (command_class == CommandClass::BuildLike && bep_transport != BepTransport::Bes).then(
-                || {
-                    capture::LiveBepCapture::Tail(capture::IncrementalBepCapture::start(
-                        paths.bep.clone(),
-                        extension_limits,
-                    ))
-                },
-            )
+            (captures_bep(command_class) && bep_transport != BepTransport::Bes).then(|| {
+                capture::LiveBepCapture::Tail(capture::IncrementalBepCapture::start(
+                    paths.bep.clone(),
+                    extension_limits,
+                ))
+            })
         });
         Ok(StartExecution::Running(Box::new(RunningInvocation {
             plan,
@@ -656,7 +676,15 @@ impl InvocationService {
         let timeout = plan.timeout;
         let timeout_sleep = tokio::time::sleep(timeout);
         tokio::pin!(timeout_sleep);
-        let (status, termination, state) = tokio::select! {
+        let output_limit_stdout = plan.paths.stdout.clone();
+        let output_limit_stderr = plan.paths.stderr.clone();
+        let output_limit = wait_for_run_output_limit(
+            &output_limit_stdout,
+            &output_limit_stderr,
+            self.config.maximum_run_output_bytes,
+        );
+        tokio::pin!(output_limit);
+        let (mut status, mut termination, mut state) = tokio::select! {
             result = child.wait() => finish_from_status(result?),
             () = cancellation.cancelled() => {
                 let status = terminate_child(
@@ -674,7 +702,37 @@ impl InvocationService {
                 ).await?;
                 (Some(status), Termination::Timeout, InvocationState::TimedOut)
             }
+            () = &mut output_limit, if plan.request.command == BazelCommand::Run => {
+                let status = terminate_child(
+                    &mut child,
+                    self.config.cancellation_interrupt_grace,
+                    self.config.cancellation_terminate_grace,
+                ).await?;
+                (
+                    Some(status),
+                    Termination::OutputLimit {
+                        maximum_bytes: self.config.maximum_run_output_bytes,
+                    },
+                    InvocationState::Failed,
+                )
+            }
         };
+        if plan.request.command == BazelCommand::Run
+            && !matches!(
+                termination,
+                Termination::Cancelled | Termination::Timeout | Termination::OutputLimit { .. }
+            )
+            && capture::file_size(&plan.paths.stdout)
+                .await
+                .saturating_add(capture::file_size(&plan.paths.stderr).await)
+                > self.config.maximum_run_output_bytes
+        {
+            termination = Termination::OutputLimit {
+                maximum_bytes: self.config.maximum_run_output_bytes,
+            };
+            state = InvocationState::Failed;
+            status = None;
+        }
         process_group.disarm();
         native_output_base_wait.finish().await;
         let bazel_wall_ms = duration_millis(started.elapsed());
@@ -815,6 +873,7 @@ impl InvocationService {
             canonical_arguments,
             reducer_events,
             reducer_input_truncated,
+            run_bep_outcome,
         } = reduced.unwrap_or_else(|_| {
             tracing::warn!(
                 invocation_id = %queued.request.id,
@@ -826,9 +885,25 @@ impl InvocationService {
                 canonical_arguments: None,
                 reducer_events: Vec::new(),
                 reducer_input_truncated: false,
+                run_bep_outcome: RunBepOutcome::default(),
             }
         });
-        let canonical_arguments = canonical_arguments.map(|mut arguments| {
+        let canonical_arguments = if queued.request.command == BazelCommand::Run {
+            let mut arguments = queued.request.startup_arguments.clone();
+            arguments.push("run".to_owned());
+            arguments.extend(queued.request.arguments.iter().cloned());
+            arguments.extend(queued.request.target.iter().cloned());
+            if !queued.request.program_arguments.is_empty() {
+                arguments.push(format!(
+                    "[REDACTED_PROGRAM_ARGS:{}]",
+                    queued.request.program_arguments.len()
+                ));
+            }
+            Some(arguments)
+        } else {
+            canonical_arguments
+        }
+        .map(|mut arguments| {
             let workspace = queued.request.workspace.to_string_lossy();
             for argument in &mut arguments {
                 *argument = self.redactor.redact_bounded(
@@ -859,6 +934,51 @@ impl InvocationService {
                 if excerpt.len() > 1_000 {
                     summary.truncated = true;
                     summary.inspect_hint = Some(InspectHint::Log);
+                }
+            }
+        }
+        let run = self.build_run_summary(
+            &queued.request,
+            exit_code,
+            &exited.termination,
+            run_bep_outcome,
+            &stdout,
+            &stderr,
+        );
+        if let Some(run) = &run {
+            match run.outcome {
+                RunOutcome::BuildFailed => {}
+                RunOutcome::NotLaunched => {
+                    summary.headline = format!("{} was built but not launched", run.target);
+                }
+                RunOutcome::Succeeded => {
+                    summary.headline = format!("{} exited successfully", run.target);
+                }
+                RunOutcome::ProgramFailed => {
+                    summary.headline = run.program_exit_code.map_or_else(
+                        || format!("{} terminated without an exit code", run.target),
+                        |code| format!("{} exited with code {code}", run.target),
+                    );
+                }
+                RunOutcome::CancelledDuringBuild => {
+                    summary.headline = format!("{} was cancelled while building", run.target);
+                }
+                RunOutcome::CancelledDuringProgram => {
+                    summary.headline = format!("{} was cancelled while running", run.target);
+                }
+                RunOutcome::TimedOutDuringBuild => {
+                    summary.headline = format!("{} timed out while building", run.target);
+                }
+                RunOutcome::TimedOutDuringProgram => {
+                    summary.headline = format!("{} timed out while running", run.target);
+                }
+                RunOutcome::OutputLimitDuringBuild => {
+                    summary.headline =
+                        format!("{} exceeded the output limit while building", run.target);
+                }
+                RunOutcome::OutputLimitDuringProgram => {
+                    summary.headline =
+                        format!("{} exceeded the output limit while running", run.target);
                 }
             }
         }
@@ -973,6 +1093,7 @@ impl InvocationService {
                 state: exited.state,
                 termination: exited.termination,
                 summary,
+                run,
                 metrics,
                 canonical_arguments,
                 artifacts,
@@ -1052,6 +1173,7 @@ impl InvocationService {
                     inspect_hint: Some(InspectHint::Log),
                     ..Default::default()
                 },
+                run: None,
                 metrics: InvocationMetrics::default(),
                 canonical_arguments: None,
                 artifacts: Vec::new(),
@@ -1117,6 +1239,70 @@ impl InvocationService {
                 file.path = sanitize(&file.path, 1_000);
             }
         }
+    }
+
+    fn build_run_summary(
+        &self,
+        request: &InvocationRequest,
+        exit_code: Option<i32>,
+        termination: &Termination,
+        bep: RunBepOutcome,
+        stdout: &[u8],
+        stderr: &[u8],
+    ) -> Option<RunSummary> {
+        if request.command != BazelCommand::Run {
+            return None;
+        }
+        let launched = bep.exec_request_should_execute == Some(true);
+        let outcome = match termination {
+            Termination::OutputLimit { .. } if launched => RunOutcome::OutputLimitDuringProgram,
+            Termination::OutputLimit { .. } => RunOutcome::OutputLimitDuringBuild,
+            Termination::Cancelled if launched => RunOutcome::CancelledDuringProgram,
+            Termination::Cancelled => RunOutcome::CancelledDuringBuild,
+            Termination::Timeout if launched => RunOutcome::TimedOutDuringProgram,
+            Termination::Timeout => RunOutcome::TimedOutDuringBuild,
+            _ if bep.build_success == Some(false) => RunOutcome::BuildFailed,
+            _ if !launched => RunOutcome::NotLaunched,
+            _ if exit_code == Some(0) => RunOutcome::Succeeded,
+            _ => RunOutcome::ProgramFailed,
+        };
+        let program_exit_code = launched.then_some(exit_code).flatten();
+        let output_excerpt = if launched {
+            self.run_output_excerpt(&request.workspace, stdout, stderr)
+        } else {
+            Vec::new()
+        };
+        Some(RunSummary {
+            target: self.redactor.redact_bounded(
+                request.target.as_deref().unwrap_or("<missing target>"),
+                1_000,
+            ),
+            outcome,
+            program_exit_code,
+            output_excerpt,
+        })
+    }
+
+    fn run_output_excerpt(&self, workspace: &Path, stdout: &[u8], stderr: &[u8]) -> Vec<String> {
+        let normalized_stdout = normalize_terminal_text(stdout);
+        let text = if normalized_stdout.trim().is_empty() {
+            normalize_terminal_text(stderr)
+        } else {
+            normalized_stdout
+        };
+        let workspace = workspace.to_string_lossy();
+        let mut lines = text
+            .lines()
+            .filter(|line| !line.trim().is_empty())
+            .rev()
+            .take(8)
+            .map(|line| {
+                self.redactor
+                    .redact_bounded(&line.replace(workspace.as_ref(), "<workspace>"), 512)
+            })
+            .collect::<Vec<_>>();
+        lines.reverse();
+        lines
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -1380,6 +1566,22 @@ pub(crate) fn finish_from_status(
         #[cfg(not(unix))]
         {
             (Some(status), Termination::Exit { code: -1 }, state)
+        }
+    }
+}
+
+fn captures_bep(command_class: CommandClass) -> bool {
+    matches!(command_class, CommandClass::BuildLike | CommandClass::Run)
+}
+
+async fn wait_for_run_output_limit(stdout: &Path, stderr: &Path, maximum_bytes: u64) {
+    loop {
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        let bytes = capture::file_size(stdout)
+            .await
+            .saturating_add(capture::file_size(stderr).await);
+        if bytes > maximum_bytes {
+            return;
         }
     }
 }

--- a/crates/bazel-mcp-runner/src/inspection.rs
+++ b/crates/bazel-mcp-runner/src/inspection.rs
@@ -143,6 +143,7 @@ impl InvocationService {
                         }),
                         query_result_count: summary.query_result_count,
                         query_sample: summary.query_sample.clone(),
+                        run: record.run.clone(),
                         elapsed_ms: summary.elapsed_ms,
                         truncated: summary.truncated,
                         inspect_hint: summary.inspect_hint,

--- a/crates/bazel-mcp-runner/src/service.rs
+++ b/crates/bazel-mcp-runner/src/service.rs
@@ -10,7 +10,8 @@ use bazel_mcp_bes::{BesError, BesServer};
 use bazel_mcp_policy::{
     PolicyConfig, PolicyError, Redactor, effective_output_base, filtered_environment,
     resolve_aspect_executable, resolve_bazel_executable, validate_arguments,
-    validate_aspect_arguments, validate_command, validate_query_arguments, validate_workspace,
+    validate_aspect_arguments, validate_command, validate_query_arguments, validate_run_arguments,
+    validate_workspace,
 };
 use bazel_mcp_reducer::{
     RawStarlarkConfig, ReducerPipeline, StarlarkReducerConfig, load_starlark_reducers,
@@ -71,6 +72,7 @@ pub enum BepTransport {
 pub struct RawRunnerConfig {
     pub default_timeout_seconds: u64,
     pub maximum_timeout_seconds: u64,
+    pub maximum_run_output_bytes: u64,
     pub cancellation_interrupt_grace_seconds: u64,
     pub cancellation_terminate_grace_seconds: u64,
     pub global_concurrency: usize,
@@ -91,6 +93,7 @@ impl Default for RawRunnerConfig {
         Self {
             default_timeout_seconds: config.default_timeout.as_secs(),
             maximum_timeout_seconds: config.maximum_timeout.as_secs(),
+            maximum_run_output_bytes: config.maximum_run_output_bytes,
             cancellation_interrupt_grace_seconds: config.cancellation_interrupt_grace.as_secs(),
             cancellation_terminate_grace_seconds: config.cancellation_terminate_grace.as_secs(),
             global_concurrency: config.global_concurrency,
@@ -112,6 +115,7 @@ pub struct RunnerConfig {
     pub policy: PolicyConfig,
     pub default_timeout: Duration,
     pub maximum_timeout: Duration,
+    pub maximum_run_output_bytes: u64,
     pub cancellation_interrupt_grace: Duration,
     pub cancellation_terminate_grace: Duration,
     pub global_concurrency: usize,
@@ -133,6 +137,7 @@ impl Default for RunnerConfig {
             policy: PolicyConfig::default(),
             default_timeout: Duration::from_secs(30 * 60),
             maximum_timeout: Duration::from_secs(2 * 60 * 60),
+            maximum_run_output_bytes: 256 * 1024 * 1024,
             cancellation_interrupt_grace: Duration::from_secs(10),
             cancellation_terminate_grace: Duration::from_secs(5),
             global_concurrency: 4,
@@ -172,6 +177,11 @@ impl RunnerConfig {
                 "maximum timeout must be greater than zero",
             ));
         }
+        if self.maximum_run_output_bytes == 0 {
+            return Err(RunnerError::InvalidConfiguration(
+                "maximum run output bytes must be greater than zero",
+            ));
+        }
         if self.default_timeout > self.maximum_timeout {
             return Err(RunnerError::InvalidConfiguration(
                 "default timeout exceeds maximum timeout",
@@ -195,6 +205,11 @@ impl RunnerConfig {
         if self.aspect.has_invalid_command() {
             return Err(RunnerError::InvalidConfiguration(
                 "Aspect routes must be non-empty command names without whitespace or a leading dash",
+            ));
+        }
+        if self.aspect.commands.contains("run") {
+            return Err(RunnerError::InvalidConfiguration(
+                "bazel run cannot be routed through Aspect CLI",
             ));
         }
         if self.aspect.commands.iter().any(|command| {
@@ -226,6 +241,7 @@ impl TryFrom<(RawRunnerConfig, PolicyConfig)> for RunnerConfig {
             policy,
             default_timeout: Duration::from_secs(raw.default_timeout_seconds),
             maximum_timeout: Duration::from_secs(raw.maximum_timeout_seconds),
+            maximum_run_output_bytes: raw.maximum_run_output_bytes,
             cancellation_interrupt_grace: Duration::from_secs(
                 raw.cancellation_interrupt_grace_seconds,
             ),
@@ -627,6 +643,12 @@ impl InvocationService {
         validate_command(&self.config.policy, &request.command)?;
         validate_arguments(&request.startup_arguments)?;
         validate_arguments(&request.arguments)?;
+        validate_run_arguments(
+            &request.command,
+            &request.arguments,
+            request.target.as_deref(),
+            &request.program_arguments,
+        )?;
         let uses_aspect = self.config.aspect.routes(&request.command);
         if uses_aspect {
             validate_aspect_arguments(
@@ -1154,6 +1176,13 @@ impl InvocationService {
         {
             *argument = self.redactor.redact_bounded(argument, 64 * 1024);
         }
+        for argument in &mut request.program_arguments {
+            *argument = "[REDACTED]".to_owned();
+        }
+        request.target = request
+            .target
+            .as_deref()
+            .map(|target| self.redactor.redact_bounded(target, 64 * 1024));
         for value in request.environment.values_mut() {
             *value = self.redactor.redact_bounded(value, 64 * 1024);
         }
@@ -1236,7 +1265,22 @@ mod tests {
             maximum_timeout: Duration::ZERO,
             ..RunnerConfig::default()
         };
-        assert!(InvocationService::new(store, zero_timeout).is_err());
+        assert!(InvocationService::new(store.clone(), zero_timeout).is_err());
+
+        let zero_run_output = RunnerConfig {
+            maximum_run_output_bytes: 0,
+            ..RunnerConfig::default()
+        };
+        assert!(InvocationService::new(store.clone(), zero_run_output).is_err());
+
+        let aspect_run = RunnerConfig {
+            aspect: AspectConfig {
+                commands: ["run".to_owned()].into(),
+                ..AspectConfig::default()
+            },
+            ..RunnerConfig::default()
+        };
+        assert!(InvocationService::new(store, aspect_run).is_err());
     }
 
     #[test]

--- a/crates/bazel-mcp-runner/tests/process.rs
+++ b/crates/bazel-mcp-runner/tests/process.rs
@@ -7,8 +7,8 @@ use std::{
 };
 
 use bazel_mcp_bep::proto::{
-    ActionExecuted, BuildEvent, BuildEventId, File, TestResult as BepTestResult,
-    TestSummary as BepTestSummary, build_event, build_event_id, file,
+    ActionExecuted, BuildEvent, BuildEventId, BuildFinished, ExecRequestConstructed, File,
+    TestResult as BepTestResult, TestSummary as BepTestSummary, build_event, build_event_id, file,
 };
 use bazel_mcp_bep::{encode_event_id, encode_frame};
 use bazel_mcp_policy::PolicyConfig;
@@ -20,7 +20,8 @@ use bazel_mcp_store::Store;
 use bazel_mcp_types::{
     Artifact, ArtifactKind, BazelCommand, DeferredRetrieval, Diagnostic, DiagnosticCategory,
     InspectHint, InspectPayload, InvocationRecord, InvocationRequest, InvocationState,
-    InvocationSummary, ResultDisposition, Severity, Termination, TestCase, TestResult, TestStatus,
+    InvocationSummary, ResultDisposition, RunOutcome, Severity, Termination, TestCase, TestResult,
+    TestStatus,
 };
 use tempfile::TempDir;
 use tokio_util::sync::CancellationToken;
@@ -73,6 +74,24 @@ fn failed_test_bep(log_uri: &str, xml_uri: &str) -> Vec<u8> {
         ..Default::default()
     };
     [encode_frame(&result), encode_frame(&summary)].concat()
+}
+
+fn successful_run_build_bep(should_exec: bool) -> Vec<u8> {
+    let finished = BuildEvent {
+        payload: Some(build_event::Payload::Finished(Box::new(BuildFinished {
+            overall_success: true,
+            ..Default::default()
+        }))),
+        ..Default::default()
+    };
+    let exec_request = BuildEvent {
+        last_message: true,
+        payload: Some(build_event::Payload::ExecRequest(Box::new(
+            ExecRequestConstructed { should_exec },
+        ))),
+        ..Default::default()
+    };
+    [encode_frame(&finished), encode_frame(&exec_request)].concat()
 }
 
 async fn wait_for_path(path: &Path) {
@@ -308,6 +327,107 @@ async fn shared_executable_service(
         },
     )
     .unwrap()
+}
+
+#[tokio::test]
+async fn run_keeps_program_arguments_private_and_classifies_program_exit() {
+    let root = tempfile::tempdir().unwrap();
+    let workspace = root.path().join("workspace");
+    tokio::fs::create_dir(&workspace).await.unwrap();
+    let bep = root.path().join("run.bep");
+    tokio::fs::write(&bep, successful_run_build_bep(true))
+        .await
+        .unwrap();
+    let argv = root.path().join("run-argv.txt");
+    let script = format!(
+        "#!/bin/sh\nif [ \"${{1:-}}\" = --version ]; then echo 'bazel 9.1.0'; exit 0; fi\n: > '{}'\nfor arg in \"$@\"; do\n  printf '%s\\n' \"$arg\" >> '{}'\n  case \"$arg\" in --build_event_binary_file=*) bep_path=${{arg#*=}} ;; esac\ndone\ncp '{}' \"$bep_path\"\nprintf 'program output\\n'\nexit 7\n",
+        argv.display(),
+        argv.display(),
+        bep.display(),
+    );
+    let service = configured_service(&root, &workspace, &script, |config| {
+        config.policy.allowed_commands.insert("run".to_owned());
+        config.policy.denied_commands.remove("run");
+    })
+    .await;
+    let secret = "token=PROGRAM_ARGUMENT_SECRET";
+    let mut request = InvocationRequest::new(
+        workspace,
+        BazelCommand::Run,
+        vec!["--config=dev".to_owned()],
+    );
+    request.target = Some("//cmd:example".to_owned());
+    request.program_arguments = vec!["--format=json".to_owned(), secret.to_owned()];
+
+    let record = service.run(request).await.unwrap();
+
+    assert_eq!(record.state, InvocationState::Failed);
+    let run = record.run.as_ref().unwrap();
+    assert_eq!(run.target, "//cmd:example");
+    assert_eq!(run.outcome, RunOutcome::ProgramFailed);
+    assert_eq!(run.program_exit_code, Some(7));
+    assert_eq!(run.output_excerpt, vec!["program output"]);
+    assert_eq!(
+        record.request.program_arguments,
+        vec!["[REDACTED]", "[REDACTED]"]
+    );
+    let encoded = serde_json::to_string(&record).unwrap();
+    assert!(!encoded.contains(secret));
+    assert!(
+        record
+            .canonical_arguments
+            .as_ref()
+            .unwrap()
+            .contains(&"[REDACTED_PROGRAM_ARGS:2]".to_owned())
+    );
+
+    let argv = tokio::fs::read_to_string(argv).await.unwrap();
+    let arguments = argv.lines().collect::<Vec<_>>();
+    assert!(arguments.contains(&"--run=true"));
+    assert!(arguments.contains(&"--omit_run_args=true"));
+    assert!(arguments.contains(&"--noexperimental_run_bep_event_include_residue"));
+    assert!(arguments.contains(&"--subcommands=false"));
+    assert_eq!(
+        &arguments[arguments.len() - 4..],
+        &["//cmd:example", "--", "--format=json", secret]
+    );
+}
+
+#[tokio::test]
+async fn run_terminates_when_raw_output_exceeds_its_ceiling() {
+    let root = tempfile::tempdir().unwrap();
+    let workspace = root.path().join("workspace");
+    tokio::fs::create_dir(&workspace).await.unwrap();
+    let bep = root.path().join("run-output-limit.bep");
+    tokio::fs::write(&bep, successful_run_build_bep(true))
+        .await
+        .unwrap();
+    let script = format!(
+        "#!/bin/sh\nif [ \"${{1:-}}\" = --version ]; then echo 'bazel 9.1.0'; exit 0; fi\nfor arg in \"$@\"; do case \"$arg\" in --build_event_binary_file=*) bep_path=${{arg#*=}} ;; esac; done\ncp '{}' \"$bep_path\"\ni=0\nwhile [ \"$i\" -lt 4096 ]; do printf x; i=$((i+1)); done\nsleep 5\n",
+        bep.display(),
+    );
+    let service = configured_service(&root, &workspace, &script, |config| {
+        config.policy.allowed_commands.insert("run".to_owned());
+        config.policy.denied_commands.remove("run");
+        config.maximum_run_output_bytes = 1_024;
+    })
+    .await;
+    let mut request = InvocationRequest::new(workspace, BazelCommand::Run, Vec::new());
+    request.target = Some("//cmd:noisy".to_owned());
+
+    let record = service.run(request).await.unwrap();
+
+    assert_eq!(record.state, InvocationState::Failed);
+    assert_eq!(
+        record.termination,
+        Some(Termination::OutputLimit {
+            maximum_bytes: 1_024
+        })
+    );
+    assert_eq!(
+        record.run.as_ref().unwrap().outcome,
+        RunOutcome::OutputLimitDuringProgram
+    );
 }
 
 #[tokio::test]

--- a/crates/bazel-mcp-server/src/agent.rs
+++ b/crates/bazel-mcp-server/src/agent.rs
@@ -139,6 +139,8 @@ async fn run_agent_inner(mut arguments: Vec<OsString>) -> anyhow::Result<AgentRe
     let runner = InvocationService::start(store.clone(), RunnerConfig::from(&config)).await?;
     let mut request = InvocationRequest::new(workspace, parsed.command, parsed.arguments);
     request.startup_arguments = parsed.startup_arguments;
+    request.target = parsed.target;
+    request.program_arguments = parsed.program_arguments;
     let cancellation = CancellationToken::new();
     let signal_cancellation = cancellation.clone();
     let signal = tokio::spawn(async move {
@@ -176,6 +178,8 @@ struct ParsedBazelArguments {
     startup_arguments: Vec<String>,
     command: BazelCommand,
     arguments: Vec<String>,
+    target: Option<String>,
+    program_arguments: Vec<String>,
 }
 
 fn parse_bazel_arguments(
@@ -187,6 +191,8 @@ fn parse_bazel_arguments(
             startup_arguments: Vec::new(),
             command: BazelCommand::Help,
             arguments: Vec::new(),
+            target: None,
+            program_arguments: Vec::new(),
         });
     }
     if arguments.len() == 1 && matches!(arguments[0].to_str(), Some("--version" | "--help")) {
@@ -198,6 +204,8 @@ fn parse_bazel_arguments(
                 BazelCommand::Help
             },
             arguments: Vec::new(),
+            target: None,
+            program_arguments: Vec::new(),
         });
     }
 
@@ -229,10 +237,30 @@ fn parse_bazel_arguments(
     let command = strings[command_index]
         .parse::<BazelCommand>()
         .expect("BazelCommand parsing is infallible");
+    let mut command_arguments = strings[command_index + 1..].to_vec();
+    let mut target = None;
+    let mut program_arguments = Vec::new();
+    if command == BazelCommand::Run {
+        if let Some(delimiter) = command_arguments
+            .iter()
+            .position(|argument| argument == "--")
+        {
+            program_arguments = command_arguments.split_off(delimiter + 1);
+            command_arguments.pop();
+        }
+        if let Some(target_index) = command_arguments
+            .iter()
+            .position(|argument| !argument.starts_with('-'))
+        {
+            target = Some(command_arguments.remove(target_index));
+        }
+    }
     Ok(ParsedBazelArguments {
         startup_arguments: strings[..command_index].to_vec(),
         command,
-        arguments: strings[command_index + 1..].to_vec(),
+        arguments: command_arguments,
+        target,
+        program_arguments,
     })
 }
 
@@ -273,7 +301,12 @@ fn invocation_exit_code(record: &InvocationRecord) -> i32 {
         Some(Termination::Signal { signal }) => 128_i32.saturating_add(*signal),
         Some(Termination::Timeout) => 124,
         Some(Termination::Cancelled) => 130,
-        Some(Termination::SpawnFailure { .. } | Termination::Interrupted) | None => 1,
+        Some(
+            Termination::OutputLimit { .. }
+            | Termination::SpawnFailure { .. }
+            | Termination::Interrupted,
+        )
+        | None => 1,
     }
 }
 
@@ -355,6 +388,32 @@ mod tests {
         assert_eq!(parsed.startup_arguments, ["--output_base", "/tmp/output"]);
         assert_eq!(parsed.command, BazelCommand::Test);
         assert_eq!(parsed.arguments, ["//pkg:all", "--test_filter=one"]);
+        assert_eq!(parsed.target, None);
+        assert!(parsed.program_arguments.is_empty());
+    }
+
+    #[test]
+    fn separates_run_target_and_private_program_arguments() {
+        let mut policy = PolicyConfig::default();
+        policy.allowed_commands.insert("run".to_owned());
+        policy.denied_commands.remove("run");
+        let parsed = parse_bazel_arguments(
+            &os(&[
+                "run",
+                "--config=dev",
+                "//cmd:example",
+                "--",
+                "--token=secret",
+                "input.txt",
+            ]),
+            &policy,
+        )
+        .unwrap();
+
+        assert_eq!(parsed.command, BazelCommand::Run);
+        assert_eq!(parsed.arguments, ["--config=dev"]);
+        assert_eq!(parsed.target.as_deref(), Some("//cmd:example"));
+        assert_eq!(parsed.program_arguments, ["--token=secret", "input.txt"]);
     }
 
     #[test]

--- a/crates/bazel-mcp-server/src/handler.rs
+++ b/crates/bazel-mcp-server/src/handler.rs
@@ -54,13 +54,35 @@ pub struct RunParams {
     /// Bazel startup arguments placed before the command.
     #[serde(default)]
     pub startup_args: Vec<String>,
-    /// Bazel command or a configured Aspect command such as lint.
+    /// Bazel command such as build, test, query, or run, or a configured Aspect command such as lint.
     pub command: String,
-    /// Arguments placed after the selected command.
+    /// Arguments placed after the selected command. For run, valued options must use --flag=value.
     #[serde(default)]
     pub args: Vec<String>,
+    /// The single executable target required when command is run.
+    pub target: Option<String>,
+    /// Sensitive arguments passed to the executed program after `--`.
+    #[serde(default)]
+    pub program_args: Vec<String>,
     /// Optional timeout in seconds.
     pub timeout_seconds: Option<u64>,
+}
+
+impl RunParams {
+    fn into_request(self) -> InvocationRequest {
+        let command = match BazelCommand::from_str(&self.command) {
+            Ok(command) => command,
+            Err(never) => match never {},
+        };
+        let mut request = InvocationRequest::new(PathBuf::from(self.workspace), command, self.args);
+        request.startup_arguments = self.startup_args;
+        request.target = self.target;
+        request.program_arguments = self.program_args;
+        request.timeout_ms = self
+            .timeout_seconds
+            .map(|seconds| seconds.saturating_mul(1_000));
+        request
+    }
 }
 
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
@@ -139,7 +161,7 @@ impl BazelMcpServer {
 impl BazelMcpServer {
     #[tool(
         name = "bazel.run",
-        description = "Execute one allowed Bazel or configured Aspect command silently and return a bounded actionable summary."
+        description = "Execute one allowed Bazel or configured Aspect command silently and return a bounded actionable summary. For command=run, pass one target and optional sensitive program_args; run must be enabled by server policy."
     )]
     async fn bazel_run(
         &self,
@@ -148,16 +170,7 @@ impl BazelMcpServer {
         meta: Meta,
         client: Peer<RoleServer>,
     ) -> Result<CallToolResult, String> {
-        let command = match BazelCommand::from_str(&params.command) {
-            Ok(command) => command,
-            Err(never) => match never {},
-        };
-        let mut request =
-            InvocationRequest::new(PathBuf::from(params.workspace), command, params.args);
-        request.startup_arguments = params.startup_args;
-        request.timeout_ms = params
-            .timeout_seconds
-            .map(|seconds| seconds.saturating_mul(1000));
+        let request = params.into_request();
         let id = request.id;
         let runner = self.runner.clone();
         let mut task =
@@ -462,17 +475,7 @@ impl BazelMcpServer {
         let params: RunParams =
             serde_json::from_value(serde_json::Value::Object(arguments.unwrap_or_default()))
                 .map_err(|error| format!("invalid bazel.run arguments: {error}"))?;
-        let command = match BazelCommand::from_str(&params.command) {
-            Ok(command) => command,
-            Err(never) => match never {},
-        };
-        let mut request =
-            InvocationRequest::new(PathBuf::from(params.workspace), command, params.args);
-        request.startup_arguments = params.startup_args;
-        request.timeout_ms = params
-            .timeout_seconds
-            .map(|seconds| seconds.saturating_mul(1_000));
-        Ok(request)
+        Ok(params.into_request())
     }
 
     async fn submit_deferred(
@@ -1017,6 +1020,30 @@ mod tests {
     use tempfile::tempdir;
 
     use super::*;
+
+    #[test]
+    fn run_request_keeps_bazel_and_program_arguments_separate() {
+        let arguments = serde_json::from_value(serde_json::json!({
+            "workspace": "/workspace/example",
+            "command": "run",
+            "args": ["--config=dev"],
+            "target": "//cmd:example",
+            "program_args": ["--format=json", "input.txt"],
+            "timeout_seconds": 300
+        }))
+        .unwrap();
+
+        let request = BazelMcpServer::decode_run_request(Some(arguments)).unwrap();
+
+        assert_eq!(request.command, BazelCommand::Run);
+        assert_eq!(request.arguments, vec!["--config=dev"]);
+        assert_eq!(request.target.as_deref(), Some("//cmd:example"));
+        assert_eq!(
+            request.program_arguments,
+            vec!["--format=json", "input.txt"]
+        );
+        assert_eq!(request.timeout_ms, Some(300_000));
+    }
 
     #[tokio::test]
     async fn invocation_ledger_can_be_scoped_to_a_workspace() {

--- a/crates/bazel-mcp-server/src/result.rs
+++ b/crates/bazel-mcp-server/src/result.rs
@@ -2,7 +2,7 @@
 
 use bazel_mcp_types::{
     AvailableViews, Diagnostic, InspectHint, InspectPayload, InspectResult, InvocationRecord,
-    InvocationState, QueryRow, TargetCounts, Termination, TestCounts,
+    InvocationState, QueryRow, RunSummary, TargetCounts, Termination, TestCounts,
 };
 use rmcp::model::{CallToolResult, ContentBlock};
 use serde::Serialize;
@@ -66,6 +66,8 @@ struct RunResult {
     query_result_count: Option<u64>,
     #[serde(skip_serializing_if = "Vec::is_empty")]
     query_sample: Vec<QueryRow>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    run: Option<RunSummary>,
     truncated: bool,
     #[serde(skip_serializing_if = "Option::is_none")]
     inspect_hint: Option<InspectHint>,
@@ -186,6 +188,7 @@ impl RunResultBuilder {
             diagnostics: summary.diagnostics.clone(),
             query_result_count: summary.query_result_count,
             query_sample: summary.query_sample.clone(),
+            run: record.run.clone(),
             truncated: summary.truncated,
             inspect_hint: if retained { summary.inspect_hint } else { None },
             available_views: if retained {
@@ -211,7 +214,13 @@ impl RunResultBuilder {
             if !retained {
                 result.rerun_hint = Some("rerun with --no-agent-mode for unfiltered Bazel output");
             }
-            if result.query_sample.pop().is_some() || result.diagnostics.pop().is_some() {
+            if result
+                .run
+                .as_mut()
+                .is_some_and(|run| run.output_excerpt.pop().is_some())
+                || result.query_sample.pop().is_some()
+                || result.diagnostics.pop().is_some()
+            {
                 continue;
             }
             if shrink_utf8(&mut result.headline, 96) || shrink_utf8(&mut result.command, 32) {
@@ -287,11 +296,11 @@ mod tests {
 
     use bazel_mcp_types::{
         BazelCommand, InspectPayload, InspectResult, InspectView, InvocationRecord,
-        InvocationRequest, InvocationState, InvocationSummary, Termination,
+        InvocationRequest, InvocationState, InvocationSummary, RunOutcome, RunSummary, Termination,
     };
     use rmcp::model::ContentBlock;
 
-    use super::{ResultEncoder, RunResultBuilder, shrink_utf8};
+    use super::{ExecutionResult, ResultEncoder, RunResultBuilder, shrink_utf8};
     use crate::ResultEncoding;
 
     #[test]
@@ -331,6 +340,36 @@ mod tests {
             "rerun with --no-agent-mode for unfiltered Bazel output"
         );
         assert!(text.len() <= 8 * 1024);
+    }
+
+    #[test]
+    fn run_result_exposes_typed_program_outcome() {
+        let mut record = InvocationRecord::queued(InvocationRequest::new(
+            PathBuf::from("/workspace/example"),
+            BazelCommand::Run,
+            vec!["--config=dev".to_owned()],
+        ));
+        record.state = InvocationState::Failed;
+        record.termination = Some(Termination::Exit { code: 7 });
+        record.summary = Some(InvocationSummary {
+            headline: "//cmd:example exited with code 7".to_owned(),
+            ..Default::default()
+        });
+        record.run = Some(RunSummary {
+            target: "//cmd:example".to_owned(),
+            outcome: RunOutcome::ProgramFailed,
+            program_exit_code: Some(7),
+            output_excerpt: vec!["program output".to_owned()],
+        });
+
+        let encoded = RunResultBuilder::new(ResultEncoder::new(ResultEncoding::Structured))
+            .build(ExecutionResult::new(&record, false))
+            .unwrap();
+        let value = encoded.result.structured_content.unwrap();
+
+        assert_eq!(value["run"]["outcome"], "program_failed");
+        assert_eq!(value["run"]["program_exit_code"], 7);
+        assert_eq!(value["run"]["output_excerpt"][0], "program output");
     }
 
     #[test]

--- a/crates/bazel-mcp-store/src/record.rs
+++ b/crates/bazel-mcp-store/src/record.rs
@@ -2,8 +2,8 @@
 
 use bazel_mcp_types::{
     CoverageFile, CoverageSummary, Diagnostic, InspectHint, InvocationMetrics, InvocationRecord,
-    InvocationRequest, InvocationState, InvocationSummary, QueryRow, TargetCounts, TargetResult,
-    Termination, TestCounts, TestResult,
+    InvocationRequest, InvocationState, InvocationSummary, QueryRow, RunSummary, TargetCounts,
+    TargetResult, Termination, TestCounts, TestResult,
 };
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
@@ -20,6 +20,7 @@ pub struct InvocationHeader {
     pub finished_at_ms: Option<i64>,
     pub termination: Option<Termination>,
     pub summary: Option<InvocationSummaryHeader>,
+    pub run: Option<RunSummary>,
     pub metrics: InvocationMetrics,
     pub canonical_arguments: Option<Vec<String>>,
     pub cancellation_reason: Option<String>,
@@ -41,6 +42,7 @@ impl From<InvocationRecord> for InvocationHeader {
             finished_at_ms: record.finished_at_ms,
             termination: record.termination,
             summary: record.summary.map(InvocationSummaryHeader::from),
+            run: record.run,
             metrics: record.metrics,
             canonical_arguments: record.canonical_arguments,
             cancellation_reason: record.cancellation_reason,
@@ -58,6 +60,7 @@ impl InvocationHeader {
             finished_at_ms: self.finished_at_ms,
             termination: self.termination,
             summary: self.summary.map(InvocationSummaryHeader::into_summary),
+            run: self.run,
             metrics: self.metrics,
             canonical_arguments: self.canonical_arguments,
             cancellation_reason: self.cancellation_reason,

--- a/crates/bazel-mcp-store/src/storage.rs
+++ b/crates/bazel-mcp-store/src/storage.rs
@@ -113,6 +113,7 @@ pub struct InvocationCompletion {
     pub state: InvocationState,
     pub termination: Termination,
     pub summary: InvocationSummary,
+    pub run: Option<bazel_mcp_types::RunSummary>,
     pub metrics: InvocationMetrics,
     pub canonical_arguments: Option<Vec<String>>,
     pub artifacts: Vec<Artifact>,
@@ -397,6 +398,7 @@ impl Store {
             state,
             termination,
             summary,
+            run,
             metrics,
             canonical_arguments,
             artifacts,
@@ -418,6 +420,7 @@ impl Store {
         result.transition(state)?;
         result.termination = Some(termination);
         result.summary = Some(summary);
+        result.run = run;
         result.metrics = metrics;
         let telemetry_generation = {
             let index = self.inner.index.read().await;
@@ -1537,6 +1540,7 @@ mod tests {
                     state: InvocationState::Succeeded,
                     termination: Termination::Exit { code: 0 },
                     summary,
+                    run: None,
                     metrics: InvocationMetrics::default(),
                     canonical_arguments: None,
                     artifacts: Vec::new(),
@@ -2132,6 +2136,7 @@ mod tests {
                         }],
                         ..InvocationSummary::default()
                     },
+                    run: None,
                     metrics: InvocationMetrics::default(),
                     canonical_arguments: None,
                     artifacts: Vec::new(),

--- a/crates/bazel-mcp-types/src/command.rs
+++ b/crates/bazel-mcp-types/src/command.rs
@@ -6,6 +6,7 @@ use serde::{Deserialize, Serialize};
 #[serde(rename_all = "snake_case")]
 pub enum CommandClass {
     BuildLike,
+    Run,
     Query,
     Informational,
     Unsafe,
@@ -39,9 +40,10 @@ impl BazelCommand {
             Self::Build | Self::Test | Self::Coverage | Self::MobileInstall => {
                 CommandClass::BuildLike
             }
+            Self::Run => CommandClass::Run,
             Self::Query | Self::Cquery | Self::Aquery => CommandClass::Query,
             Self::Info | Self::Version | Self::Help | Self::Mod => CommandClass::Informational,
-            Self::Clean | Self::Shutdown | Self::Run => CommandClass::Unsafe,
+            Self::Clean | Self::Shutdown => CommandClass::Unsafe,
             Self::Custom(_) => CommandClass::Unknown,
         }
     }

--- a/crates/bazel-mcp-types/src/inspection.rs
+++ b/crates/bazel-mcp-types/src/inspection.rs
@@ -2,7 +2,7 @@ use serde::{Deserialize, Serialize, Serializer};
 
 use crate::{
     Artifact, BazelCommand, CoverageFile, Diagnostic, InspectHint, InvocationId, InvocationMetrics,
-    InvocationState, QueryRow, TargetCounts, Termination, TestCounts, TestResult,
+    InvocationState, QueryRow, RunSummary, TargetCounts, Termination, TestCounts, TestResult,
 };
 
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
@@ -115,6 +115,8 @@ pub struct InspectSummary {
     pub coverage: Option<InspectCoverageSummary>,
     pub query_result_count: Option<u64>,
     pub query_sample: Vec<QueryRow>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub run: Option<RunSummary>,
     pub elapsed_ms: u64,
     pub truncated: bool,
     pub inspect_hint: Option<InspectHint>,

--- a/crates/bazel-mcp-types/src/invocation.rs
+++ b/crates/bazel-mcp-types/src/invocation.rs
@@ -4,7 +4,7 @@ use serde::{Deserialize, Serialize};
 use thiserror::Error;
 use uuid::Uuid;
 
-use crate::{BazelCommand, InvocationSummary};
+use crate::{BazelCommand, InvocationSummary, RunSummary};
 
 /// Stable, opaque identity for one Bazel invocation.
 #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, Deserialize)]
@@ -58,6 +58,14 @@ pub struct InvocationRequest {
     pub command: BazelCommand,
     #[serde(default)]
     pub arguments: Vec<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub target: Option<String>,
+    /// Arguments passed to the executed program after Bazel's `--` delimiter.
+    ///
+    /// These values are always treated as sensitive and must be replaced before
+    /// an invocation record is persisted.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub program_arguments: Vec<String>,
     pub timeout_ms: Option<u64>,
     #[serde(default)]
     pub environment: BTreeMap<String, String>,
@@ -73,6 +81,8 @@ impl InvocationRequest {
             startup_arguments: Vec::new(),
             command,
             arguments,
+            target: None,
+            program_arguments: Vec::new(),
             timeout_ms: None,
             environment: BTreeMap::new(),
             requested_at_ms: unix_timestamp_ms(),
@@ -158,6 +168,7 @@ pub enum Termination {
     Exit { code: i32 },
     Signal { signal: i32 },
     Timeout,
+    OutputLimit { maximum_bytes: u64 },
     Cancelled,
     SpawnFailure { message: String },
     Interrupted,
@@ -187,6 +198,8 @@ pub struct InvocationRecord {
     pub finished_at_ms: Option<i64>,
     pub termination: Option<Termination>,
     pub summary: Option<InvocationSummary>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub run: Option<RunSummary>,
     pub metrics: InvocationMetrics,
     #[serde(default)]
     pub canonical_arguments: Option<Vec<String>>,
@@ -204,6 +217,7 @@ impl InvocationRecord {
             finished_at_ms: None,
             termination: None,
             summary: None,
+            run: None,
             metrics: InvocationMetrics::default(),
             canonical_arguments: None,
             cancellation_reason: None,

--- a/crates/bazel-mcp-types/src/lib.rs
+++ b/crates/bazel-mcp-types/src/lib.rs
@@ -31,5 +31,7 @@ pub use invocation::{
 };
 pub use pagination::{Page, PageRequest};
 pub use query::QueryRow;
-pub use result::{InspectHint, InvocationSummary, TargetCounts, TargetResult, TestCounts};
+pub use result::{
+    InspectHint, InvocationSummary, RunOutcome, RunSummary, TargetCounts, TargetResult, TestCounts,
+};
 pub use test::{TestCase, TestResult, TestStatus};

--- a/crates/bazel-mcp-types/src/result.rs
+++ b/crates/bazel-mcp-types/src/result.rs
@@ -4,6 +4,31 @@ use crate::{CoverageSummary, Diagnostic, QueryRow, TestResult};
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
+pub enum RunOutcome {
+    BuildFailed,
+    NotLaunched,
+    Succeeded,
+    ProgramFailed,
+    CancelledDuringBuild,
+    CancelledDuringProgram,
+    TimedOutDuringBuild,
+    TimedOutDuringProgram,
+    OutputLimitDuringBuild,
+    OutputLimitDuringProgram,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub struct RunSummary {
+    pub target: String,
+    pub outcome: RunOutcome,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub program_exit_code: Option<i32>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub output_excerpt: Vec<String>,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
 pub enum InspectHint {
     Diagnostics,
     Tests,

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -92,6 +92,8 @@ When `aspect.executable` is omitted, the server resolves `aspect` from its
 `PATH`. The underlying Bazel executable still follows the normal discovery
 rules and is passed to Aspect through `BAZEL_REAL`; commands not listed in
 `aspect.commands` continue to invoke Bazel directly.
+The `run` command cannot be routed through Aspect CLI; its privacy controls
+require the direct Bazel driver.
 
 For build-like Aspect commands (`build`, `test`, and `lint`), bazel-mcp starts
 its loopback BES even when `bep_transport = "tail"`. Aspect keeps ownership of
@@ -132,6 +134,47 @@ redaction_patterns = [
 ```
 
 Raw evidence remains local and should still be treated as sensitive.
+
+### Enable Bazel run
+
+The Bazel `run` command is denied by default because it executes a built target.
+To opt in, add `run` to `allowed_commands` and remove it from
+`denied_commands`. Configuration arrays replace the defaults, so retain every
+other command your clients need:
+
+```toml
+allowed_commands = [
+  "aquery", "build", "coverage", "cquery", "help", "info", "mod",
+  "query", "run", "test", "version",
+]
+denied_commands = ["clean", "fetch", "mobile-install", "shutdown", "sync"]
+```
+
+A run request uses separate Bazel and program argument fields:
+
+```json
+{
+  "workspace": "/src/project",
+  "command": "run",
+  "args": ["--config=dev"],
+  "target": "//cmd/example",
+  "program_args": ["--format=json", "input.txt"],
+  "timeout_seconds": 300
+}
+```
+
+`target` is required and singular. `args` may contain Bazel flags only; valued
+options use `--flag=value`. `program_args` is passed after a server-owned `--`
+delimiter and is always replaced by placeholders in stored metadata, canonical
+arguments, reducer input, and telemetry projections. The server also reserves
+run options that could bypass this boundary, including `--script_path`,
+`--run_under`, `--run_env`, subcommand logging, and the BEP residue controls.
+
+Run support is Unix-only and non-interactive: stdin is connected to null, no
+PTY is allocated, and the invocation keeps Bazel's native output-base lock for
+the lifetime of the foreground program. Use it for finite commands rather than
+long-lived servers. The combined raw stdout and stderr ceiling defaults to 256
+MiB and is configured with `maximum_run_output_bytes`.
 
 ### Choose BEP transport
 
@@ -234,11 +277,11 @@ the native result and add a bounded note. See the
 | `cache_root` | Platform user cache under `bazel-mcp` | Shared directory for metadata, logs, and BEP evidence. Multiple server processes may use the same root concurrently. |
 | `bep_transport` | `tail` | BEP ingestion path: portable private binary file (`tail`), opt-in POSIX named pipe with file fallback (`fifo`), or loopback Build Event Service (`bes`). |
 | `bazel_executable` | unset | Explicit Bazel or Bazelisk executable. |
-| `aspect.commands` | `[]` | Commands routed through Aspect CLI. Each must also be present in `allowed_commands`. |
+| `aspect.commands` | `[]` | Commands routed through Aspect CLI. Each must also be present in `allowed_commands`; `run` is not supported. |
 | `aspect.executable` | unset | Explicit Aspect CLI executable. When unset and Aspect routing is enabled, resolves `aspect` from `PATH`. |
 | `aspect.allow_workspace_mutation` | `false` | Permit known mutation arguments such as `aspect lint --fix`; configured tasks themselves remain operator-trusted. |
 | `output_user_root` | unset | Isolated Bazel output user root managed by the server. |
-| `allowed_commands` | build, test, coverage, query commands, and selected informational commands | Commands eligible to run. |
+| `allowed_commands` | build, test, coverage, query commands, and selected informational commands | Commands eligible to run. Add `run` explicitly to opt in. |
 | `denied_commands` | `clean`, `fetch`, `mobile-install`, `run`, `shutdown`, `sync` | Commands rejected even if also present in `allowed_commands`. |
 | `environment_allowlist` | `[]` | Additional environment variables passed to Bazel. |
 | `redaction_patterns` | `[]` | Regular expressions removed from model-visible and persisted text fields. |
@@ -246,6 +289,7 @@ the native result and add a bounded note. See the
 | `maximum_pending_invocations` | `256` | Maximum queued and running invocations. Must be at least `global_concurrency`. |
 | `default_timeout_seconds` | `1800` | Timeout used when a request omits one. |
 | `maximum_timeout_seconds` | `7200` | Maximum timeout accepted from a request. |
+| `maximum_run_output_bytes` | `268435456` | Combined raw stdout and stderr ceiling for a Bazel run invocation. |
 | `cancellation_interrupt_grace_seconds` | `10` | Time allowed after the initial interrupt. |
 | `cancellation_terminate_grace_seconds` | `5` | Additional time allowed after termination. |
 | `progress_initial_seconds` | `30` | Delay before the first MCP progress notification. |


### PR DESCRIPTION
## Summary

- add opt-in, non-interactive Unix support for `bazel run` with an explicit target/program-argument boundary
- keep program arguments out of durable and model-visible projections while classifying build, launch, and program outcomes from bounded BEP evidence
- enforce a configurable combined stdout/stderr ceiling and document the security and configuration model
- add policy, reducer, server, storage, and fake-Bazel process coverage

## Why

`bazel.run` previously rejected `command = "run"`, forcing clients outside the MCP execution, cancellation, evidence, and inspection lifecycle. This adds the feature without expanding the three-tool surface or allowing interactive execution.

## Impact

`run` remains denied by default and must be explicitly allowlisted. The runner forces non-interactive stdin, disables argument residue in terminal/BEP output, preserves raw local evidence, and exposes a typed `RunSummary` with build/program phase outcomes.

## Validation

- `cargo test --workspace --all-features`
- `make check`

The live Bazel matrix was not run locally because this Codex environment did not expose a Bazel MCP tool; CI remains the live Bazel validation path.
