### PR TITLE
feat(cli): add ephemeral Bazel agent mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,37 @@ No configuration file is required. By default, the server can run Bazel in any
 workspace accessible to the current user. See [Security and local data](#security-and-local-data)
 to restrict it to specific roots.
 
+### Use the filtered Bazel CLI
+
+Harnesses that can launch only a Bazel-style command can use the same bounded
+result without speaking MCP:
+
+```sh
+bazel-mcp passthrough -- test //services/...
+```
+
+Agent mode is also selected when `BAZEL_MCP_MODE=agent` is set or when the
+executable filename is `bazel`, for example through a symlink placed earlier on
+the harness's `PATH`. It accepts ordinary Bazel startup arguments, a configured
+command, and command arguments. The current workspace is discovered by walking
+upward from the launch directory.
+
+Agent mode captures and reduces output through the same runner as `bazel.run`,
+prints the configured JSON or TOON representation, and exits with Bazel's exit
+code. Its raw output and BEP files live only in an invocation-scoped temporary
+directory that is removed before the command returns. Because there is no
+retained invocation, the result does not advertise `bazel.inspect`; truncated
+or otherwise omitted detail instead produces a hint for an unfiltered rerun:
+
+```sh
+bazel --no-agent-mode test //services/...
+```
+
+`--no-agent-mode` must be the first argument. It executes the resolved real
+Bazel with inherited standard input, output, and error streams. Configure
+`bazel_executable` when the shim would otherwise be the only `bazel` on `PATH`;
+the wrapper refuses to resolve itself recursively.
+
 ## Tools
 
 The server exposes three tools:

--- a/crates/bazel-mcp-policy/src/executable.rs
+++ b/crates/bazel-mcp-policy/src/executable.rs
@@ -6,16 +6,34 @@ pub fn resolve_bazel_executable(
     workspace: &Path,
     config: &PolicyConfig,
 ) -> Result<PathBuf, PolicyError> {
+    resolve_bazel_executable_excluding(workspace, config, None)
+}
+
+/// Resolve Bazel while refusing to select the executable currently acting as
+/// the `bazel` agent-mode shim.
+pub fn resolve_bazel_executable_excluding(
+    workspace: &Path,
+    config: &PolicyConfig,
+    excluded: Option<&Path>,
+) -> Result<PathBuf, PolicyError> {
     if let Some(path) = &config.bazel_executable {
-        return executable(path).ok_or_else(|| PolicyError::ExecutableNotFound(path.clone()));
+        let path = executable(path).ok_or_else(|| PolicyError::ExecutableNotFound(path.clone()))?;
+        if is_excluded(&path, excluded) {
+            return Err(PolicyError::ExecutableRecursion(path));
+        }
+        return Ok(path);
     }
     let wrapper = workspace.join("tools/bazel");
-    if let Some(path) = executable(&wrapper) {
+    if let Some(path) = executable(&wrapper).filter(|path| !is_excluded(path, excluded)) {
         return Ok(path);
     }
     for name in ["bazelisk", "bazel"] {
-        if let Ok(path) = which::which(name) {
-            return Ok(path);
+        if let Ok(paths) = which::which_all(name) {
+            for path in paths {
+                if !is_excluded(&path, excluded) {
+                    return Ok(path);
+                }
+            }
         }
     }
     Err(PolicyError::ExecutableNotFound(workspace.to_owned()))
@@ -43,6 +61,16 @@ fn resolve_aspect_on_path(
 ) -> Result<PathBuf, PolicyError> {
     which::which_in("aspect", path, current_dir)
         .map_err(|_| PolicyError::AspectExecutableNotFound(PathBuf::from("aspect")))
+}
+
+fn is_excluded(candidate: &Path, excluded: Option<&Path>) -> bool {
+    let Some(excluded) = excluded else {
+        return false;
+    };
+    match (candidate.canonicalize(), excluded.canonicalize()) {
+        (Ok(candidate), Ok(excluded)) => candidate == excluded,
+        _ => candidate == excluded,
+    }
 }
 
 fn executable(path: &Path) -> Option<PathBuf> {
@@ -108,5 +136,27 @@ mod tests {
             resolve_aspect_on_path(Some(root.path().as_os_str()), root.path()).unwrap(),
             aspect
         );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn rejects_an_explicit_executable_that_resolves_to_the_agent_shim() {
+        use std::os::unix::fs::{PermissionsExt, symlink};
+
+        let root = tempdir().unwrap();
+        let executable = root.path().join("bazel-mcp");
+        let shim = root.path().join("bazel");
+        fs::write(&executable, "#!/bin/sh\n").unwrap();
+        fs::set_permissions(&executable, fs::Permissions::from_mode(0o700)).unwrap();
+        symlink(&executable, &shim).unwrap();
+        let config = PolicyConfig {
+            bazel_executable: Some(shim.clone()),
+            ..PolicyConfig::default()
+        };
+
+        assert!(matches!(
+            resolve_bazel_executable_excluding(root.path(), &config, Some(&executable)),
+            Err(PolicyError::ExecutableRecursion(path)) if path == shim
+        ));
     }
 }

--- a/crates/bazel-mcp-policy/src/lib.rs
+++ b/crates/bazel-mcp-policy/src/lib.rs
@@ -11,7 +11,9 @@ mod workspace;
 pub use command::validate_command;
 pub use config::{PolicyConfig, RawPolicyConfig};
 pub use environment::filtered_environment;
-pub use executable::{resolve_aspect_executable, resolve_bazel_executable};
+pub use executable::{
+    resolve_aspect_executable, resolve_bazel_executable, resolve_bazel_executable_excluding,
+};
 pub use flags::{
     INTERNAL_BEP_FLAG, effective_output_base, validate_arguments, validate_aspect_arguments,
     validate_query_arguments,
@@ -59,6 +61,8 @@ pub enum PolicyError {
     AspectReservedArgument(String),
     #[error("Aspect lint --fix is disabled; set aspect.allow_workspace_mutation = true to opt in")]
     AspectWorkspaceMutationDenied,
+    #[error("resolved Bazel executable would recursively launch the agent-mode shim: {0}")]
+    ExecutableRecursion(PathBuf),
     #[error("invalid redaction expression {pattern:?}: {source}")]
     InvalidRedaction {
         pattern: String,

--- a/crates/bazel-mcp-server/BUILD.bazel
+++ b/crates/bazel-mcp-server/BUILD.bazel
@@ -44,6 +44,22 @@ rust_test(
 )
 
 rust_test(
+    name = "agent_cli_test",
+    srcs = ["tests/agent_cli.rs"],
+    data = [":bazel-mcp"],
+    size = "small",
+    deps = all_crate_deps(
+        cargo_only = True,
+        normal = True,
+        normal_dev = True,
+    ),
+    target_compatible_with = select({
+        "@platforms//os:windows": ["@platforms//:incompatible"],
+        "//conditions:default": [],
+    }),
+)
+
+rust_test(
     name = "shutdown_test",
     srcs = ["tests/shutdown.rs"],
     data = [":bazel-mcp"],

--- a/crates/bazel-mcp-server/Cargo.toml
+++ b/crates/bazel-mcp-server/Cargo.toml
@@ -28,6 +28,7 @@ rmcp.workspace = true
 schemars.workspace = true
 serde.workspace = true
 serde_json.workspace = true
+tempfile.workspace = true
 tokio.workspace = true
 tokio-util.workspace = true
 toon-format.workspace = true

--- a/crates/bazel-mcp-server/src/agent.rs
+++ b/crates/bazel-mcp-server/src/agent.rs
@@ -1,0 +1,382 @@
+//! Ephemeral CLI frontend that presents the bounded `bazel.run` result.
+
+use std::{
+    collections::BTreeSet,
+    ffi::{OsStr, OsString},
+    io::Write,
+    path::{Path, PathBuf},
+    process::{ExitCode, ExitStatus, Stdio},
+};
+
+use anyhow::{Context, bail};
+use bazel_mcp_policy::{PolicyConfig, resolve_bazel_executable_excluding};
+use bazel_mcp_runner::{InvocationService, RunnerConfig};
+use bazel_mcp_store::Store;
+use bazel_mcp_types::{BazelCommand, InvocationRecord, InvocationRequest, Termination};
+use tempfile::Builder;
+use tokio::process::Command;
+use tokio_util::sync::CancellationToken;
+
+use crate::{
+    Cli, McpConfig, ValidatedServerConfig,
+    result::{ResultEncoder, RunResultBuilder},
+};
+
+const AGENT_MODE_ENV: &str = "BAZEL_MCP_MODE";
+const NO_AGENT_MODE: &str = "--no-agent-mode";
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum LaunchMode {
+    Mcp,
+    Agent(Vec<OsString>),
+}
+
+#[must_use]
+pub fn detect_launch<I>(arguments: I) -> LaunchMode
+where
+    I: IntoIterator<Item = OsString>,
+{
+    detect_launch_with_mode(arguments, std::env::var_os(AGENT_MODE_ENV).as_deref())
+}
+
+fn detect_launch_with_mode<I>(arguments: I, environment_mode: Option<&OsStr>) -> LaunchMode
+where
+    I: IntoIterator<Item = OsString>,
+{
+    let mut arguments = arguments.into_iter();
+    let executable = arguments.next().unwrap_or_default();
+    let mut remaining = arguments.collect::<Vec<_>>();
+    let shim_name = Path::new(&executable)
+        .file_name()
+        .and_then(OsStr::to_str)
+        .is_some_and(|name| matches!(name, "bazel" | "bazel.exe"));
+    let environment_mode = environment_mode
+        .and_then(OsStr::to_str)
+        .is_some_and(|mode| mode == "agent");
+    let explicit_mode = remaining
+        .first()
+        .is_some_and(|argument| argument == "passthrough");
+
+    if !(shim_name || environment_mode || explicit_mode) {
+        return LaunchMode::Mcp;
+    }
+    if explicit_mode {
+        remaining.remove(0);
+        if remaining.first().is_some_and(|argument| argument == "--") {
+            remaining.remove(0);
+        }
+    }
+    LaunchMode::Agent(remaining)
+}
+
+#[must_use]
+pub fn agent_log_filter() -> String {
+    std::env::var("BAZEL_MCP_LOG").unwrap_or_else(|_| "bazel_mcp=warn".to_owned())
+}
+
+pub async fn run_agent(arguments: Vec<OsString>) -> ExitCode {
+    match run_agent_inner(arguments).await {
+        Ok(result) => {
+            if let Some(output) = result.output {
+                let mut stdout = std::io::stdout().lock();
+                if let Err(error) = writeln!(stdout, "{output}") {
+                    eprintln!("bazel-mcp agent mode failed: could not write result: {error}");
+                    return ExitCode::FAILURE;
+                }
+            }
+            process_exit_code(result.exit_code)
+        }
+        Err(error) => {
+            eprintln!("bazel-mcp agent mode failed: {error:#}");
+            ExitCode::from(2)
+        }
+    }
+}
+
+struct AgentResult {
+    output: Option<String>,
+    exit_code: i32,
+}
+
+async fn run_agent_inner(mut arguments: Vec<OsString>) -> anyhow::Result<AgentResult> {
+    let raw = arguments
+        .first()
+        .is_some_and(|argument| argument == NO_AGENT_MODE);
+    if raw {
+        arguments.remove(0);
+    }
+
+    let launch_directory = std::env::current_dir().context("read current directory")?;
+    let workspace = discover_workspace(&launch_directory);
+    let cli = agent_cli();
+    let mut config = ValidatedServerConfig::load(&cli)?;
+    let policy = PolicyConfig::from(&config);
+    let lookup_directory = workspace.as_deref().unwrap_or(&launch_directory);
+    let current_executable = std::env::current_exe().context("resolve current executable")?;
+    let bazel_executable =
+        resolve_bazel_executable_excluding(lookup_directory, &policy, Some(&current_executable))?;
+
+    if raw {
+        return run_unfiltered(&bazel_executable, &launch_directory, &arguments).await;
+    }
+
+    let workspace = workspace.ok_or_else(|| {
+        anyhow::anyhow!(
+            "could not find MODULE.bazel, WORKSPACE.bazel, or WORKSPACE in {} or its ancestors",
+            launch_directory.display()
+        )
+    })?;
+    let parsed = parse_bazel_arguments(&arguments, &policy)?;
+    let scratch = Builder::new()
+        .prefix("bazel-mcp-agent-")
+        .tempdir()
+        .context("create ephemeral invocation store")?;
+    config = config.with_agent_runtime(scratch.path().to_owned(), bazel_executable);
+    let result_encoding = McpConfig::from(&config).result_encoding;
+    let store = Store::open(config.cache_root())
+        .await
+        .context("open ephemeral invocation store")?;
+    let runner = InvocationService::start(store.clone(), RunnerConfig::from(&config)).await?;
+    let mut request = InvocationRequest::new(workspace, parsed.command, parsed.arguments);
+    request.startup_arguments = parsed.startup_arguments;
+    let cancellation = CancellationToken::new();
+    let signal_cancellation = cancellation.clone();
+    let signal = tokio::spawn(async move {
+        crate::shutdown_signal().await;
+        signal_cancellation.cancel();
+    });
+    let record = runner.run_with_cancellation(request, cancellation).await;
+    signal.abort();
+    let record = record.context("run filtered Bazel invocation")?;
+    let output = RunResultBuilder::new(ResultEncoder::new(result_encoding))
+        .build_cli(&record)
+        .map_err(anyhow::Error::msg)?;
+    let exit_code = invocation_exit_code(&record);
+    drop(runner);
+    drop(store);
+    scratch
+        .close()
+        .context("remove ephemeral invocation store")?;
+    Ok(AgentResult {
+        output: Some(output),
+        exit_code,
+    })
+}
+
+fn agent_cli() -> Cli {
+    Cli {
+        config: std::env::var_os("BAZEL_MCP_CONFIG").map(PathBuf::from),
+        allowed_roots: Vec::new(),
+        cache_root: None,
+        log: "bazel_mcp=warn".to_owned(),
+    }
+}
+
+struct ParsedBazelArguments {
+    startup_arguments: Vec<String>,
+    command: BazelCommand,
+    arguments: Vec<String>,
+}
+
+fn parse_bazel_arguments(
+    arguments: &[OsString],
+    policy: &PolicyConfig,
+) -> anyhow::Result<ParsedBazelArguments> {
+    if arguments.is_empty() {
+        return Ok(ParsedBazelArguments {
+            startup_arguments: Vec::new(),
+            command: BazelCommand::Help,
+            arguments: Vec::new(),
+        });
+    }
+    if arguments.len() == 1 && matches!(arguments[0].to_str(), Some("--version" | "--help")) {
+        return Ok(ParsedBazelArguments {
+            startup_arguments: Vec::new(),
+            command: if arguments[0] == "--version" {
+                BazelCommand::Version
+            } else {
+                BazelCommand::Help
+            },
+            arguments: Vec::new(),
+        });
+    }
+
+    let command_names = policy
+        .allowed_commands
+        .union(&policy.denied_commands)
+        .map(String::as_str)
+        .collect::<BTreeSet<_>>();
+    let command_index = arguments.iter().position(|argument| {
+        argument
+            .to_str()
+            .is_some_and(|argument| command_names.contains(argument))
+    });
+    let Some(command_index) = command_index else {
+        bail!(
+            "could not identify a configured Bazel command in argv; use --no-agent-mode for unsupported Bazel syntax"
+        );
+    };
+    let strings = arguments
+        .iter()
+        .map(|argument| {
+            argument.to_str().map(str::to_owned).ok_or_else(|| {
+                anyhow::anyhow!(
+                    "agent mode accepts only UTF-8 Bazel arguments; use --no-agent-mode for arbitrary platform arguments"
+                )
+            })
+        })
+        .collect::<anyhow::Result<Vec<_>>>()?;
+    let command = strings[command_index]
+        .parse::<BazelCommand>()
+        .expect("BazelCommand parsing is infallible");
+    Ok(ParsedBazelArguments {
+        startup_arguments: strings[..command_index].to_vec(),
+        command,
+        arguments: strings[command_index + 1..].to_vec(),
+    })
+}
+
+fn discover_workspace(start: &Path) -> Option<PathBuf> {
+    let start = start.canonicalize().ok()?;
+    start.ancestors().find_map(|directory| {
+        ["MODULE.bazel", "WORKSPACE.bazel", "WORKSPACE"]
+            .iter()
+            .any(|marker| directory.join(marker).is_file())
+            .then(|| directory.to_owned())
+    })
+}
+
+async fn run_unfiltered(
+    executable: &Path,
+    launch_directory: &Path,
+    arguments: &[OsString],
+) -> anyhow::Result<AgentResult> {
+    let status = Command::new(executable)
+        .args(arguments)
+        .current_dir(launch_directory)
+        .env_remove(AGENT_MODE_ENV)
+        .stdin(Stdio::inherit())
+        .stdout(Stdio::inherit())
+        .stderr(Stdio::inherit())
+        .status()
+        .await
+        .with_context(|| format!("run unfiltered Bazel at {}", executable.display()))?;
+    Ok(AgentResult {
+        output: None,
+        exit_code: status_exit_code(status),
+    })
+}
+
+fn invocation_exit_code(record: &InvocationRecord) -> i32 {
+    match record.termination.as_ref() {
+        Some(Termination::Exit { code }) => *code,
+        Some(Termination::Signal { signal }) => 128_i32.saturating_add(*signal),
+        Some(Termination::Timeout) => 124,
+        Some(Termination::Cancelled) => 130,
+        Some(Termination::SpawnFailure { .. } | Termination::Interrupted) | None => 1,
+    }
+}
+
+fn status_exit_code(status: ExitStatus) -> i32 {
+    if let Some(code) = status.code() {
+        return code;
+    }
+    #[cfg(unix)]
+    {
+        use std::os::unix::process::ExitStatusExt;
+        status.signal().map_or(1, |signal| 128 + signal)
+    }
+    #[cfg(not(unix))]
+    1
+}
+
+fn process_exit_code(code: i32) -> ExitCode {
+    u8::try_from(code)
+        .map(ExitCode::from)
+        .unwrap_or(ExitCode::FAILURE)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+
+    use tempfile::tempdir;
+
+    use super::*;
+
+    fn os(arguments: &[&str]) -> Vec<OsString> {
+        arguments.iter().map(OsString::from).collect()
+    }
+
+    #[test]
+    fn detects_each_agent_mode_entrypoint() {
+        assert_eq!(
+            detect_launch_with_mode(os(&["/tmp/bazel", "test", "//..."]), None),
+            LaunchMode::Agent(os(&["test", "//..."]))
+        );
+        assert!(matches!(
+            detect_launch_with_mode(os(&["/tmp/bazel.exe", "test", "//..."]), None),
+            LaunchMode::Agent(_)
+        ));
+        assert_eq!(
+            detect_launch_with_mode(
+                os(&["bazel-mcp", "build", "//..."]),
+                Some(OsStr::new("agent"))
+            ),
+            LaunchMode::Agent(os(&["build", "//..."]))
+        );
+        assert_eq!(
+            detect_launch_with_mode(
+                os(&["bazel-mcp", "passthrough", "--", "query", "//..."]),
+                None
+            ),
+            LaunchMode::Agent(os(&["query", "//..."]))
+        );
+        assert_eq!(
+            detect_launch_with_mode(os(&["bazel-mcp", "--config", "config.toml"]), None),
+            LaunchMode::Mcp
+        );
+    }
+
+    #[test]
+    fn parses_startup_arguments_around_a_configured_command() {
+        let parsed = parse_bazel_arguments(
+            &os(&[
+                "--output_base",
+                "/tmp/output",
+                "test",
+                "//pkg:all",
+                "--test_filter=one",
+            ]),
+            &PolicyConfig::default(),
+        )
+        .unwrap();
+
+        assert_eq!(parsed.startup_arguments, ["--output_base", "/tmp/output"]);
+        assert_eq!(parsed.command, BazelCommand::Test);
+        assert_eq!(parsed.arguments, ["//pkg:all", "--test_filter=one"]);
+    }
+
+    #[test]
+    fn translates_common_commandless_forms() {
+        let empty = parse_bazel_arguments(&[], &PolicyConfig::default()).unwrap();
+        assert_eq!(empty.command, BazelCommand::Help);
+        let version = parse_bazel_arguments(&os(&["--version"]), &PolicyConfig::default()).unwrap();
+        assert_eq!(version.command, BazelCommand::Version);
+        let help = parse_bazel_arguments(&os(&["--help"]), &PolicyConfig::default()).unwrap();
+        assert_eq!(help.command, BazelCommand::Help);
+    }
+
+    #[test]
+    fn discovers_the_nearest_workspace_from_a_subdirectory() {
+        let root = tempdir().unwrap();
+        let nested = root.path().join("one/two");
+        fs::create_dir_all(&nested).unwrap();
+        fs::write(root.path().join("MODULE.bazel"), "").unwrap();
+
+        assert_eq!(
+            discover_workspace(&nested),
+            Some(root.path().canonicalize().unwrap())
+        );
+    }
+}

--- a/crates/bazel-mcp-server/src/config.rs
+++ b/crates/bazel-mcp-server/src/config.rs
@@ -273,6 +273,16 @@ impl ValidatedServerConfig {
         &self.cache_root
     }
 
+    pub(crate) fn with_agent_runtime(
+        mut self,
+        cache_root: PathBuf,
+        bazel_executable: PathBuf,
+    ) -> Self {
+        self.cache_root = cache_root;
+        self.runner.policy.bazel_executable = Some(bazel_executable);
+        self
+    }
+
     #[must_use]
     pub fn shutdown_wait(&self) -> Duration {
         self.runner

--- a/crates/bazel-mcp-server/src/lib.rs
+++ b/crates/bazel-mcp-server/src/lib.rs
@@ -1,11 +1,13 @@
 //! Thin stdio MCP boundary for the Bazel invocation service.
 
+mod agent;
 mod config;
 mod handler;
 mod protocol;
 mod result;
 mod tasks;
 
+pub use agent::{LaunchMode, agent_log_filter, detect_launch, run_agent};
 pub use bazel_mcp_runner::BepTransport;
 pub use config::{
     Cli, McpConfig, McpExecutionPolicy, RawAspectConfig, RawMcpConfig, RawPolicyConfig,

--- a/crates/bazel-mcp-server/src/main.rs
+++ b/crates/bazel-mcp-server/src/main.rs
@@ -1,14 +1,38 @@
 use clap::Parser;
 use tracing_subscriber::EnvFilter;
 
-use bazel_mcp_server::{Cli, ValidatedServerConfig};
+use bazel_mcp_server::{
+    Cli, LaunchMode, ValidatedServerConfig, agent_log_filter, detect_launch, run_agent,
+};
 
 fn main() -> std::process::ExitCode {
-    let cli = Cli::parse();
+    let launch = detect_launch(std::env::args_os());
+    match launch {
+        LaunchMode::Mcp => run_mcp(Cli::parse()),
+        LaunchMode::Agent(arguments) => run_agent_mode(arguments),
+    }
+}
+
+fn run_mcp(cli: Cli) -> std::process::ExitCode {
     tracing_subscriber::fmt()
         .with_env_filter(EnvFilter::new(&cli.log))
         .with_writer(std::io::stderr)
         .init();
+    run_runtime(run_server(cli))
+}
+
+fn run_agent_mode(arguments: Vec<std::ffi::OsString>) -> std::process::ExitCode {
+    tracing_subscriber::fmt()
+        .with_env_filter(EnvFilter::new(agent_log_filter()))
+        .with_writer(std::io::stderr)
+        .init();
+    run_runtime(run_agent(arguments))
+}
+
+fn run_runtime<F>(future: F) -> std::process::ExitCode
+where
+    F: std::future::Future<Output = std::process::ExitCode>,
+{
     let runtime = match tokio::runtime::Builder::new_multi_thread()
         .enable_all()
         .build()
@@ -19,7 +43,7 @@ fn main() -> std::process::ExitCode {
             return std::process::ExitCode::FAILURE;
         }
     };
-    let result = runtime.block_on(run(cli));
+    let result = runtime.block_on(future);
     // Tokio's standard-input adapter may own a blocking read that cannot be
     // interrupted by SIGTERM while an MCP client keeps the pipe open. Bound
     // runtime teardown after the service has cancelled and joined Bazel work.
@@ -27,7 +51,7 @@ fn main() -> std::process::ExitCode {
     result
 }
 
-async fn run(cli: Cli) -> std::process::ExitCode {
+async fn run_server(cli: Cli) -> std::process::ExitCode {
     match ValidatedServerConfig::load(&cli) {
         Ok(config) => match bazel_mcp_server::serve(config).await {
             Ok(()) => std::process::ExitCode::SUCCESS,

--- a/crates/bazel-mcp-server/src/result.rs
+++ b/crates/bazel-mcp-server/src/result.rs
@@ -29,12 +29,26 @@ pub(crate) struct EncodedResult {
 pub(crate) struct ExecutionResult<'a> {
     pub(crate) record: &'a InvocationRecord,
     pub(crate) tool_error: bool,
+    pub(crate) retained: bool,
 }
 
 impl<'a> ExecutionResult<'a> {
     #[must_use]
     pub(crate) const fn new(record: &'a InvocationRecord, tool_error: bool) -> Self {
-        Self { record, tool_error }
+        Self {
+            record,
+            tool_error,
+            retained: true,
+        }
+    }
+
+    #[must_use]
+    pub(crate) const fn ephemeral(record: &'a InvocationRecord) -> Self {
+        Self {
+            record,
+            tool_error: false,
+            retained: false,
+        }
     }
 }
 
@@ -57,6 +71,8 @@ struct RunResult {
     inspect_hint: Option<InspectHint>,
     available_views: AvailableViews,
     more_available: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    rerun_hint: Option<&'static str>,
 }
 
 impl ResultEncoder {
@@ -141,7 +157,11 @@ impl RunResultBuilder {
     }
 
     pub(crate) fn build(&self, execution: ExecutionResult<'_>) -> Result<EncodedResult, String> {
-        let ExecutionResult { record, tool_error } = execution;
+        let ExecutionResult {
+            record,
+            tool_error,
+            retained,
+        } = execution;
         let exit_code = match &record.termination {
             Some(Termination::Exit { code }) => Some(*code),
             _ => None,
@@ -150,6 +170,10 @@ impl RunResultBuilder {
             .summary
             .as_ref()
             .ok_or_else(|| "completed invocation has no summary".to_owned())?;
+        let follow_up_available = summary.truncated
+            || !summary.targets.is_empty()
+            || !summary.tests.is_empty()
+            || summary.inspect_hint.is_some();
         let mut result = RunResult {
             invocation_id: record.request.id.to_string(),
             state: record.state,
@@ -163,12 +187,15 @@ impl RunResultBuilder {
             query_result_count: summary.query_result_count,
             query_sample: summary.query_sample.clone(),
             truncated: summary.truncated,
-            inspect_hint: summary.inspect_hint,
-            available_views: AvailableViews::follow_up(),
-            more_available: summary.truncated
-                || !summary.targets.is_empty()
-                || !summary.tests.is_empty()
-                || summary.inspect_hint.is_some(),
+            inspect_hint: if retained { summary.inspect_hint } else { None },
+            available_views: if retained {
+                AvailableViews::follow_up()
+            } else {
+                AvailableViews::none()
+            },
+            more_available: retained && follow_up_available,
+            rerun_hint: (!retained && follow_up_available)
+                .then_some("rerun with --no-agent-mode for unfiltered Bazel output"),
         };
         let limit = if summary.success { 2 * 1024 } else { 8 * 1024 };
         loop {
@@ -180,7 +207,10 @@ impl RunResultBuilder {
                 return Ok(encoded);
             }
             result.truncated = true;
-            result.more_available = true;
+            result.more_available = retained;
+            if !retained {
+                result.rerun_hint = Some("rerun with --no-agent-mode for unfiltered Bazel output");
+            }
             if result.query_sample.pop().is_some() || result.diagnostics.pop().is_some() {
                 continue;
             }
@@ -189,6 +219,19 @@ impl RunResultBuilder {
             }
             return Err("bounded bazel.run response could not fit its hard byte limit".into());
         }
+    }
+
+    pub(crate) fn build_cli(&self, record: &InvocationRecord) -> Result<String, String> {
+        let encoded = self.build(ExecutionResult::ephemeral(record))?;
+        if let Some(ContentBlock::Text(text)) = encoded.result.content.first() {
+            return Ok(text.text.clone());
+        }
+        encoded
+            .result
+            .structured_content
+            .as_ref()
+            .ok_or_else(|| "encoded result has no CLI representation".to_owned())
+            .and_then(|value| serde_json::to_string(value).map_err(|error| error.to_string()))
     }
 }
 
@@ -240,10 +283,15 @@ fn shrink_utf8(value: &mut String, minimum: usize) -> bool {
 
 #[cfg(test)]
 mod tests {
-    use bazel_mcp_types::{InspectPayload, InspectResult, InspectView};
+    use std::path::PathBuf;
+
+    use bazel_mcp_types::{
+        BazelCommand, InspectPayload, InspectResult, InspectView, InvocationRecord,
+        InvocationRequest, InvocationState, InvocationSummary, Termination,
+    };
     use rmcp::model::ContentBlock;
 
-    use super::{ResultEncoder, shrink_utf8};
+    use super::{ResultEncoder, RunResultBuilder, shrink_utf8};
     use crate::ResultEncoding;
 
     #[test]
@@ -252,6 +300,37 @@ mod tests {
         assert!(shrink_utf8(&mut value, 16));
         assert!(value.ends_with('…'));
         assert!(value.len() < 203);
+    }
+
+    #[test]
+    fn oversized_ephemeral_results_offer_a_rerun_without_promising_inspection() {
+        let request = InvocationRequest::new(
+            PathBuf::from("/workspace"),
+            BazelCommand::Build,
+            vec!["//:target".to_owned()],
+        );
+        let mut record = InvocationRecord::queued(request);
+        record.state = InvocationState::Failed;
+        record.termination = Some(Termination::Exit { code: 1 });
+        record.summary = Some(InvocationSummary {
+            success: false,
+            headline: "failure ".repeat(4_000),
+            ..InvocationSummary::default()
+        });
+
+        let text = RunResultBuilder::new(ResultEncoder::new(ResultEncoding::Text))
+            .build_cli(&record)
+            .unwrap();
+        let value: serde_json::Value = serde_json::from_str(&text).unwrap();
+
+        assert_eq!(value["truncated"], true);
+        assert_eq!(value["available_views"], serde_json::json!([]));
+        assert_eq!(value["more_available"], false);
+        assert_eq!(
+            value["rerun_hint"],
+            "rerun with --no-agent-mode for unfiltered Bazel output"
+        );
+        assert!(text.len() <= 8 * 1024);
     }
 
     #[test]

--- a/crates/bazel-mcp-server/tests/agent_cli.rs
+++ b/crates/bazel-mcp-server/tests/agent_cli.rs
@@ -1,0 +1,182 @@
+#![cfg(unix)]
+
+use std::{
+    fs,
+    os::unix::fs::{PermissionsExt, symlink},
+    path::PathBuf,
+    process::{Command, Output},
+};
+
+struct Fixture {
+    _root: tempfile::TempDir,
+    workspace: PathBuf,
+    config: PathBuf,
+    configured_cache: PathBuf,
+    temporary_root: PathBuf,
+}
+
+impl Fixture {
+    fn new() -> Self {
+        let root = tempfile::tempdir().unwrap();
+        let workspace = root.path().join("workspace");
+        let nested = workspace.join("pkg/subdir");
+        let fake_bazel = root.path().join("real-bazel");
+        let config = root.path().join("config.toml");
+        let configured_cache = root.path().join("configured-cache-must-stay-unused");
+        let temporary_root = root.path().join("temporary");
+        fs::create_dir_all(&nested).unwrap();
+        fs::create_dir(&temporary_root).unwrap();
+        fs::write(workspace.join("MODULE.bazel"), "module(name='agent_cli')\n").unwrap();
+        fs::write(
+            &fake_bazel,
+            r#"#!/bin/sh
+if [ "${1:-}" = "--version" ]; then
+  printf 'bazel 9.1.0\n'
+  exit 0
+fi
+printf 'RAW_STDOUT should not be replayed\n'
+printf 'ERROR: RAW_SECRET synthetic compiler failure\n' >&2
+exit 7
+"#,
+        )
+        .unwrap();
+        fs::set_permissions(&fake_bazel, fs::Permissions::from_mode(0o700)).unwrap();
+        fs::write(
+            &config,
+            format!(
+                "allowed_roots = [{workspace:?}]\ncache_root = {configured_cache:?}\nbazel_executable = {fake_bazel:?}\nresult_encoding = \"text\"\nredaction_patterns = [\"RAW_SECRET\"]\n"
+            ),
+        )
+        .unwrap();
+        Self {
+            _root: root,
+            workspace: nested,
+            config,
+            configured_cache,
+            temporary_root,
+        }
+    }
+
+    fn command(&self) -> Command {
+        let mut command = Command::new(bazel_mcp_binary());
+        command
+            .current_dir(&self.workspace)
+            .env("BAZEL_MCP_CONFIG", &self.config)
+            .env("TMPDIR", &self.temporary_root)
+            .env_remove("BAZEL_MCP_LOG");
+        command
+    }
+
+    fn assert_ephemeral_storage_removed(&self) {
+        assert!(
+            !self.configured_cache.exists(),
+            "agent mode used the configured persistent cache"
+        );
+        assert_eq!(fs::read_dir(&self.temporary_root).unwrap().count(), 0);
+    }
+}
+
+fn assert_filtered(output: &Output) {
+    assert_eq!(output.status.code(), Some(7));
+    assert!(
+        output.stderr.is_empty(),
+        "{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let value: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(value["state"], "failed");
+    assert_eq!(value["exit_code"], 7);
+    assert_eq!(value["available_views"], serde_json::json!([]));
+    assert_eq!(value["more_available"], false);
+    assert!(value.get("inspect_hint").is_none());
+    assert_eq!(
+        value["rerun_hint"],
+        "rerun with --no-agent-mode for unfiltered Bazel output"
+    );
+    assert!(!String::from_utf8_lossy(&output.stdout).contains("RAW_SECRET"));
+    assert!(String::from_utf8_lossy(&output.stdout).contains("[REDACTED]"));
+}
+
+#[test]
+fn environment_mode_returns_the_bounded_result_and_deletes_its_store() {
+    let fixture = Fixture::new();
+    let output = fixture
+        .command()
+        .env("BAZEL_MCP_MODE", "agent")
+        .args(["build", "//:failure"])
+        .output()
+        .unwrap();
+
+    assert_filtered(&output);
+    fixture.assert_ephemeral_storage_removed();
+}
+
+#[test]
+fn explicit_passthrough_mode_returns_the_bounded_result() {
+    let fixture = Fixture::new();
+    let output = fixture
+        .command()
+        .args(["passthrough", "--", "build", "//:failure"])
+        .output()
+        .unwrap();
+
+    assert_filtered(&output);
+    fixture.assert_ephemeral_storage_removed();
+}
+
+#[test]
+fn bazel_filename_activates_agent_mode() {
+    let fixture = Fixture::new();
+    let shim = fixture.temporary_root.join("bazel");
+    symlink(bazel_mcp_binary(), &shim).unwrap();
+    let output = Command::new(&shim)
+        .current_dir(&fixture.workspace)
+        .env("BAZEL_MCP_CONFIG", &fixture.config)
+        .env("TMPDIR", &fixture.temporary_root)
+        .env_remove("BAZEL_MCP_MODE")
+        .env_remove("BAZEL_MCP_LOG")
+        .args(["build", "//:failure"])
+        .output()
+        .unwrap();
+
+    assert_filtered(&output);
+    fs::remove_file(&shim).unwrap();
+    fixture.assert_ephemeral_storage_removed();
+}
+
+fn bazel_mcp_binary() -> PathBuf {
+    let path = PathBuf::from(env!("CARGO_BIN_EXE_bazel-mcp"));
+    let path = if path.is_absolute() {
+        path
+    } else {
+        std::env::current_dir().unwrap().join(path)
+    };
+    assert!(
+        path.is_file(),
+        "bazel-mcp test binary is missing at {}",
+        path.display()
+    );
+    path
+}
+
+#[test]
+fn no_agent_mode_inherits_raw_output_and_exit_status() {
+    let fixture = Fixture::new();
+    let output = fixture
+        .command()
+        .env("BAZEL_MCP_MODE", "agent")
+        .args(["--no-agent-mode", "build", "//:failure"])
+        .output()
+        .unwrap();
+
+    assert_eq!(output.status.code(), Some(7));
+    assert_eq!(
+        String::from_utf8(output.stdout).unwrap(),
+        "RAW_STDOUT should not be replayed\n"
+    );
+    assert_eq!(
+        String::from_utf8(output.stderr).unwrap(),
+        "ERROR: RAW_SECRET synthetic compiler failure\n"
+    );
+    fixture.assert_ephemeral_storage_removed();
+}

--- a/crates/bazel-mcp-types/src/inspection.rs
+++ b/crates/bazel-mcp-types/src/inspection.rs
@@ -73,6 +73,11 @@ pub struct AvailableViews(Vec<InspectView>);
 
 impl AvailableViews {
     #[must_use]
+    pub const fn none() -> Self {
+        Self(Vec::new())
+    }
+
+    #[must_use]
     pub fn follow_up() -> Self {
         Self(InspectView::FOLLOW_UP.to_vec())
     }

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -104,6 +104,10 @@ inject Aspect's `--bazel-startup-flag`, task identity, or local capture header.
 Configured Aspect tasks are operator-trusted code and may have other side
 effects that bazel-mcp cannot infer from their names.
 
+An explicit executable is especially useful when `bazel-mcp` is installed as
+a symlink named `bazel` for agent-mode CLI use. Executable discovery skips the
+currently running shim and fails instead of recursively launching it.
+
 ### Pass environment variables
 
 Child Bazel processes always receive `HOME`, `PATH`, `TMPDIR`, `TEMP`, `TMP`,
@@ -286,7 +290,7 @@ metrics view. Owner labels are deliberately bounded and omit workspace paths.
 
 ## CLI options
 
-Run `bazel-mcp --help` for the authoritative command-line reference:
+Run `bazel-mcp --help` for the MCP server option reference:
 
 | Option | Description |
 | --- | --- |
@@ -297,3 +301,38 @@ Run `bazel-mcp --help` for the authoritative command-line reference:
 
 Standard output is reserved for MCP protocol frames. Tracing and diagnostics
 are always written to standard error.
+
+## Agent-mode CLI
+
+Agent mode exposes the bounded `bazel.run` presentation to harnesses that can
+invoke only a Bazel-shaped CLI. Any of these forms select it:
+
+```sh
+bazel-mcp passthrough -- build //app:server
+BAZEL_MCP_MODE=agent bazel-mcp test //services/...
+bazel query 'deps(//app:server)'
+```
+
+The third form applies when the launched executable filename is `bazel`, such
+as a symlink to `bazel-mcp`. `BAZEL_MCP_CONFIG` and the normal default config
+path select configuration; Bazel-shaped argv is not parsed for MCP-only
+`--config`, `--allow-root`, or `--cache-root` options.
+
+The CLI discovers the nearest workspace ancestor, applies the configured
+command and argument policy, captures through the ordinary runner, prints the
+configured bounded result, and preserves Bazel's exit code. Capture uses a
+private temporary filesystem store that is deleted before exit. Consequently
+`available_views` is empty, `inspect_hint` is omitted, and a truncated result
+or other normally inspectable detail produces a `rerun_hint` instead of
+promising retained evidence.
+
+Put `--no-agent-mode` first to bypass capture and filtering:
+
+```sh
+bazel --no-agent-mode query --output=label 'deps(//app:server)'
+```
+
+The bypass invokes the resolved Bazel directly with inherited stdio and the
+original remaining arguments. It intentionally bypasses agent-mode command and
+flag policy. `BAZEL_MCP_LOG` optionally enables wrapper tracing in agent mode;
+the default emits warnings and errors only.

--- a/specs/001-product-requirements.md
+++ b/specs/001-product-requirements.md
@@ -371,6 +371,31 @@ The server supports four deployment-level result encodings:
 The encoding is server configuration, not a per-call argument. The benchmark
 MUST use the encoding intended for the production MCP host.
 
+### 8.6 Ephemeral agent-mode CLI
+
+The `bazel-mcp` executable exposes the `bazel.run` capture, reduction, and
+bounded presentation pipeline to CLI-only agent harnesses. Agent mode is
+selected when the executable basename is `bazel`, `BAZEL_MCP_MODE=agent` is
+set, or the invocation begins with `bazel-mcp passthrough --`.
+
+- The launch directory is resolved to its nearest Bazel workspace ancestor.
+- Bazel argv is split into startup arguments, a configured command, and command
+  arguments without shell evaluation.
+- Execution uses `InvocationService`, the normal command and flag policy, the
+  configured reducers and redaction, and the configured result encoding.
+- Raw output and BEP evidence are captured in a private invocation-scoped
+  filesystem store. That store is removed before normal process exit and is
+  never added to the persistent invocation ledger.
+- The final bounded result is written to stdout and the CLI exits with Bazel's
+  exit code. Non-Bazel wrapper failures use exit code 2.
+- An ephemeral result MUST NOT advertise inspection views or an inspect hint.
+  When omitted evidence exists, it provides a bounded rerun hint instead.
+- A leading `--no-agent-mode` removes the wrapper flag and invokes the resolved
+  real Bazel with inherited stdio and the remaining argv. This bypass is
+  explicit and does not apply agent-mode command or presentation policy.
+- Executable discovery MUST reject the current shim to prevent recursive
+  self-launch.
+
 ## 9. Workspace and Bazel discovery
 
 ### 9.1 Workspace validation

--- a/specs/002-project-architecture.md
+++ b/specs/002-project-architecture.md
@@ -514,13 +514,18 @@ thin.
 
 Responsibilities:
 
-- Parse CLI options and locate server configuration.
+- Select stdio MCP or ephemeral agent-mode CLI startup, parse the applicable
+  options or Bazel argv, and locate server configuration.
 - Initialize tracing without writing application logs to MCP stdout.
 - Construct `InvocationService` and run startup recovery.
 - Serve MCP over stdio.
 - Define and route exactly `bazel.run`, `bazel.inspect`, and `bazel.cancel`.
 - Map MCP progress and cancellation to `InvocationService`.
-- Encode tool results according to the configured result encoding.
+- Encode MCP and ephemeral CLI results from one bounded logical result according
+  to the configured result encoding.
+- Give agent-mode invocations private temporary store roots and remove them
+  before normal CLI exit; only stdio MCP mode runs retention and exposes
+  inspection.
 - Report tool-execution errors separately from failed Bazel invocations.
 
 Suggested layout:


### PR DESCRIPTION
## Summary

- add an ephemeral CLI frontend selected when the executable is named `bazel`, `BAZEL_MCP_MODE=agent` is set, or `bazel-mcp passthrough --` is used
- reuse the normal invocation service and bounded result renderer, while using a temporary evidence store and returning no inspection promises
- add `--no-agent-mode` as an explicit raw-Bazel escape hatch, with recursion-safe executable discovery
- document the harness setup and cover every activation path, exit status, redaction, cache isolation, and temporary-store cleanup

## Why

Some agent harnesses can invoke a Bazel-shaped CLI but cannot call MCP tools directly. This lets those harnesses treat bazel-mcp as `bazel` and receive the same compact, filtered result that `bazel.run` produces, without adding persistence or changing the MCP tool surface.

## Impact

MCP server mode remains unchanged and continues to expose exactly `bazel.run`, `bazel.inspect`, and `bazel.cancel`. Agent CLI mode is intentionally ephemeral: it prints one bounded result, preserves the Bazel exit status, and discards its temporary evidence store. Callers can rerun with `--no-agent-mode` when they need native Bazel output.

## Validation

- `make test`
- `make check`
- `target/debug/bazel-mcp passthrough -- test //crates/bazel-mcp-server:unit_test //crates/bazel-mcp-server:agent_cli_test` (2 targets and tests passed with Bazel 9.2.0)
- `target/debug/bazel-mcp passthrough -- --no-agent-mode --version` (reported `bazel 9.2.0`)
- `git diff --check`

The full multi-version Bazel matrix was not run.
