### PR TITLE
chore: deny unaudited unsafe code

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,9 @@ description = "A token-efficient MCP server for Bazel invocations"
 keywords = ["bazel", "mcp", "llm", "build"]
 categories = ["command-line-utilities", "development-tools"]
 
+[workspace.lints.rust]
+unsafe_code = "deny"
+
 [workspace.dependencies]
 # Internal crates
 bazel-mcp-bep = { path = "crates/bazel-mcp-bep" }

--- a/crates/bazel-mcp-benchmark/Cargo.toml
+++ b/crates/bazel-mcp-benchmark/Cargo.toml
@@ -8,6 +8,9 @@ authors.workspace = true
 repository.workspace = true
 publish = false
 
+[lints]
+workspace = true
+
 [dependencies]
 anyhow.workspace = true
 bazel-mcp-bep.workspace = true

--- a/crates/bazel-mcp-benchmark/src/bin/storage-benchmark.rs
+++ b/crates/bazel-mcp-benchmark/src/bin/storage-benchmark.rs
@@ -1070,10 +1070,18 @@ fn peak_rss_bytes() -> Option<u64> {
     let mut usage = std::mem::MaybeUninit::<libc::rusage>::zeroed();
     // SAFETY: `usage` points to writable storage for `getrusage`, and is only
     // assumed initialized after the operating system reports success.
+    #[expect(
+        unsafe_code,
+        reason = "libc::getrusage writes benchmark process resource usage"
+    )]
     if unsafe { libc::getrusage(libc::RUSAGE_SELF, usage.as_mut_ptr()) } != 0 {
         return None;
     }
     // SAFETY: a successful `getrusage` call initialized the entire structure.
+    #[expect(
+        unsafe_code,
+        reason = "successful getrusage initialized the rusage value"
+    )]
     let raw = unsafe { usage.assume_init() }.ru_maxrss;
     let raw = u64::try_from(raw).ok()?;
     #[cfg(target_os = "macos")]

--- a/crates/bazel-mcp-bep/Cargo.toml
+++ b/crates/bazel-mcp-bep/Cargo.toml
@@ -9,6 +9,9 @@ repository.workspace = true
 publish = false
 build = "build.rs"
 
+[lints]
+workspace = true
+
 [dependencies]
 buffa.workspace = true
 thiserror.workspace = true

--- a/crates/bazel-mcp-bes/Cargo.toml
+++ b/crates/bazel-mcp-bes/Cargo.toml
@@ -8,6 +8,9 @@ authors.workspace = true
 repository.workspace = true
 publish = false
 
+[lints]
+workspace = true
+
 [dependencies]
 bazel-mcp-bep.workspace = true
 buffa.workspace = true

--- a/crates/bazel-mcp-policy/Cargo.toml
+++ b/crates/bazel-mcp-policy/Cargo.toml
@@ -8,6 +8,9 @@ authors.workspace = true
 repository.workspace = true
 publish = false
 
+[lints]
+workspace = true
+
 [dependencies]
 bazel-mcp-types.workspace = true
 regex.workspace = true
@@ -17,4 +20,3 @@ which.workspace = true
 
 [dev-dependencies]
 tempfile.workspace = true
-

--- a/crates/bazel-mcp-reducer-cases/Cargo.toml
+++ b/crates/bazel-mcp-reducer-cases/Cargo.toml
@@ -9,6 +9,9 @@ repository.workspace = true
 description.workspace = true
 publish = false
 
+[lints]
+workspace = true
+
 [dependencies]
 anyhow.workspace = true
 bazel-mcp-bep.workspace = true

--- a/crates/bazel-mcp-reducer/Cargo.toml
+++ b/crates/bazel-mcp-reducer/Cargo.toml
@@ -8,6 +8,9 @@ authors.workspace = true
 repository.workspace = true
 publish = false
 
+[lints]
+workspace = true
+
 [dependencies]
 anyhow.workspace = true
 bazel-mcp-bep.workspace = true

--- a/crates/bazel-mcp-runner/Cargo.toml
+++ b/crates/bazel-mcp-runner/Cargo.toml
@@ -8,6 +8,9 @@ authors.workspace = true
 repository.workspace = true
 publish = false
 
+[lints]
+workspace = true
+
 [dependencies]
 bazel-mcp-bep.workspace = true
 bazel-mcp-bes.workspace = true

--- a/crates/bazel-mcp-runner/src/capture.rs
+++ b/crates/bazel-mcp-runner/src/capture.rs
@@ -768,6 +768,10 @@ fn is_process_alive(pid: u32) -> bool {
     }
     // SAFETY: signal 0 performs a POSIX liveness/permission check and does not
     // deliver a signal to the target process.
+    #[expect(
+        unsafe_code,
+        reason = "libc::kill is the POSIX process-liveness primitive"
+    )]
     let result = unsafe { libc::kill(pid as libc::pid_t, 0) };
     result == 0 || io::Error::last_os_error().raw_os_error() == Some(libc::EPERM)
 }

--- a/crates/bazel-mcp-runner/src/output_base_lock.rs
+++ b/crates/bazel-mcp-runner/src/output_base_lock.rs
@@ -105,6 +105,10 @@ pub(crate) fn default_output_base_lock_root() -> PathBuf {
         // Use a process-environment-independent root so MCP instances launched
         // by different hosts still share one advisory-lock namespace.
         // SAFETY: geteuid has no preconditions and does not mutate memory.
+        #[expect(
+            unsafe_code,
+            reason = "libc::geteuid is the Unix effective-user-id primitive"
+        )]
         let identity = unsafe { libc::geteuid() };
         PathBuf::from("/tmp").join(format!("bazel-mcp-output-base-locks-{identity}"))
     }
@@ -379,6 +383,10 @@ fn process_exists(pid: u32) -> bool {
         return false;
     };
     // SAFETY: signal 0 performs process-existence and permission checks only.
+    #[expect(
+        unsafe_code,
+        reason = "libc::kill is the POSIX process-existence primitive"
+    )]
     if unsafe { libc::kill(pid, 0) } == 0 {
         return true;
     }

--- a/crates/bazel-mcp-server/Cargo.toml
+++ b/crates/bazel-mcp-server/Cargo.toml
@@ -10,6 +10,9 @@ homepage.workspace = true
 description.workspace = true
 publish = false
 
+[lints]
+workspace = true
+
 [package.metadata.dist]
 dist = true
 

--- a/crates/bazel-mcp-store/Cargo.toml
+++ b/crates/bazel-mcp-store/Cargo.toml
@@ -8,6 +8,9 @@ authors.workspace = true
 repository.workspace = true
 publish = false
 
+[lints]
+workspace = true
+
 [dependencies]
 base64.workspace = true
 bazel-mcp-types.workspace = true

--- a/crates/bazel-mcp-types/Cargo.toml
+++ b/crates/bazel-mcp-types/Cargo.toml
@@ -8,6 +8,9 @@ authors.workspace = true
 repository.workspace = true
 publish = false
 
+[lints]
+workspace = true
+
 [dependencies]
 serde.workspace = true
 thiserror.workspace = true

--- a/crates/diagnostic-reducer/Cargo.toml
+++ b/crates/diagnostic-reducer/Cargo.toml
@@ -9,6 +9,9 @@ repository.workspace = true
 description = "Deterministic, source-agnostic reduction of compiler and test diagnostics"
 publish = false
 
+[lints]
+workspace = true
+
 [features]
 test-support = []
 

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -6,6 +6,12 @@ publish = false
 
 [workspace]
 
+[workspace.lints.rust]
+unsafe_code = "deny"
+
+[lints]
+workspace = true
+
 [package.metadata]
 cargo-fuzz = true
 


### PR DESCRIPTION
## Summary

- deny unaudited Rust `unsafe` code across every root workspace crate
- apply the same policy to the standalone fuzz workspace
- keep the five existing audited operations behind statement-level `#[expect(unsafe_code, reason = "...")]` exceptions

## Why

The workspace previously allowed new unsafe blocks by default. This makes unsafe code a compile-time error unless the specific operation carries an explicit, reviewed exception. The policy uses `deny` because Rust `forbid` cannot be overridden for audited call sites.

## Impact

This is a compile-time policy change only; runtime behavior is unchanged. The statement-level expectations also become stale-lint failures if an unsafe operation is removed or moved away from its documented exception.

## Validation

- `make test`
- `make check`
- `cargo check --manifest-path fuzz/Cargo.toml --all-targets`
- `git diff --check origin/main...HEAD`
