### PR TITLE
chore(security): harden repository supply chain

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,36 @@
+version: 2
+
+updates:
+  - package-ecosystem: cargo
+    directory: "/"
+    schedule:
+      interval: weekly
+    cooldown:
+      default-days: 7
+    open-pull-requests-limit: 5
+
+  - package-ecosystem: cargo
+    directory: "/fuzz"
+    schedule:
+      interval: weekly
+    cooldown:
+      default-days: 7
+    open-pull-requests-limit: 2
+
+  - package-ecosystem: npm
+    directories:
+      - "/website"
+      - "/scripts/compat"
+    schedule:
+      interval: weekly
+    cooldown:
+      default-days: 7
+    open-pull-requests-limit: 5
+
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+    cooldown:
+      default-days: 7
+    open-pull-requests-limit: 5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -126,7 +126,7 @@ jobs:
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with: { persist-credentials: false }
-      - uses: cachix/install-nix-action@7e1d5bdb99afadeb0885b07e3913a4240e12ede5 # v31
+      - uses: cachix/install-nix-action@630ae543ea3a38a9a4166f03376c02c50f408342 # v31.11.0
       - run: nix flake check
   zizmor:
     permissions:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,13 +6,14 @@ on:
 concurrency:
   group: ci-${{ github.ref }}
   cancel-in-progress: true
-permissions:
-  contents: read
+permissions: {}
 env:
   CARGO_INCREMENTAL: "0"
   CARGO_TERM_COLOR: always
 jobs:
   lint:
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
@@ -23,6 +24,8 @@ jobs:
       - run: cargo clippy --workspace --all-targets --all-features -- -D warnings
       - run: cargo install cargo-shear --version 1.12.0 --locked && cargo shear
   bazel-build:
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
@@ -46,6 +49,8 @@ jobs:
       - run: PATH="$HOME/go/bin:$PATH" bazelisk test --config=ci //crates/...
       - run: PATH="$HOME/go/bin:$PATH" make build BAZEL_BUILD_FLAGS=--config=ci
   cargo-test-linux:
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
@@ -54,6 +59,8 @@ jobs:
       - run: cargo test --workspace --all-features
       - run: cargo test --workspace --doc
   cargo-test-macos:
+    permissions:
+      contents: read
     runs-on: macos-latest
     timeout-minutes: 30
     steps:
@@ -61,6 +68,8 @@ jobs:
         with: { persist-credentials: false }
       - run: cargo test --workspace --all-features
   cargo-check-windows:
+    permissions:
+      contents: read
     runs-on: windows-latest
     timeout-minutes: 30
     steps:
@@ -68,6 +77,8 @@ jobs:
         with: { persist-credentials: false }
       - run: cargo check --workspace --all-targets --all-features
   windows-release-smoke:
+    permissions:
+      contents: read
     runs-on: windows-latest
     timeout-minutes: 30
     # PR CI validates native linking, archive layout, and startup. Tagged releases
@@ -80,7 +91,7 @@ jobs:
         with: { persist-credentials: false }
       - name: Install dist
         shell: pwsh
-        run: irm https://github.com/axodotdev/cargo-dist/releases/download/v0.31.0/cargo-dist-installer.ps1 | iex
+        run: ./scripts/install-cargo-dist.ps1
       - name: Build Windows release archive
         shell: pwsh
         run: dist build --print=linkage --output-format=json --artifacts=local --target=x86_64-pc-windows-msvc > dist-manifest.json
@@ -88,6 +99,8 @@ jobs:
         shell: pwsh
         run: ./scripts/smoke-windows-release.ps1
   cargo-deny:
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
@@ -96,6 +109,8 @@ jobs:
       - run: cargo install cargo-deny --version 0.20.2 --locked
       - run: cargo deny check
   cargo-audit:
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
@@ -104,6 +119,8 @@ jobs:
       - run: cargo install cargo-audit --version 0.22.2 --locked
       - run: cargo audit
   nix-flake-check:
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
@@ -112,14 +129,21 @@ jobs:
       - uses: cachix/install-nix-action@7e1d5bdb99afadeb0885b07e3913a4240e12ede5 # v31
       - run: nix flake check
   zizmor:
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with: { persist-credentials: false }
       - run: python3 -m unittest scripts/test_publish_github_release_assets.py
-      - run: pipx run zizmor .github/workflows
+      - name: Audit GitHub Actions supply chain
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: pipx run --spec zizmor==1.25.2 zizmor .github
   bazel-matrix:
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     timeout-minutes: 45
     steps:
@@ -139,6 +163,8 @@ jobs:
       - run: go install github.com/bazelbuild/bazelisk@v1.26.0
       - run: PATH="$HOME/go/bin:$PATH" ./scripts/test-bazel-matrix.sh
   mcp-conformance:
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
@@ -146,6 +172,8 @@ jobs:
         with: { persist-credentials: false }
       - run: make mcp-conformance
   claude-code-compatibility:
+    permissions:
+      contents: read
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]
@@ -159,6 +187,8 @@ jobs:
       - run: npm ci --prefix scripts/compat
       - run: PATH="$PWD/scripts/compat/node_modules/.bin:$PATH" make test-claude-code
   fuzz-smoke:
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     timeout-minutes: 25
     steps:

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,0 +1,30 @@
+name: Dependency review
+
+on:
+  pull_request:
+    paths:
+      - ".github/dependabot.yml"
+      - ".github/workflows/**"
+      - "**/Cargo.lock"
+      - "**/Cargo.toml"
+      - "**/package-lock.json"
+      - "**/package.json"
+
+permissions: {}
+
+concurrency:
+  group: dependency-review-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  dependency-review:
+    name: Reject vulnerable dependency changes
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    steps:
+      - name: Review dependency changes
+        uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294 # v5.0.0
+        with:
+          fail-on-severity: moderate

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -30,14 +30,19 @@ on:
         default: false
         type: boolean
 
-permissions:
-  contents: read
+permissions: {}
+
+concurrency:
+  group: docs-${{ github.ref }}-${{ inputs.deploy || false }}
+  cancel-in-progress: ${{ inputs.deploy != true }}
 
 jobs:
   build:
     name: Build documentation
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with: { persist-credentials: false }
@@ -67,8 +72,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:
-      pages: write
-      id-token: write
+      pages: write # Publishes the validated Pages artifact.
+      id-token: write # Authenticates the Pages deployment via OIDC.
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -3,13 +3,14 @@ on:
   workflow_dispatch:
   schedule:
     - cron: "43 5 * * 6"
-permissions:
-  contents: read
+permissions: {}
 concurrency:
   group: fuzz-${{ github.ref }}
   cancel-in-progress: false
 jobs:
   fuzz:
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     timeout-minutes: 45
     strategy:
@@ -21,7 +22,10 @@ jobs:
         with: { persist-credentials: false }
       - run: rustup toolchain install nightly --profile minimal
       - run: cargo install cargo-fuzz --version 0.13.2 --locked
-      - run: cd fuzz && cargo +nightly fuzz run ${{ matrix.target }} -- -max_total_time=300
+      - name: Fuzz selected target
+        env:
+          FUZZ_TARGET: ${{ matrix.target }}
+        run: cd fuzz && cargo +nightly fuzz run "$FUZZ_TARGET" -- -max_total_time=300
       - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         if: failure()
         with:

--- a/.github/workflows/reducer-integration.yml
+++ b/.github/workflows/reducer-integration.yml
@@ -49,8 +49,7 @@ concurrency:
   group: reducer-integration-${{ github.ref }}
   cancel-in-progress: true
 
-permissions:
-  contents: read
+permissions: {}
 
 env:
   CARGO_INCREMENTAL: "0"
@@ -65,6 +64,8 @@ jobs:
         os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     timeout-minutes: 20
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with: { persist-credentials: false }
@@ -77,6 +78,8 @@ jobs:
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     timeout-minutes: 45
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
@@ -99,6 +102,8 @@ jobs:
       (github.event_name == 'workflow_dispatch' && inputs.tier == 'smoke')
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with: { persist-credentials: false }
@@ -121,6 +126,8 @@ jobs:
         bazel: [8.4.2, 9.2.0]
     runs-on: ${{ matrix.os }}
     timeout-minutes: 60
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with: { persist-credentials: false }
@@ -137,10 +144,12 @@ jobs:
             echo "MCP_SERVER_BIN=$PWD/target/debug/bazel-mcp" >> "$GITHUB_ENV"
           fi
       - name: Verify all supported fast cases through MCP
+        env:
+          BAZEL_VERSION: ${{ matrix.bazel }}
         shell: bash
         run: >-
           cargo run -p bazel-mcp-reducer-cases -- verify --live
-          --tag fast --bazel-version "${{ matrix.bazel }}"
+          --tag fast --bazel-version "$BAZEL_VERSION"
           --server "$MCP_SERVER_BIN" --bazel "$BAZELISK_BIN"
 
   reducer-live-heavy:
@@ -148,6 +157,8 @@ jobs:
     if: github.event_name == 'workflow_dispatch' && inputs.tier == 'heavy'
     runs-on: ubuntu-latest
     timeout-minutes: 120
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with: { persist-credentials: false }

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -2,8 +2,7 @@ name: Release Please
 on:
   push:
     branches: [main]
-permissions:
-  contents: read
+permissions: {}
 concurrency:
   group: release-please
   cancel-in-progress: false
@@ -12,8 +11,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     permissions:
-      contents: write
-      pull-requests: write
+      contents: write # Creates the release tag and GitHub release.
+      pull-requests: write # Updates the managed release pull request.
     outputs:
       release_created: ${{ steps.release.outputs.release_created }}
       tag_name: ${{ steps.release.outputs.tag_name }}
@@ -28,7 +27,9 @@ jobs:
     needs: release
     if: ${{ needs.release.outputs.release_created == 'true' }}
     permissions:
-      contents: write
+      contents: write # Publishes assets to the GitHub release.
+      attestations: write # Stores Sigstore provenance for release assets.
+      id-token: write # Authenticates release attestations via OIDC.
     uses: ./.github/workflows/release.yml
     with:
       tag: ${{ needs.release.outputs.tag_name }}
@@ -40,8 +41,8 @@ jobs:
     if: ${{ needs.release.outputs.release_created == 'true' }}
     permissions:
       contents: read
-      pages: write
-      id-token: write
+      pages: write # Publishes the validated Pages artifact.
+      id-token: write # Authenticates the Pages deployment via OIDC.
     uses: ./.github/workflows/docs.yml
     with:
       deploy: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,8 +14,7 @@
 # title/body based on your changelogs.
 
 name: Release
-permissions:
-  "contents": "read"
+permissions: {}
 concurrency:
   group: release-${{ inputs.tag || github.ref }}
   cancel-in-progress: false
@@ -73,7 +72,7 @@ jobs:
     runs-on: "ubuntu-22.04"
     timeout-minutes: 15
     permissions:
-      contents: write
+      contents: write # Lets cargo-dist inspect or create the selected release.
     outputs:
       val: ${{ steps.plan.outputs.manifest }}
       publishing: ${{ !github.event.pull_request }}
@@ -86,10 +85,8 @@ jobs:
           ref: ${{ env.RELEASE_TAG }}
           submodules: recursive
       - name: Install dist
-        # we specify bash to get pipefail; it guards against the `curl` command
-        # failing. otherwise `sh` won't catch that `curl` returned non-0
         shell: bash
-        run: "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/v0.31.0/cargo-dist-installer.sh | sh"
+        run: ./scripts/install-cargo-dist.sh
       # Pass the validated tag input through the environment instead of expanding
       # event data directly into shell source.
       - id: plan
@@ -126,6 +123,8 @@ jobs:
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       BUILD_MANIFEST_NAME: target/distrib/${{ join(matrix.targets, '-') }}-dist-manifest.json
+    permissions:
+      contents: read
     steps:
       - name: enable windows longpaths
         run: |
@@ -140,11 +139,11 @@ jobs:
         # Install a native binary for this matrix runner. Reusing the plan
         # job's binary breaks on ARM Linux and macOS runners.
         shell: bash
-        run: "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/v0.31.0/cargo-dist-installer.sh | sh"
+        run: ./scripts/install-cargo-dist.sh
       - name: Install dist (Windows)
         if: ${{ runner.os == 'Windows' }}
         shell: pwsh
-        run: irm https://github.com/axodotdev/cargo-dist/releases/download/v0.31.0/cargo-dist-installer.ps1 | iex
+        run: ./scripts/install-cargo-dist.ps1
       # Get the dist-manifest
       - name: Fetch local artifacts
         uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7
@@ -209,6 +208,8 @@ jobs:
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       BUILD_MANIFEST_NAME: target/distrib/global-dist-manifest.json
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
@@ -217,7 +218,7 @@ jobs:
           submodules: recursive
       - name: Install dist
         shell: bash
-        run: "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/v0.31.0/cargo-dist-installer.sh | sh"
+        run: ./scripts/install-cargo-dist.sh
       # Get all the local artifacts for the global tasks to use (for e.g. checksums)
       - name: Fetch local artifacts
         uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7
@@ -262,7 +263,9 @@ jobs:
     runs-on: "ubuntu-22.04"
     timeout-minutes: 30
     permissions:
-      contents: write
+      contents: write # Uploads artifacts to the GitHub release.
+      attestations: write # Stores Sigstore provenance for release assets.
+      id-token: write # Authenticates release attestations via OIDC.
     outputs:
       val: ${{ steps.host.outputs.manifest }}
     steps:
@@ -283,7 +286,7 @@ jobs:
           sparse-checkout-cone-mode: false
       - name: Install dist
         shell: bash
-        run: "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/v0.31.0/cargo-dist-installer.sh | sh"
+        run: ./scripts/install-cargo-dist.sh
       # Fetch artifacts from scratch-storage
       - name: Fetch artifacts
         uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7
@@ -316,6 +319,10 @@ jobs:
         run: |
           # Remove the granular manifests
           rm -f artifacts/*-dist-manifest.json
+      - name: Attest release artifacts
+        uses: actions/attest@f7c74d28b9d84cb8768d0b8ca14a4bac6ef463e6 # v4.2.0
+        with:
+          subject-path: artifacts/*
       - name: Publish GitHub release artifacts
         env:
           ANNOUNCEMENT_IS_PRERELEASE: "${{ fromJson(steps.host.outputs.manifest).announcement_is_prerelease }}"
@@ -347,6 +354,8 @@ jobs:
       GITHUB_USER: "axo bot"
       GITHUB_EMAIL: "admin+bot@axo.dev"
     if: ${{ !fromJson(needs.plan.outputs.val).announcement_is_prerelease || fromJson(needs.plan.outputs.val).publish_prereleases }}
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
@@ -395,6 +404,8 @@ jobs:
     timeout-minutes: 10
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:

--- a/.github/workflows/remote-integration.yml
+++ b/.github/workflows/remote-integration.yml
@@ -10,13 +10,14 @@ on:
         description: BES or BuildBuddy endpoint accepted by Bazel
         required: true
         type: string
-permissions:
-  contents: read
+permissions: {}
 concurrency:
   group: remote-bazel-integration
   cancel-in-progress: false
 jobs:
   remote-execution-and-bes:
+    permissions:
+      contents: read
     runs-on: ubuntu-24.04
     environment: remote-integration
     timeout-minutes: 60

--- a/.github/workflows/token-integration.yml
+++ b/.github/workflows/token-integration.yml
@@ -3,13 +3,14 @@ on:
   workflow_dispatch:
   schedule:
     - cron: "17 7 * * 1"
-permissions:
-  contents: read
+permissions: {}
 concurrency:
   group: token-integration
   cancel-in-progress: false
 jobs:
   abseil:
+    permissions:
+      contents: read
     strategy:
       fail-fast: false
       matrix:

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -10,3 +10,17 @@ and regex redaction reduce risk but do not make untrusted repositories safe.
 Use a sandbox or isolated account for untrusted source. Invocation logs and BEP
 files may contain source paths and compiler output; they are stored with private
 permissions, retained locally, and should be treated as sensitive.
+
+## Supply-chain verification
+
+Release workflows use commit-pinned GitHub Actions, least-privilege job tokens,
+checksum-verified tool bootstrapping, cache-free release builds, and OIDC-backed
+Sigstore attestations. Release archives include SHA-256 checksums and a locked
+CycloneDX SBOM.
+
+After downloading a release asset, verify its provenance and integrity with:
+
+```console
+gh attestation verify <asset> --repo ewhauser/bazel-mcp
+shasum -a 256 --check <checksums-file>
+```

--- a/scripts/check-release-security.py
+++ b/scripts/check-release-security.py
@@ -7,8 +7,13 @@ root = pathlib.Path(__file__).resolve().parents[1]
 errors = []
 for workflow in (root / ".github/workflows").glob("*.yml"):
     source = workflow.read_text()
-    if "permissions:" not in source or "timeout-minutes:" not in source:
-        errors.append(f"{workflow.name}: missing permissions or timeout")
+    if not re.search(r"(?m)^permissions: \{\}$", source):
+        errors.append(f"{workflow.name}: workflow permissions must default to none")
+    if "timeout-minutes:" not in source:
+        errors.append(f"{workflow.name}: missing job timeout")
+    for dangerous_trigger in ("pull_request_target", "workflow_run"):
+        if re.search(rf"(?m)^\s*{dangerous_trigger}\s*:", source):
+            errors.append(f"{workflow.name}: forbidden trigger: {dangerous_trigger}")
     for line in source.splitlines():
         if "uses:" in line:
             reference = line.split("uses:", 1)[1].split("#", 1)[0].strip()
@@ -18,6 +23,18 @@ for workflow in (root / ".github/workflows").glob("*.yml"):
                 errors.append(f"{workflow.name}: action is not pinned: {reference}")
     if "actions/checkout" in source and "persist-credentials: false" not in source:
         errors.append(f"{workflow.name}: checkout credentials are not disabled")
+
+release_source = (root / ".github/workflows/release.yml").read_text()
+if re.search(r"(?m)^\s+uses: actions/cache@|^\s+cache:\s*", release_source):
+    errors.append("release.yml: release jobs must not restore mutable caches")
+if "actions/attest@" not in release_source:
+    errors.append("release.yml: release artifacts must receive build provenance")
+if "install-cargo-dist.sh" not in release_source or "install-cargo-dist.ps1" not in release_source:
+    errors.append("release.yml: cargo-dist must use checksum-verifying installers")
+
+dependabot_source = (root / ".github/dependabot.yml").read_text()
+if "cooldown:" not in dependabot_source or "default-days: 7" not in dependabot_source:
+    errors.append("dependabot.yml: dependency updates must use a seven-day cooldown")
 if errors:
     print("\n".join(errors), file=sys.stderr)
     raise SystemExit(1)

--- a/scripts/install-cargo-dist.ps1
+++ b/scripts/install-cargo-dist.ps1
@@ -1,0 +1,17 @@
+$ErrorActionPreference = "Stop"
+
+$distVersion = "0.31.0"
+$installerSha256 = "ffec5b52cfbe29465d831150b01f8a254668fc271e5102fab7aea7da5d51ec69"
+$installerUrl = "https://github.com/axodotdev/cargo-dist/releases/download/v$distVersion/cargo-dist-installer.ps1"
+$installer = Join-Path ([System.IO.Path]::GetTempPath()) "cargo-dist-installer-$PID.ps1"
+
+try {
+    Invoke-WebRequest -Uri $installerUrl -OutFile $installer
+    $actualSha256 = (Get-FileHash -Algorithm SHA256 -Path $installer).Hash.ToLowerInvariant()
+    if ($actualSha256 -ne $installerSha256) {
+        throw "cargo-dist installer checksum mismatch: expected $installerSha256, got $actualSha256"
+    }
+    & $installer
+} finally {
+    Remove-Item -Path $installer -Force -ErrorAction SilentlyContinue
+}

--- a/scripts/install-cargo-dist.sh
+++ b/scripts/install-cargo-dist.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+readonly DIST_VERSION="0.31.0"
+readonly INSTALLER_SHA256="e79d87e418b9d2cbe992d014985457c28a5a7c553add3da4ed1047e161c928f4"
+readonly INSTALLER_URL="https://github.com/axodotdev/cargo-dist/releases/download/v${DIST_VERSION}/cargo-dist-installer.sh"
+
+installer="$(mktemp)"
+trap 'rm -f "$installer"' EXIT
+
+curl --proto '=https' --tlsv1.2 --location --silent --show-error --fail \
+  --output "$installer" "$INSTALLER_URL"
+echo "${INSTALLER_SHA256}  ${installer}" | shasum -a 256 --check
+sh "$installer"


### PR DESCRIPTION
## Summary

- default every workflow to no permissions and grant capabilities per job
- enforce commit-pinned Actions, reject dangerous triggers, and audit workflows with pinned zizmor
- add Dependabot cooldowns and pull-request dependency vulnerability review
- replace mutable cargo-dist installer execution with checksum verification
- generate OIDC-backed Sigstore attestations for release assets while keeping release builds cache-free
- document release verification and extend the repository security gate

## Why

The repository already pinned direct Actions and used read-only default tokens, but it did not enforce those controls comprehensively or protect against mutable release-tool bootstrapping, newly introduced vulnerable dependencies, or unattested release artifacts. These changes apply the practical CI/CD, release, and dependency controls described in Astral's open-source security guidance.

## Impact

Contributors receive dependency vulnerability feedback on pull requests. Maintainers get delayed routine dependency updates, stricter workflow validation, checksum-verified release tooling, and verifiable release provenance. Release consumers can verify assets with `gh attestation verify`.

The associated live repository hardening was applied separately: Actions PR approvals are disabled, Actions are restricted and SHA pinning is required, Dependabot alerts/security updates are enabled, and active no-bypass rulesets protect `main` and `v*` tags.

Immutable GitHub releases remain disabled because the existing Release Please flow publishes a release before attaching its assets; enabling immutability without redesigning that sequence would break releases.

## Validation

- `make test`
- `make check`
- `python3 scripts/check-release-security.py`
- `uvx --from zizmor==1.25.2 zizmor .github`
- `python3 -m unittest scripts/test_publish_github_release_assets.py`
- `git diff --check`
