### PR TITLE
chore(deps): limit Dependabot to security updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,7 +7,7 @@ updates:
       interval: weekly
     cooldown:
       default-days: 7
-    open-pull-requests-limit: 5
+    open-pull-requests-limit: 0
 
   - package-ecosystem: cargo
     directory: "/fuzz"
@@ -15,7 +15,7 @@ updates:
       interval: weekly
     cooldown:
       default-days: 7
-    open-pull-requests-limit: 2
+    open-pull-requests-limit: 0
 
   - package-ecosystem: npm
     directories:
@@ -25,7 +25,7 @@ updates:
       interval: weekly
     cooldown:
       default-days: 7
-    open-pull-requests-limit: 5
+    open-pull-requests-limit: 0
 
   - package-ecosystem: github-actions
     directory: "/"
@@ -33,4 +33,4 @@ updates:
       interval: weekly
     cooldown:
       default-days: 7
-    open-pull-requests-limit: 5
+    open-pull-requests-limit: 0


### PR DESCRIPTION
## Summary

- disable routine Dependabot version-update pull requests for Cargo, npm, and GitHub Actions
- retain each ecosystem entry so Dependabot security updates continue to use the configured manifest paths

## Why

Scheduled version updates create routine dependency pull requests that are not wanted for this repository. Setting `open-pull-requests-limit` to `0` is GitHub's supported security-only configuration; security update pull requests use a separate limit.

## Impact

Dependabot will only open pull requests for vulnerable dependencies. Routine new-version notifications will no longer create pull requests.

## Validation

- parsed `.github/dependabot.yml` with Ruby YAML
- verified all four update entries have a zero version-update PR limit
- ran `git diff --check`