### PR TITLE
chore(ci): add Hawk dead-code checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,28 @@ jobs:
       - run: cargo fmt --all -- --check
       - run: cargo clippy --workspace --all-targets --all-features -- -D warnings
       - run: cargo install cargo-shear --version 1.12.0 --locked && cargo shear
+  hawk:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with: { persist-credentials: false }
+      - name: Install Hawk toolchain
+        run: rustup toolchain install 1.97.0 --profile minimal
+      - name: Install Hawk
+        shell: bash
+        run: |
+          archive="$RUNNER_TEMP/cargo-hawk.tar.gz"
+          install_dir="$RUNNER_TEMP/cargo-hawk"
+          curl --proto '=https' --tlsv1.2 -LsSf \
+            -o "$archive" \
+            https://github.com/astral-sh/hawk/releases/download/0.1.8/cargo-hawk-x86_64-unknown-linux-gnu.tar.gz
+          echo "a95e5772f1c853c2cfeeadb96d00ae4c9592312052334d5c642974d1cd436dd9  $archive" \
+            | sha256sum --check
+          mkdir -p "$install_dir"
+          tar -xzf "$archive" --strip-components=1 -C "$install_dir"
+          echo "$install_dir" >> "$GITHUB_PATH"
+      - run: make hawk
   bazel-build:
     permissions:
       contents: read

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,10 +4,11 @@ Install the pinned Rust toolchain, Bazelisk, Git, a C++ toolchain, and the tools
 provided by `nix develop`. Run `make setup-hooks` once per checkout.
 
 Use the root Makefile as the stable interface. Before opening a pull request,
-run `make check` and `make test`; run `make test-bazel-matrix` for runner, BEP,
-policy, or reducer changes. Reducer changes require reviewed fixture/snapshot
-diffs. Raw fixtures must not contain usernames, hostnames, credentials, or
-absolute local paths.
+run `make check`, `make test`, and `make hawk`; Hawk requires the prebuilt 0.1.8
+release on `PATH` and its pinned Rust 1.97.0 toolchain. Run
+`make test-bazel-matrix` for runner, BEP, policy, or reducer changes. Reducer
+changes require reviewed fixture/snapshot diffs. Raw fixtures must not contain
+usernames, hostnames, credentials, or absolute local paths.
 
 Reducer work should add or update a manifest-driven live example and recorded
 contract. Run `make test-reducer-corpus`; use the explicitly gated record and

--- a/Makefile
+++ b/Makefile
@@ -8,10 +8,14 @@
 	fuzz-run harden-release check-release-security \
 	mcp-conformance test-claude-code test-claude-code-live generate-sbom \
 	reducer-cases-list test-reducer-corpus test-reducer-live record-reducer-case \
-	record-reducer-replay accept-reducer-case generate-reducer-case-schema check-reducer-case-schema
+	record-reducer-replay accept-reducer-case generate-reducer-case-schema check-reducer-case-schema hawk
 
 ARGS ?= --help
 BAZEL ?= bazelisk
+HAWK_TOOLCHAIN ?= 1.97.0
+HAWK_CARGO ?= $(shell rustup which --toolchain $(HAWK_TOOLCHAIN) cargo)
+HAWK_RUSTC ?= $(shell rustup which --toolchain $(HAWK_TOOLCHAIN) rustc)
+HAWK_TARGET_DIR ?= target/hawk
 BAZEL_BUILD_FLAGS ?=
 FUZZ_TARGET ?= bep_framing
 FUZZ_ARGS ?= -max_total_time=60
@@ -100,6 +104,11 @@ check:
 	cargo fmt --all -- --check
 	cargo clippy --workspace --all-targets --all-features -- -D warnings
 	$(NIX_DEVELOP) cargo shear
+
+hawk:
+	PATH="$(dir $(HAWK_CARGO)):$$PATH" CARGO="$(HAWK_CARGO)" RUSTC="$(HAWK_RUSTC)" \
+		"$(HAWK_CARGO)" hawk check --manifest-path Cargo.toml \
+		--target-dir "$(HAWK_TARGET_DIR)" -D warnings
 
 bench:
 	cargo bench -p bazel-mcp-benchmark

--- a/crates/bazel-mcp-benchmark/src/agentic.rs
+++ b/crates/bazel-mcp-benchmark/src/agentic.rs
@@ -34,7 +34,7 @@ pub enum AgenticAdapter {
 }
 
 impl AgenticAdapter {
-    pub const fn name(self) -> &'static str {
+    const fn name(self) -> &'static str {
         match self {
             Self::ShellDefault => "shell-default",
             Self::ShellOptimized => "shell-optimized",
@@ -67,28 +67,27 @@ impl AgenticAdapter {
 
 #[derive(Clone, Debug, Deserialize)]
 pub struct AgenticProjectManifest {
-    pub name: String,
-    pub url: String,
-    pub commit: String,
-    pub license: String,
-    pub bazel_version: String,
-    pub tasks: Vec<AgenticTask>,
+    name: String,
+    commit: String,
+    license: String,
+    bazel_version: String,
+    tasks: Vec<AgenticTask>,
     #[serde(skip)]
     resource_root: PathBuf,
 }
 
 #[derive(Clone, Debug, Deserialize)]
 pub struct AgenticTask {
-    pub name: String,
-    pub prompt_file: PathBuf,
-    pub workspace_overlay: PathBuf,
-    pub verification_overlay: Option<PathBuf>,
-    pub verify_command: String,
-    pub verify_args: Vec<String>,
+    name: String,
+    prompt_file: PathBuf,
+    workspace_overlay: PathBuf,
+    verification_overlay: Option<PathBuf>,
+    verify_command: String,
+    verify_args: Vec<String>,
     #[serde(default)]
-    pub protected_paths: Vec<PathBuf>,
+    protected_paths: Vec<PathBuf>,
     #[serde(default = "default_task_timeout_seconds")]
-    pub timeout_seconds: u64,
+    timeout_seconds: u64,
 }
 
 fn default_task_timeout_seconds() -> u64 {
@@ -194,113 +193,113 @@ pub struct AgenticConfig {
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct AgenticSample {
-    pub adapter: String,
-    pub task: String,
-    pub sample: u32,
-    pub verified: bool,
-    pub verifier_exit_code: Option<i32>,
-    pub protected_paths_unchanged: bool,
-    pub protected_path_violations: Vec<String>,
-    pub used_expected_bazel_path: bool,
-    pub shell_bazel_calls: u64,
-    pub mcp_bazel_run_calls: u64,
-    pub model_events: u64,
-    pub agent_message_events: u64,
-    pub tool_calls: u64,
-    pub file_change_events: u64,
-    pub command_output_bytes: u64,
-    pub mcp_output_bytes: u64,
-    pub changed_paths: Vec<String>,
-    pub patch_bytes: u64,
-    pub end_to_end_ms: u64,
-    pub verifier_ms: u64,
-    pub usage: ProviderUsage,
-    pub final_summary: String,
-    pub reported_validation: Vec<String>,
+    adapter: String,
+    task: String,
+    sample: u32,
+    verified: bool,
+    verifier_exit_code: Option<i32>,
+    protected_paths_unchanged: bool,
+    protected_path_violations: Vec<String>,
+    used_expected_bazel_path: bool,
+    shell_bazel_calls: u64,
+    mcp_bazel_run_calls: u64,
+    model_events: u64,
+    agent_message_events: u64,
+    tool_calls: u64,
+    file_change_events: u64,
+    command_output_bytes: u64,
+    mcp_output_bytes: u64,
+    changed_paths: Vec<String>,
+    patch_bytes: u64,
+    end_to_end_ms: u64,
+    verifier_ms: u64,
+    usage: ProviderUsage,
+    final_summary: String,
+    reported_validation: Vec<String>,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct AgenticSummary {
-    pub adapter: String,
-    pub attempts: usize,
-    pub verified_solves: usize,
-    pub solve_rate_percent: f64,
-    pub input_tokens: u64,
-    pub cached_input_tokens: u64,
-    pub uncached_input_tokens: u64,
-    pub output_tokens: u64,
-    pub reasoning_output_tokens: u64,
-    pub total_tokens: u64,
-    pub tokens_per_verified_solve: Option<f64>,
-    pub agent_message_events: u64,
-    pub tool_calls: u64,
-    pub command_output_bytes: u64,
-    pub mcp_output_bytes: u64,
-    pub end_to_end_ms: u64,
+    adapter: String,
+    attempts: usize,
+    verified_solves: usize,
+    solve_rate_percent: f64,
+    input_tokens: u64,
+    cached_input_tokens: u64,
+    uncached_input_tokens: u64,
+    output_tokens: u64,
+    reasoning_output_tokens: u64,
+    total_tokens: u64,
+    tokens_per_verified_solve: Option<f64>,
+    agent_message_events: u64,
+    tool_calls: u64,
+    command_output_bytes: u64,
+    mcp_output_bytes: u64,
+    end_to_end_ms: u64,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct AgenticWeightedSummary {
-    pub adapter: String,
-    pub cached_input_weight_percent: u32,
-    pub weighted_tokens: f64,
-    pub weighted_tokens_per_verified_solve: Option<f64>,
+    adapter: String,
+    cached_input_weight_percent: u32,
+    weighted_tokens: f64,
+    weighted_tokens_per_verified_solve: Option<f64>,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct AgenticComparison {
-    pub baseline_adapter: String,
-    pub candidate_adapter: String,
-    pub paired_attempts: usize,
-    pub concordant_verified_solves: usize,
-    pub solve_rate_delta_percentage_points: f64,
-    pub total_token_reduction_percent: Estimate,
-    pub uncached_input_reduction_percent: Estimate,
-    pub concordant_total_token_reduction_percent: Option<Estimate>,
-    pub tokens_per_verified_solve_reduction_percent: Option<f64>,
+    baseline_adapter: String,
+    candidate_adapter: String,
+    paired_attempts: usize,
+    concordant_verified_solves: usize,
+    solve_rate_delta_percentage_points: f64,
+    total_token_reduction_percent: Estimate,
+    uncached_input_reduction_percent: Estimate,
+    concordant_total_token_reduction_percent: Option<Estimate>,
+    tokens_per_verified_solve_reduction_percent: Option<f64>,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct AgenticWeightedComparison {
-    pub baseline_adapter: String,
-    pub candidate_adapter: String,
-    pub cached_input_weight_percent: u32,
-    pub weighted_token_reduction_percent: Estimate,
+    baseline_adapter: String,
+    candidate_adapter: String,
+    cached_input_weight_percent: u32,
+    weighted_token_reduction_percent: Estimate,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct AgenticTaskComparison {
-    pub task: String,
-    pub baseline_adapter: String,
-    pub candidate_adapter: String,
-    pub paired_attempts: usize,
-    pub baseline_verified_solves: usize,
-    pub candidate_verified_solves: usize,
-    pub total_token_reduction_percent: f64,
-    pub active_token_reduction_percent: f64,
-    pub tool_output_byte_reduction_percent: f64,
-    pub end_to_end_reduction_percent: f64,
+    task: String,
+    baseline_adapter: String,
+    candidate_adapter: String,
+    paired_attempts: usize,
+    baseline_verified_solves: usize,
+    candidate_verified_solves: usize,
+    total_token_reduction_percent: f64,
+    active_token_reduction_percent: f64,
+    tool_output_byte_reduction_percent: f64,
+    end_to_end_reduction_percent: f64,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct AgenticReport {
-    pub schema_version: u32,
-    pub provider: String,
-    pub provider_version: String,
-    pub model: Option<String>,
-    pub reasoning_effort: Option<String>,
-    pub project: String,
-    pub commit: String,
-    pub bazel_version: String,
-    pub adapter_order_seed: u64,
-    pub adapter_order_strategy: String,
-    pub environment: EnvironmentMetadata,
-    pub samples: Vec<AgenticSample>,
-    pub summaries: Vec<AgenticSummary>,
-    pub comparisons: Vec<AgenticComparison>,
-    pub task_comparisons: Vec<AgenticTaskComparison>,
-    pub weighted_summaries: Vec<AgenticWeightedSummary>,
-    pub weighted_comparisons: Vec<AgenticWeightedComparison>,
+    schema_version: u32,
+    provider: String,
+    provider_version: String,
+    model: Option<String>,
+    reasoning_effort: Option<String>,
+    project: String,
+    commit: String,
+    bazel_version: String,
+    adapter_order_seed: u64,
+    adapter_order_strategy: String,
+    environment: EnvironmentMetadata,
+    samples: Vec<AgenticSample>,
+    summaries: Vec<AgenticSummary>,
+    comparisons: Vec<AgenticComparison>,
+    task_comparisons: Vec<AgenticTaskComparison>,
+    weighted_summaries: Vec<AgenticWeightedSummary>,
+    weighted_comparisons: Vec<AgenticWeightedComparison>,
 }
 
 impl AgenticReport {
@@ -2084,7 +2083,6 @@ mod tests {
             repository_root: repository_root.to_owned(),
             project: AgenticProjectManifest {
                 name: "test".to_owned(),
-                url: "local".to_owned(),
                 commit,
                 license: "test".to_owned(),
                 bazel_version: "9.1.0".to_owned(),

--- a/crates/bazel-mcp-benchmark/src/corpus.rs
+++ b/crates/bazel-mcp-benchmark/src/corpus.rs
@@ -5,24 +5,24 @@ use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct ProjectManifest {
-    pub name: String,
-    pub url: String,
-    pub release_tag: String,
-    pub commit: String,
-    pub license: String,
-    pub bazel_version: String,
+    pub(crate) name: String,
+    url: String,
+    release_tag: String,
+    pub(crate) commit: String,
+    license: String,
+    pub(crate) bazel_version: String,
     pub scenarios: Vec<Scenario>,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct Scenario {
-    pub name: String,
-    pub command: String,
-    pub args: Vec<String>,
-    pub expected_exit: i32,
-    pub expected_cause: Option<String>,
+    pub(crate) name: String,
+    pub(crate) command: String,
+    pub(crate) args: Vec<String>,
+    pub(crate) expected_exit: i32,
+    pub(crate) expected_cause: Option<String>,
     #[serde(default)]
-    pub cache_condition: String,
+    cache_condition: String,
 }
 
 impl ProjectManifest {

--- a/crates/bazel-mcp-benchmark/src/harness.rs
+++ b/crates/bazel-mcp-benchmark/src/harness.rs
@@ -15,7 +15,8 @@ use tokio::{
 
 use crate::{
     AdapterMetrics, BaselineComparison, BenchmarkReport, EnvironmentMetadata, Estimate,
-    ProjectManifest, Scenario, SummaryStatistics, Transcript, TranscriptEvent, TranscriptKind,
+    ProjectManifest, Scenario, SummaryStatistics,
+    transcript::{Transcript, TranscriptEvent, TranscriptKind},
 };
 
 const BOOTSTRAP_RESAMPLES: usize = 4_000;

--- a/crates/bazel-mcp-benchmark/src/lib.rs
+++ b/crates/bazel-mcp-benchmark/src/lib.rs
@@ -22,4 +22,4 @@ pub use report::{
     AdapterMetrics, BaselineComparison, BenchmarkReport, EnvironmentMetadata, Estimate,
     SummaryStatistics,
 };
-pub use transcript::{Transcript, TranscriptEvent, TranscriptKind, TranscriptMetrics};
+pub use transcript::TranscriptMetrics;

--- a/crates/bazel-mcp-benchmark/src/live_agent.rs
+++ b/crates/bazel-mcp-benchmark/src/live_agent.rs
@@ -48,75 +48,75 @@ pub struct CodexLiveConfig {
 
 #[derive(Clone, Debug, Default, Serialize, Deserialize)]
 pub struct ProviderUsage {
-    pub input_tokens: u64,
-    pub cached_input_tokens: u64,
-    pub output_tokens: u64,
-    pub reasoning_output_tokens: u64,
+    pub(crate) input_tokens: u64,
+    pub(crate) cached_input_tokens: u64,
+    pub(crate) output_tokens: u64,
+    pub(crate) reasoning_output_tokens: u64,
 }
 
 impl ProviderUsage {
-    pub fn uncached_input_tokens(&self) -> u64 {
+    pub(crate) fn uncached_input_tokens(&self) -> u64 {
         self.input_tokens.saturating_sub(self.cached_input_tokens)
     }
 
-    pub fn total_tokens(&self) -> u64 {
+    pub(crate) fn total_tokens(&self) -> u64 {
         self.input_tokens.saturating_add(self.output_tokens)
     }
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct LiveAgentSample {
-    pub adapter: String,
-    pub scenario: String,
-    pub cache_condition: String,
-    pub sample: u32,
-    pub expected_exit: i32,
-    pub reported_exit: i32,
-    pub expected_cause: Option<String>,
-    pub diagnostic_found: bool,
-    pub used_expected_tool: bool,
-    pub end_to_end_ms: u64,
-    pub model_events: u64,
-    pub tool_calls: u64,
-    pub usage: ProviderUsage,
-    pub final_summary: String,
+    adapter: String,
+    scenario: String,
+    cache_condition: String,
+    sample: u32,
+    expected_exit: i32,
+    reported_exit: i32,
+    expected_cause: Option<String>,
+    diagnostic_found: bool,
+    used_expected_tool: bool,
+    end_to_end_ms: u64,
+    model_events: u64,
+    tool_calls: u64,
+    usage: ProviderUsage,
+    final_summary: String,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct LiveAgentSummary {
-    pub adapter: String,
-    pub observations: usize,
-    pub correct_observations: usize,
-    pub input_tokens: u64,
-    pub cached_input_tokens: u64,
-    pub uncached_input_tokens: u64,
-    pub output_tokens: u64,
-    pub reasoning_output_tokens: u64,
-    pub total_tokens: u64,
+    adapter: String,
+    observations: usize,
+    correct_observations: usize,
+    input_tokens: u64,
+    cached_input_tokens: u64,
+    uncached_input_tokens: u64,
+    output_tokens: u64,
+    reasoning_output_tokens: u64,
+    total_tokens: u64,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct LiveAgentComparison {
-    pub baseline_adapter: String,
-    pub candidate_adapter: String,
-    pub input_token_reduction_percent: f64,
-    pub uncached_input_token_reduction_percent: f64,
-    pub total_token_reduction_percent: f64,
+    baseline_adapter: String,
+    candidate_adapter: String,
+    input_token_reduction_percent: f64,
+    uncached_input_token_reduction_percent: f64,
+    total_token_reduction_percent: f64,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct LiveAgentReport {
-    pub schema_version: u32,
-    pub provider: String,
-    pub provider_version: String,
-    pub model: Option<String>,
-    pub project: String,
-    pub commit: String,
-    pub bazel_version: String,
-    pub environment: EnvironmentMetadata,
-    pub samples: Vec<LiveAgentSample>,
-    pub summaries: Vec<LiveAgentSummary>,
-    pub comparisons: Vec<LiveAgentComparison>,
+    schema_version: u32,
+    provider: String,
+    provider_version: String,
+    model: Option<String>,
+    project: String,
+    commit: String,
+    bazel_version: String,
+    environment: EnvironmentMetadata,
+    samples: Vec<LiveAgentSample>,
+    summaries: Vec<LiveAgentSummary>,
+    comparisons: Vec<LiveAgentComparison>,
 }
 
 impl LiveAgentReport {

--- a/crates/bazel-mcp-benchmark/src/report.rs
+++ b/crates/bazel-mcp-benchmark/src/report.rs
@@ -6,73 +6,73 @@ use crate::TranscriptMetrics;
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct AdapterMetrics {
-    pub adapter: String,
-    pub scenario: String,
-    pub cache_condition: String,
+    pub(crate) adapter: String,
+    pub(crate) scenario: String,
+    pub(crate) cache_condition: String,
     pub sample: u32,
-    pub bazel_wall_ms: u64,
-    pub end_to_end_ms: u64,
-    pub exit_code: Option<i32>,
-    pub diagnostic_found: bool,
-    pub raw_process_bytes: u64,
-    pub transcript: TranscriptMetrics,
+    pub(crate) bazel_wall_ms: u64,
+    pub(crate) end_to_end_ms: u64,
+    pub(crate) exit_code: Option<i32>,
+    pub(crate) diagnostic_found: bool,
+    pub(crate) raw_process_bytes: u64,
+    pub(crate) transcript: TranscriptMetrics,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct EnvironmentMetadata {
-    pub os: String,
-    pub architecture: String,
-    pub rustc: String,
-    pub logical_cpus: usize,
+    pub(crate) os: String,
+    pub(crate) architecture: String,
+    pub(crate) rustc: String,
+    pub(crate) logical_cpus: usize,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct SummaryStatistics {
-    pub cache_condition: String,
-    pub adapter: String,
-    pub observations: usize,
-    pub median_bazel_wall_ms: u64,
-    pub p95_bazel_wall_ms: u64,
-    pub median_context_tokens: u64,
-    pub p95_context_tokens: u64,
-    pub median_visible_bytes: u64,
-    pub p95_visible_bytes: u64,
+    pub(crate) cache_condition: String,
+    pub(crate) adapter: String,
+    pub(crate) observations: usize,
+    pub(crate) median_bazel_wall_ms: u64,
+    pub(crate) p95_bazel_wall_ms: u64,
+    pub(crate) median_context_tokens: u64,
+    pub(crate) p95_context_tokens: u64,
+    pub(crate) median_visible_bytes: u64,
+    pub(crate) p95_visible_bytes: u64,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct Estimate {
-    pub value: f64,
-    pub ci95_lower: f64,
-    pub ci95_upper: f64,
+    pub(crate) value: f64,
+    pub(crate) ci95_lower: f64,
+    pub(crate) ci95_upper: f64,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct BaselineComparison {
-    pub baseline_adapter: String,
-    pub candidate_adapter: String,
-    pub aggregate: BTreeMap<String, Estimate>,
-    pub by_cache: BTreeMap<String, BTreeMap<String, Estimate>>,
+    pub(crate) baseline_adapter: String,
+    pub(crate) candidate_adapter: String,
+    pub(crate) aggregate: BTreeMap<String, Estimate>,
+    pub(crate) by_cache: BTreeMap<String, BTreeMap<String, Estimate>>,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct BenchmarkReport {
-    pub schema_version: u32,
-    pub project: String,
-    pub commit: String,
-    pub bazel_version: String,
-    pub tokenizer_crate_version: String,
-    pub encoding: String,
-    pub canonicalization_version: u32,
-    pub adapter_order_seed: u64,
-    pub environment: EnvironmentMetadata,
+    pub(crate) schema_version: u32,
+    pub(crate) project: String,
+    pub(crate) commit: String,
+    pub(crate) bazel_version: String,
+    pub(crate) tokenizer_crate_version: String,
+    pub(crate) encoding: String,
+    pub(crate) canonicalization_version: u32,
+    pub(crate) adapter_order_seed: u64,
+    pub(crate) environment: EnvironmentMetadata,
     pub samples: Vec<AdapterMetrics>,
-    pub statistics: Vec<SummaryStatistics>,
+    pub(crate) statistics: Vec<SummaryStatistics>,
     #[serde(default)]
-    pub comparisons: Vec<BaselineComparison>,
+    pub(crate) comparisons: Vec<BaselineComparison>,
     // Retained in schema v3 for consumers of schema v2 reports. These values
     // are the point estimates for shell-default versus bazel-mcp.
-    pub aggregate_reduction_percent: BTreeMap<String, f64>,
-    pub reduction_percent_by_cache: BTreeMap<String, BTreeMap<String, f64>>,
+    pub(crate) aggregate_reduction_percent: BTreeMap<String, f64>,
+    pub(crate) reduction_percent_by_cache: BTreeMap<String, BTreeMap<String, f64>>,
 }
 
 impl BenchmarkReport {

--- a/crates/bazel-mcp-benchmark/src/transcript.rs
+++ b/crates/bazel-mcp-benchmark/src/transcript.rs
@@ -15,36 +15,36 @@ pub enum TranscriptKind {
 
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub struct TranscriptEvent {
-    pub sequence: u64,
-    pub adapter: String,
-    pub scenario: String,
-    pub kind: TranscriptKind,
-    pub role: String,
-    pub model_visible: bool,
-    pub content: String,
+    pub(crate) sequence: u64,
+    pub(crate) adapter: String,
+    pub(crate) scenario: String,
+    pub(crate) kind: TranscriptKind,
+    pub(crate) role: String,
+    pub(crate) model_visible: bool,
+    pub(crate) content: String,
 }
 
 #[derive(Clone, Debug, Default, Eq, PartialEq, Serialize, Deserialize)]
 pub struct Transcript {
-    pub canonicalization_version: u32,
-    pub events: Vec<TranscriptEvent>,
+    pub(crate) canonicalization_version: u32,
+    pub(crate) events: Vec<TranscriptEvent>,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub struct TranscriptMetrics {
-    pub encoding: String,
-    pub visible_tool_tokens: u64,
-    pub cumulative_context_tokens: u64,
-    pub model_visible_bytes: u64,
-    pub model_events: u64,
-    pub tool_calls: u64,
-    pub polling_calls: u64,
+    encoding: String,
+    pub(crate) visible_tool_tokens: u64,
+    pub(crate) cumulative_context_tokens: u64,
+    pub(crate) model_visible_bytes: u64,
+    model_events: u64,
+    tool_calls: u64,
+    polling_calls: u64,
     #[serde(default)]
-    pub protocol_polling_bytes: u64,
+    protocol_polling_bytes: u64,
 }
 
 impl Transcript {
-    pub fn to_jsonl(&self) -> Result<String, serde_json::Error> {
+    pub(crate) fn to_jsonl(&self) -> Result<String, serde_json::Error> {
         let mut output = String::new();
         for event in &self.events {
             output.push_str(&serde_json::to_string(event)?);
@@ -53,7 +53,7 @@ impl Transcript {
         Ok(output)
     }
 
-    pub fn measure(&self, encoding: &str) -> anyhow::Result<TranscriptMetrics> {
+    pub(crate) fn measure(&self, encoding: &str) -> anyhow::Result<TranscriptMetrics> {
         let tokenizer = tokenizer(encoding)?;
         let mut prior_context = String::new();
         let mut visible_tool_tokens = 0_u64;

--- a/crates/bazel-mcp-bep/src/framing.rs
+++ b/crates/bazel-mcp-bep/src/framing.rs
@@ -38,15 +38,8 @@ pub struct BepEvent {
 }
 
 impl BepEvent {
-    /// Decode and retain an already-owned protobuf frame without copying it.
-    pub fn decode(frame: Vec<u8>) -> Result<Self, buffa::DecodeError> {
-        Ok(Self {
-            inner: BuildEventOwnedView::decode(Bytes::from(frame))?,
-        })
-    }
-
     /// Decode a borrowed frame by copying only the frame backing allocation.
-    pub fn decode_slice(frame: &[u8]) -> Result<Self, buffa::DecodeError> {
+    fn decode_slice(frame: &[u8]) -> Result<Self, buffa::DecodeError> {
         Ok(Self {
             inner: BuildEventOwnedView::decode(Bytes::copy_from_slice(frame))?,
         })
@@ -62,11 +55,6 @@ impl BepEvent {
     #[must_use]
     pub fn view(&self) -> &BuildEventView<'_> {
         self.inner.view()
-    }
-
-    #[must_use]
-    pub fn frame_bytes(&self) -> &[u8] {
-        self.inner.bytes()
     }
 }
 
@@ -160,7 +148,7 @@ impl IncrementalStreamDecoder {
     /// Once a terminal framing, limit, or decode error is encountered, later
     /// chunks are ignored and the complete prefix remains available from
     /// [`Self::finish`].
-    pub fn push<F>(&mut self, input: &[u8], mut visitor: F)
+    fn push<F>(&mut self, input: &[u8], mut visitor: F)
     where
         F: FnMut(BepEvent),
     {
@@ -176,7 +164,7 @@ impl IncrementalStreamDecoder {
     /// [`IncrementalStreamControl::ResetAfterFrame`] resets stream byte/event
     /// accounting after that frame, which lets retry-aware transports retain
     /// only the next attempt even when two writers' bytes arrive in one read.
-    pub fn push_framed<F>(&mut self, input: &[u8], mut visitor: F)
+    fn push_framed<F>(&mut self, input: &[u8], mut visitor: F)
     where
         F: FnMut(BepEvent, &[u8]) -> IncrementalStreamControl,
     {
@@ -593,11 +581,6 @@ pub fn encode_frame<M: Message>(message: &M) -> Vec<u8> {
     write_varint(body.len() as u64, &mut framed);
     framed.extend_from_slice(&body);
     framed
-}
-
-/// Decode a single borrowed frame into a retained zero-copy event handle.
-pub fn decode_event(frame: &[u8]) -> Result<BepEvent, buffa::DecodeError> {
-    BepEvent::decode_slice(frame)
 }
 
 /// Decode an event-id submessage as a borrowed view into its parent event.

--- a/crates/bazel-mcp-bep/src/lib.rs
+++ b/crates/bazel-mcp-bep/src/lib.rs
@@ -28,7 +28,6 @@ pub mod view {
 pub use framing::{
     BepEvent, BorrowedBepEvent, DEFAULT_MAX_FRAME_BYTES, DEFAULT_MAX_STREAM_BYTES,
     DEFAULT_MAX_STREAM_EVENTS, FrameError, IncrementalStreamControl, IncrementalStreamDecoder,
-    PartialStream, StreamOutcome, decode_event, decode_event_id, decode_stream,
-    decode_stream_partial, decode_stream_partial_bounded, encode_event_id, encode_frame,
-    read_frame, visit_stream_partial_borrowed_bounded, visit_stream_partial_bounded,
+    PartialStream, StreamOutcome, decode_event_id, decode_stream, decode_stream_partial,
+    encode_event_id, encode_frame, read_frame, visit_stream_partial_borrowed_bounded,
 };

--- a/crates/bazel-mcp-policy/src/config.rs
+++ b/crates/bazel-mcp-policy/src/config.rs
@@ -1,6 +1,5 @@
 use std::{collections::BTreeSet, path::PathBuf};
 
-use bazel_mcp_types::BazelCommand;
 use serde::{Deserialize, Serialize};
 
 use crate::{PolicyError, redaction::Redactor};
@@ -10,10 +9,10 @@ use crate::{PolicyError, redaction::Redactor};
 #[serde(default)]
 pub struct RawPolicyConfig {
     pub allowed_roots: Vec<PathBuf>,
-    pub allowed_commands: BTreeSet<String>,
-    pub denied_commands: BTreeSet<String>,
-    pub environment_allowlist: BTreeSet<String>,
-    pub redaction_patterns: Vec<String>,
+    allowed_commands: BTreeSet<String>,
+    denied_commands: BTreeSet<String>,
+    environment_allowlist: BTreeSet<String>,
+    redaction_patterns: Vec<String>,
     pub bazel_executable: Option<PathBuf>,
 }
 
@@ -83,15 +82,9 @@ impl Default for PolicyConfig {
 
 impl PolicyConfig {
     /// Validate policy-owned configuration before it reaches request handling.
-    pub fn validate(&self) -> Result<(), PolicyError> {
+    fn validate(&self) -> Result<(), PolicyError> {
         Redactor::new(&self.redaction_patterns)?;
         Ok(())
-    }
-
-    #[must_use]
-    pub fn permits(&self, command: &BazelCommand) -> bool {
-        let name = command.as_str();
-        self.allowed_commands.contains(name) && !self.denied_commands.contains(name)
     }
 }
 

--- a/crates/bazel-mcp-policy/src/flags.rs
+++ b/crates/bazel-mcp-policy/src/flags.rs
@@ -7,8 +7,6 @@ use bazel_mcp_types::{BazelCommand, CommandClass};
 
 use crate::PolicyError;
 
-pub const INTERNAL_BEP_FLAG: &str = "--build_event_binary_file";
-
 const MAX_ARGUMENT_BYTES: usize = 64 * 1024;
 const MAX_ARGUMENT_COUNT: usize = 10_000;
 const MAX_ARGUMENTS_BYTES: usize = 2 * 1024 * 1024;

--- a/crates/bazel-mcp-policy/src/lib.rs
+++ b/crates/bazel-mcp-policy/src/lib.rs
@@ -15,8 +15,8 @@ pub use executable::{
     resolve_aspect_executable, resolve_bazel_executable, resolve_bazel_executable_excluding,
 };
 pub use flags::{
-    INTERNAL_BEP_FLAG, effective_output_base, validate_arguments, validate_aspect_arguments,
-    validate_query_arguments, validate_run_arguments,
+    effective_output_base, validate_arguments, validate_aspect_arguments, validate_query_arguments,
+    validate_run_arguments,
 };
 pub use redaction::Redactor;
 pub use workspace::validate_workspace;

--- a/crates/bazel-mcp-reducer-cases/src/lib.rs
+++ b/crates/bazel-mcp-reducer-cases/src/lib.rs
@@ -15,7 +15,7 @@ pub use manifest::{
 };
 pub use mcp::{LiveOptions, LiveRun, run_live_case};
 pub use replay::{
-    ReplayOutput, replay_case, replay_with_evidence, verify_case_contract, verify_case_evidence,
+    ReplayOutput, replay_with_evidence, verify_case_contract, verify_case_evidence,
     verify_recorded_case,
 };
 pub use sanitize::{sanitize_binary, sanitize_text, verify_sanitized_evidence};
@@ -24,4 +24,4 @@ pub use semantics::{
     verify_live_replay_parity,
 };
 
-pub const CASE_SCHEMA_VERSION: u32 = 1;
+pub(crate) const CASE_SCHEMA_VERSION: u32 = 1;

--- a/crates/bazel-mcp-reducer-cases/src/manifest.rs
+++ b/crates/bazel-mcp-reducer-cases/src/manifest.rs
@@ -78,8 +78,8 @@ impl Default for EvidenceSpec {
 #[derive(Clone, Copy, Debug, Deserialize, JsonSchema, Serialize)]
 #[serde(default, deny_unknown_fields)]
 pub struct ReplaySpec {
-    pub max_items: usize,
-    pub max_bytes: usize,
+    pub(crate) max_items: usize,
+    pub(crate) max_bytes: usize,
 }
 
 impl Default for ReplaySpec {
@@ -119,54 +119,54 @@ pub struct CaseExpectation {
 #[serde(deny_unknown_fields)]
 pub struct DiagnosticExpectation {
     #[serde(default)]
-    pub rank: Option<usize>,
+    pub(crate) rank: Option<usize>,
     #[serde(default)]
-    pub severity: Option<String>,
+    pub(crate) severity: Option<String>,
     #[serde(default)]
-    pub category: Option<String>,
+    pub(crate) category: Option<String>,
     #[serde(default)]
-    pub message_equals: Option<String>,
+    pub(crate) message_equals: Option<String>,
     #[serde(default)]
-    pub message_prefix: Option<String>,
+    pub(crate) message_prefix: Option<String>,
     #[serde(default)]
-    pub message_contains: Option<String>,
+    pub(crate) message_contains: Option<String>,
     #[serde(default)]
-    pub path: Option<String>,
+    pub(crate) path: Option<String>,
     #[serde(default)]
-    pub line: Option<u32>,
+    pub(crate) line: Option<u32>,
     #[serde(default)]
-    pub column: Option<u32>,
+    pub(crate) column: Option<u32>,
     #[serde(default)]
-    pub target: Option<String>,
+    pub(crate) target: Option<String>,
     #[serde(default)]
-    pub action: Option<String>,
+    pub(crate) action: Option<String>,
     #[serde(default)]
-    pub repetition_count: Option<u32>,
+    pub(crate) repetition_count: Option<u32>,
 }
 
 #[derive(Clone, Debug, Deserialize, JsonSchema, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct ArtifactExpectation {
     #[serde(default)]
-    pub name_equals: Option<String>,
+    pub(crate) name_equals: Option<String>,
     #[serde(default)]
-    pub name_contains: Option<String>,
+    pub(crate) name_contains: Option<String>,
     #[serde(default)]
-    pub kind: Option<String>,
+    pub(crate) kind: Option<String>,
     #[serde(default)]
-    pub uri_contains: Option<String>,
+    pub(crate) uri_contains: Option<String>,
     #[serde(default)]
-    pub locally_available: Option<bool>,
+    pub(crate) locally_available: Option<bool>,
 }
 
 #[derive(Clone, Debug, Default, Deserialize, JsonSchema, Serialize)]
 #[serde(default, deny_unknown_fields)]
 pub struct AbsentExpectation {
-    pub message_contains: Vec<String>,
-    pub path_contains: Vec<String>,
-    pub target_contains: Vec<String>,
-    pub artifact_uri_contains: Vec<String>,
-    pub raw_contains: Vec<String>,
+    pub(crate) message_contains: Vec<String>,
+    pub(crate) path_contains: Vec<String>,
+    pub(crate) target_contains: Vec<String>,
+    pub(crate) artifact_uri_contains: Vec<String>,
+    pub(crate) raw_contains: Vec<String>,
 }
 
 #[derive(Clone, Debug, Deserialize, JsonSchema, Serialize)]
@@ -196,7 +196,7 @@ impl LoadedCase {
 }
 
 impl CaseManifest {
-    pub fn validate(&self) -> Result<()> {
+    fn validate(&self) -> Result<()> {
         ensure!(
             self.schema_version == CASE_SCHEMA_VERSION,
             "case {} uses schema {}, expected {}",

--- a/crates/bazel-mcp-reducer-cases/src/mcp.rs
+++ b/crates/bazel-mcp-reducer-cases/src/mcp.rs
@@ -32,7 +32,6 @@ pub struct LiveRun {
     pub workspace: PathBuf,
     pub cache_root: PathBuf,
     pub output_user_root: PathBuf,
-    pub run_result: Value,
     pub bazel_version: Option<String>,
     runtime: TempDir,
 }
@@ -214,7 +213,6 @@ pub fn run_live_case(case: &LoadedCase, options: &LiveOptions) -> Result<LiveRun
         workspace,
         cache_root,
         output_user_root,
-        run_result,
         bazel_version,
         runtime,
     })

--- a/crates/bazel-mcp-reducer-cases/src/replay.rs
+++ b/crates/bazel-mcp-reducer-cases/src/replay.rs
@@ -19,10 +19,10 @@ use crate::{
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct ReplayOutput {
-    pub event_count: usize,
-    pub terminal_error: Option<String>,
-    pub summary: InvocationSummary,
-    pub artifacts: Vec<Artifact>,
+    event_count: usize,
+    terminal_error: Option<String>,
+    pub(crate) summary: InvocationSummary,
+    pub(crate) artifacts: Vec<Artifact>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -41,15 +41,6 @@ struct RecordedProvenance {
     rules: BTreeMap<String, String>,
     origin_repository: Option<String>,
     origin_commit: Option<String>,
-}
-
-pub fn replay_case(case: &LoadedCase) -> Result<ReplayOutput> {
-    let evidence = case
-        .manifest
-        .evidence
-        .as_ref()
-        .context("case has no recorded evidence")?;
-    replay_with_evidence(case, evidence)
 }
 
 pub fn verify_recorded_case(case: &LoadedCase) -> Result<ReplayOutput> {

--- a/crates/bazel-mcp-reducer-cases/src/semantics.rs
+++ b/crates/bazel-mcp-reducer-cases/src/semantics.rs
@@ -7,19 +7,19 @@ use crate::{ArtifactExpectation, CaseExpectation, DiagnosticExpectation, ReplayO
 
 #[derive(Clone, Debug)]
 pub struct CaseObservation {
-    pub state: String,
+    pub(crate) state: String,
     pub exit_code: Option<i32>,
-    pub headline: String,
-    pub inspect_hint: Option<String>,
-    pub diagnostics: Vec<Diagnostic>,
-    pub artifacts: Vec<Artifact>,
-    pub visible_bytes: usize,
-    pub raw_text: String,
+    pub(crate) headline: String,
+    pub(crate) inspect_hint: Option<String>,
+    pub(crate) diagnostics: Vec<Diagnostic>,
+    pub(crate) artifacts: Vec<Artifact>,
+    pub(crate) visible_bytes: usize,
+    pub(crate) raw_text: String,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct VerificationFailure {
-    pub messages: Vec<String>,
+    messages: Vec<String>,
 }
 
 impl fmt::Display for VerificationFailure {

--- a/crates/bazel-mcp-reducer/src/budget.rs
+++ b/crates/bazel-mcp-reducer/src/budget.rs
@@ -24,6 +24,6 @@ impl Budget {
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct Budgeted<T> {
-    pub value: T,
-    pub truncated: bool,
+    pub(crate) value: T,
+    pub(crate) truncated: bool,
 }

--- a/crates/bazel-mcp-reducer/src/coverage.rs
+++ b/crates/bazel-mcp-reducer/src/coverage.rs
@@ -11,7 +11,8 @@ pub enum CoverageError {
     Io(#[from] std::io::Error),
 }
 
-pub fn parse_lcov(input: &str) -> Result<CoverageSummary, CoverageError> {
+#[cfg(test)]
+fn parse_lcov(input: &str) -> Result<CoverageSummary, CoverageError> {
     parse_lcov_reader(std::io::Cursor::new(input.as_bytes()))
 }
 

--- a/crates/bazel-mcp-reducer/src/extension.rs
+++ b/crates/bazel-mcp-reducer/src/extension.rs
@@ -22,13 +22,13 @@ pub enum ReducerEventKind {
 
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub struct ReducerEvent {
-    pub ordinal: u64,
-    pub kind: ReducerEventKind,
+    pub(crate) ordinal: u64,
+    pub(crate) kind: ReducerEventKind,
     pub label: Option<String>,
     pub target_kind: Option<String>,
     pub action_type: Option<String>,
-    pub success: Option<bool>,
-    pub exit_code: Option<i32>,
+    pub(crate) success: Option<bool>,
+    pub(crate) exit_code: Option<i32>,
     pub message: Option<String>,
 }
 
@@ -56,7 +56,7 @@ pub struct ReducerSelector {
 
 impl ReducerSelector {
     #[must_use]
-    pub fn matches(&self, context: &ReducerContext) -> bool {
+    fn matches(&self, context: &ReducerContext) -> bool {
         if !self.commands.is_empty() && !self.commands.contains(&context.command) {
             return false;
         }
@@ -67,7 +67,7 @@ impl ReducerSelector {
     }
 
     #[must_use]
-    pub fn has_event_constraints(&self) -> bool {
+    pub(crate) fn has_event_constraints(&self) -> bool {
         !self.target_labels.is_empty()
             || !self.target_kinds.is_empty()
             || !self.action_types.is_empty()
@@ -156,7 +156,7 @@ pub struct ReducerError {
 
 impl ReducerError {
     #[must_use]
-    pub fn new(message: impl Into<String>) -> Self {
+    pub(crate) fn new(message: impl Into<String>) -> Self {
         Self {
             message: message.into(),
         }

--- a/crates/bazel-mcp-reducer/src/lib.rs
+++ b/crates/bazel-mcp-reducer/src/lib.rs
@@ -15,7 +15,7 @@ pub use build::{
     BepAccumulator, ReductionInput, RunBepOutcome, StreamReductionOutput,
     extract_canonical_arguments, finalize_diagnostics, reduce_artifacts, reduce_invocation,
 };
-pub use coverage::{CoverageError, parse_lcov, parse_lcov_reader};
+pub use coverage::{CoverageError, parse_lcov_reader};
 pub use diagnostics::map_diagnostic as map_text_diagnostic;
 pub use extension::{
     CustomReducer, ReducerApplyReport, ReducerContext, ReducerError, ReducerEvent,

--- a/crates/bazel-mcp-reducer/src/starlark.rs
+++ b/crates/bazel-mcp-reducer/src/starlark.rs
@@ -71,15 +71,15 @@ impl Default for StarlarkLimits {
 #[serde(default, deny_unknown_fields)]
 pub struct RawStarlarkConfig {
     pub files: Vec<PathBuf>,
-    pub max_source_bytes: usize,
-    pub max_input_bytes: usize,
-    pub max_events: usize,
-    pub max_output_bytes: usize,
-    pub max_output_items: usize,
-    pub max_ticks: u64,
-    pub max_heap_bytes: usize,
-    pub max_callstack_size: usize,
-    pub timeout_ms: u64,
+    max_source_bytes: usize,
+    max_input_bytes: usize,
+    max_events: usize,
+    max_output_bytes: usize,
+    max_output_items: usize,
+    max_ticks: u64,
+    max_heap_bytes: usize,
+    max_callstack_size: usize,
+    timeout_ms: u64,
 }
 
 impl Default for RawStarlarkConfig {

--- a/crates/bazel-mcp-runner/src/artifacts.rs
+++ b/crates/bazel-mcp-runner/src/artifacts.rs
@@ -78,7 +78,7 @@ pub(crate) fn local_artifact_path(artifact: &bazel_mcp_types::Artifact) -> Optio
     path.is_absolute().then_some(path)
 }
 
-pub(crate) fn bazel_test_log_output_base(path: &Path) -> Option<PathBuf> {
+fn bazel_test_log_output_base(path: &Path) -> Option<PathBuf> {
     let components = path.components().collect::<Vec<_>>();
     let execroot = components
         .iter()

--- a/crates/bazel-mcp-runner/src/capture.rs
+++ b/crates/bazel-mcp-runner/src/capture.rs
@@ -108,7 +108,7 @@ impl IncrementalBepCapture {
         }
     }
 
-    pub(crate) async fn finish(mut self) -> Result<BepReduction, RunnerError> {
+    async fn finish(mut self) -> Result<BepReduction, RunnerError> {
         let started = Instant::now();
         self.finishing.store(true, Ordering::Release);
         let result = match self.task.take().expect("tail task must exist").await {

--- a/crates/bazel-mcp-runner/src/driver.rs
+++ b/crates/bazel-mcp-runner/src/driver.rs
@@ -8,8 +8,8 @@ use serde::{Deserialize, Serialize};
 #[serde(default, deny_unknown_fields)]
 pub struct RawAspectConfig {
     pub executable: Option<PathBuf>,
-    pub commands: BTreeSet<String>,
-    pub allow_workspace_mutation: bool,
+    commands: BTreeSet<String>,
+    allow_workspace_mutation: bool,
 }
 
 /// Optional Aspect CLI command routing.
@@ -46,12 +46,12 @@ impl From<AspectConfig> for RawAspectConfig {
 
 impl AspectConfig {
     #[must_use]
-    pub fn enabled(&self) -> bool {
+    pub(crate) fn enabled(&self) -> bool {
         !self.commands.is_empty()
     }
 
     #[must_use]
-    pub fn routes(&self, command: &BazelCommand) -> bool {
+    pub(crate) fn routes(&self, command: &BazelCommand) -> bool {
         self.commands.contains(command.as_str())
     }
 

--- a/crates/bazel-mcp-runner/src/execution.rs
+++ b/crates/bazel-mcp-runner/src/execution.rs
@@ -1430,7 +1430,7 @@ impl InvocationService {
 }
 
 #[cfg(unix)]
-pub(crate) async fn probe_bazel_server_pid(
+async fn probe_bazel_server_pid(
     executable: &Path,
     workspace: &Path,
     startup_arguments: &[String],
@@ -1494,7 +1494,7 @@ pub(crate) async fn probe_bazel_server_pid(
         })
 }
 
-pub(crate) fn custom_reducer_notice(message: String) -> Diagnostic {
+fn custom_reducer_notice(message: String) -> Diagnostic {
     Diagnostic {
         severity: Severity::Note,
         category: DiagnosticCategory::Bazel,
@@ -1506,7 +1506,7 @@ pub(crate) fn custom_reducer_notice(message: String) -> Diagnostic {
     }
 }
 
-pub(crate) fn finalize_with_custom_notices(
+fn finalize_with_custom_notices(
     summary: &mut bazel_mcp_types::InvocationSummary,
     notices: Vec<Diagnostic>,
 ) {
@@ -1546,9 +1546,7 @@ pub(crate) fn finalize_with_custom_notices(
     }
 }
 
-pub(crate) fn finish_from_status(
-    status: ExitStatus,
-) -> (Option<ExitStatus>, Termination, InvocationState) {
+fn finish_from_status(status: ExitStatus) -> (Option<ExitStatus>, Termination, InvocationState) {
     let state = if status.success() {
         InvocationState::Succeeded
     } else {
@@ -1586,7 +1584,7 @@ async fn wait_for_run_output_limit(stdout: &Path, stderr: &Path, maximum_bytes: 
     }
 }
 
-pub(crate) fn duration_millis(duration: Duration) -> u64 {
+fn duration_millis(duration: Duration) -> u64 {
     u64::try_from(duration.as_millis()).unwrap_or(u64::MAX)
 }
 
@@ -1598,7 +1596,7 @@ pub(crate) fn cancelled_summary() -> bazel_mcp_types::InvocationSummary {
     }
 }
 
-pub(crate) fn fallback_summary(
+fn fallback_summary(
     exit_code: Option<i32>,
     elapsed_ms: u64,
     stderr: &[u8],

--- a/crates/bazel-mcp-runner/src/inspection.rs
+++ b/crates/bazel-mcp-runner/src/inspection.rs
@@ -55,13 +55,13 @@ pub(crate) struct EvidenceRecord {
 
 pub(crate) struct EvidencePage {
     pub(crate) items: Vec<String>,
-    pub(crate) item_cursors: Vec<String>,
+    item_cursors: Vec<String>,
     pub(crate) truncated: bool,
     pub(crate) next_cursor: Option<String>,
 }
 
 impl LogCursor {
-    pub(crate) fn encode(&self) -> Result<String, RunnerError> {
+    fn encode(&self) -> Result<String, RunnerError> {
         Ok(URL_SAFE_NO_PAD.encode(serde_json::to_vec(self)?))
     }
 

--- a/crates/bazel-mcp-runner/src/output_base_lock.rs
+++ b/crates/bazel-mcp-runner/src/output_base_lock.rs
@@ -39,7 +39,7 @@ struct OutputBaseWaitTiming {
 }
 
 impl OutputBaseWaitStatus {
-    pub(crate) fn begin(&self, owner: Option<String>) {
+    fn begin(&self, owner: Option<String>) {
         let mut timing = self.inner.lock().unwrap_or_else(|error| error.into_inner());
         if timing.active_since.is_none() {
             timing.active_since = Some(Instant::now());
@@ -49,7 +49,7 @@ impl OutputBaseWaitStatus {
         }
     }
 
-    pub(crate) fn end(&self) {
+    fn end(&self) {
         let mut timing = self.inner.lock().unwrap_or_else(|error| error.into_inner());
         if let Some(started) = timing.active_since.take() {
             timing.accumulated = timing.accumulated.saturating_add(started.elapsed());

--- a/crates/bazel-mcp-runner/src/service.rs
+++ b/crates/bazel-mcp-runner/src/service.rs
@@ -70,18 +70,18 @@ pub enum BepTransport {
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 #[serde(default)]
 pub struct RawRunnerConfig {
-    pub default_timeout_seconds: u64,
-    pub maximum_timeout_seconds: u64,
-    pub maximum_run_output_bytes: u64,
-    pub cancellation_interrupt_grace_seconds: u64,
-    pub cancellation_terminate_grace_seconds: u64,
-    pub global_concurrency: usize,
+    default_timeout_seconds: u64,
+    maximum_timeout_seconds: u64,
+    maximum_run_output_bytes: u64,
+    cancellation_interrupt_grace_seconds: u64,
+    cancellation_terminate_grace_seconds: u64,
+    global_concurrency: usize,
     pub output_user_root: Option<PathBuf>,
-    pub isolated_bazel_server_idle_seconds: u64,
-    pub supported_bazel_major_versions: BTreeSet<u32>,
-    pub allow_unsupported_bazel_versions: bool,
-    pub version_check_timeout_seconds: u64,
-    pub maximum_pending_invocations: usize,
+    isolated_bazel_server_idle_seconds: u64,
+    supported_bazel_major_versions: BTreeSet<u32>,
+    allow_unsupported_bazel_versions: bool,
+    version_check_timeout_seconds: u64,
+    maximum_pending_invocations: usize,
     pub bep_transport: BepTransport,
     pub aspect: RawAspectConfig,
     pub starlark: RawStarlarkConfig,
@@ -161,7 +161,7 @@ impl RunnerConfig {
     /// Keeping this check on the runner configuration lets configuration
     /// frontends reject invalid settings without duplicating the runner's
     /// invariants.
-    pub fn validate(&self) -> Result<(), RunnerError> {
+    fn validate(&self) -> Result<(), RunnerError> {
         if self.global_concurrency == 0 {
             return Err(RunnerError::InvalidConfiguration(
                 "global concurrency must be greater than zero",
@@ -406,9 +406,9 @@ pub struct InvocationProgress {
 
 #[derive(Clone, Debug, Serialize)]
 pub struct CancelResult {
-    pub invocation_id: InvocationId,
-    pub prior_state: InvocationState,
-    pub current_state: InvocationState,
+    invocation_id: InvocationId,
+    prior_state: InvocationState,
+    current_state: InvocationState,
     pub cancellation_requested: bool,
 }
 
@@ -1114,7 +1114,7 @@ impl InvocationService {
         Ok(())
     }
 
-    pub async fn invocation_state(&self, id: InvocationId) -> Result<InvocationState, RunnerError> {
+    async fn invocation_state(&self, id: InvocationId) -> Result<InvocationState, RunnerError> {
         if let Some(state) = self.scheduler.lifecycle_state(id) {
             return Ok(state);
         }

--- a/crates/bazel-mcp-runner/src/test_evidence.rs
+++ b/crates/bazel-mcp-runner/src/test_evidence.rs
@@ -273,10 +273,7 @@ pub(crate) fn artifact_matches_test(artifact: &bazel_mcp_types::Artifact, label:
     artifact.uri.replace('\\', "/").contains(&fragment)
 }
 
-pub(crate) fn set_test_log_unavailable(
-    summary: &mut bazel_mcp_types::InvocationSummary,
-    reason: &str,
-) {
+fn set_test_log_unavailable(summary: &mut bazel_mcp_types::InvocationSummary, reason: &str) {
     for test in summary
         .tests
         .iter_mut()

--- a/crates/bazel-mcp-runner/src/version.rs
+++ b/crates/bazel-mcp-runner/src/version.rs
@@ -9,7 +9,7 @@ const VERSION_OUTPUT_LIMIT: u64 = 64 * 1024;
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub(crate) struct BazelVersion {
-    pub(crate) raw: String,
+    raw: String,
     pub(crate) major: u32,
 }
 

--- a/crates/bazel-mcp-server/src/config.rs
+++ b/crates/bazel-mcp-server/src/config.rs
@@ -42,13 +42,13 @@ pub enum McpExecutionPolicy {
 pub struct Cli {
     /// Read configuration from this TOML file.
     #[arg(long, env = "BAZEL_MCP_CONFIG")]
-    pub config: Option<PathBuf>,
+    pub(crate) config: Option<PathBuf>,
     /// Add an allowed workspace root. May be repeated.
     #[arg(long = "allow-root")]
-    pub allowed_roots: Vec<PathBuf>,
+    pub(crate) allowed_roots: Vec<PathBuf>,
     /// Override the invocation cache directory.
     #[arg(long)]
-    pub cache_root: Option<PathBuf>,
+    pub(crate) cache_root: Option<PathBuf>,
     /// Tracing filter written to stderr (stdout is MCP-only).
     #[arg(long, default_value = "bazel_mcp=info")]
     pub log: String,
@@ -58,12 +58,12 @@ pub struct Cli {
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 #[serde(default)]
 pub struct RawMcpConfig {
-    pub progress_initial_seconds: u64,
-    pub progress_interval_seconds: u64,
-    pub result_encoding: ResultEncoding,
-    pub mcp_execution_policy: McpExecutionPolicy,
-    pub task_ttl_seconds: u64,
-    pub task_poll_interval_ms: u64,
+    progress_initial_seconds: u64,
+    progress_interval_seconds: u64,
+    result_encoding: ResultEncoding,
+    mcp_execution_policy: McpExecutionPolicy,
+    task_ttl_seconds: u64,
+    task_poll_interval_ms: u64,
 }
 
 impl Default for RawMcpConfig {
@@ -82,15 +82,15 @@ impl Default for RawMcpConfig {
 /// Flat TOML compatibility layer composed from subsystem-owned raw settings.
 #[derive(Clone, Debug, Serialize)]
 pub struct RawServerConfig {
-    pub cache_root: PathBuf,
+    cache_root: PathBuf,
     #[serde(flatten)]
-    pub policy: RawPolicyConfig,
+    policy: RawPolicyConfig,
     #[serde(flatten)]
-    pub runner: RawRunnerConfig,
+    runner: RawRunnerConfig,
     #[serde(flatten)]
-    pub retention: RawRetentionConfig,
+    retention: RawRetentionConfig,
     #[serde(flatten)]
-    pub mcp: RawMcpConfig,
+    mcp: RawMcpConfig,
 }
 
 impl Default for RawServerConfig {
@@ -159,12 +159,12 @@ impl<'de> Deserialize<'de> for RawServerConfig {
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct McpConfig {
-    pub result_encoding: ResultEncoding,
-    pub progress_initial: Duration,
-    pub progress_interval: Duration,
-    pub execution_policy: McpExecutionPolicy,
-    pub task_ttl: Duration,
-    pub task_poll_interval: Duration,
+    pub(crate) result_encoding: ResultEncoding,
+    pub(crate) progress_initial: Duration,
+    pub(crate) progress_interval: Duration,
+    pub(crate) execution_policy: McpExecutionPolicy,
+    pub(crate) task_ttl: Duration,
+    pub(crate) task_poll_interval: Duration,
 }
 
 impl TryFrom<RawMcpConfig> for McpConfig {
@@ -262,14 +262,7 @@ impl ValidatedServerConfig {
     }
 
     #[must_use]
-    pub fn clamp_timeout(&self, requested: Option<u64>) -> u64 {
-        requested
-            .unwrap_or(self.runner.default_timeout.as_secs())
-            .clamp(1, self.runner.maximum_timeout.as_secs())
-    }
-
-    #[must_use]
-    pub fn cache_root(&self) -> &Path {
+    pub(crate) fn cache_root(&self) -> &Path {
         &self.cache_root
     }
 
@@ -284,7 +277,7 @@ impl ValidatedServerConfig {
     }
 
     #[must_use]
-    pub fn shutdown_wait(&self) -> Duration {
+    pub(crate) fn shutdown_wait(&self) -> Duration {
         self.runner
             .cancellation_interrupt_grace
             .saturating_add(self.runner.cancellation_terminate_grace)

--- a/crates/bazel-mcp-server/src/handler.rs
+++ b/crates/bazel-mcp-server/src/handler.rs
@@ -117,7 +117,7 @@ pub struct CancelParams {
 
 impl BazelMcpServer {
     #[must_use]
-    pub fn new(runner: InvocationService, result_encoding: ResultEncoding) -> Self {
+    pub(crate) fn new(runner: InvocationService, result_encoding: ResultEncoding) -> Self {
         let result_encoder = ResultEncoder::new(result_encoding);
         Self {
             runner,
@@ -133,7 +133,7 @@ impl BazelMcpServer {
     }
 
     #[must_use]
-    pub fn with_progress_timing(
+    pub(crate) fn with_progress_timing(
         mut self,
         initial_delay: std::time::Duration,
         interval: std::time::Duration,
@@ -144,7 +144,7 @@ impl BazelMcpServer {
     }
 
     #[must_use]
-    pub fn with_task_execution(
+    pub(crate) fn with_task_execution(
         mut self,
         policy: McpExecutionPolicy,
         ttl: Duration,

--- a/crates/bazel-mcp-server/src/lib.rs
+++ b/crates/bazel-mcp-server/src/lib.rs
@@ -10,11 +10,10 @@ mod tasks;
 pub use agent::{LaunchMode, agent_log_filter, detect_launch, run_agent};
 pub use bazel_mcp_runner::BepTransport;
 pub use config::{
-    Cli, McpConfig, McpExecutionPolicy, RawAspectConfig, RawMcpConfig, RawPolicyConfig,
-    RawRetentionConfig, RawRunnerConfig, RawServerConfig, RawStarlarkConfig, ResultEncoding,
-    RetentionConfig, ValidatedServerConfig,
+    Cli, McpConfig, McpExecutionPolicy, RawAspectConfig, RawPolicyConfig, RawRetentionConfig,
+    RawRunnerConfig, RawStarlarkConfig, ResultEncoding, RetentionConfig, ValidatedServerConfig,
 };
-pub use handler::BazelMcpServer;
+pub(crate) use handler::BazelMcpServer;
 
 use anyhow::Context;
 use bazel_mcp_runner::{InvocationService, RunnerConfig};

--- a/crates/bazel-mcp-server/src/result.rs
+++ b/crates/bazel-mcp-server/src/result.rs
@@ -27,9 +27,9 @@ pub(crate) struct EncodedResult {
 
 #[derive(Clone, Copy, Debug)]
 pub(crate) struct ExecutionResult<'a> {
-    pub(crate) record: &'a InvocationRecord,
-    pub(crate) tool_error: bool,
-    pub(crate) retained: bool,
+    record: &'a InvocationRecord,
+    tool_error: bool,
+    retained: bool,
 }
 
 impl<'a> ExecutionResult<'a> {
@@ -43,7 +43,7 @@ impl<'a> ExecutionResult<'a> {
     }
 
     #[must_use]
-    pub(crate) const fn ephemeral(record: &'a InvocationRecord) -> Self {
+    const fn ephemeral(record: &'a InvocationRecord) -> Self {
         Self {
             record,
             tool_error: false,

--- a/crates/bazel-mcp-store/src/config.rs
+++ b/crates/bazel-mcp-store/src/config.rs
@@ -7,9 +7,9 @@ use thiserror::Error;
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 #[serde(default)]
 pub struct RawRetentionConfig {
-    pub retention_days: u64,
-    pub maximum_storage_bytes: u64,
-    pub retention_cleanup_interval_seconds: u64,
+    retention_days: u64,
+    maximum_storage_bytes: u64,
+    retention_cleanup_interval_seconds: u64,
 }
 
 impl Default for RawRetentionConfig {

--- a/crates/bazel-mcp-store/src/deferred_repository.rs
+++ b/crates/bazel-mcp-store/src/deferred_repository.rs
@@ -192,7 +192,10 @@ impl Store {
         .await
     }
 
-    pub async fn delete_expired_deferred_results(&self, now_ms: i64) -> Result<usize, StoreError> {
+    pub(crate) async fn delete_expired_deferred_results(
+        &self,
+        now_ms: i64,
+    ) -> Result<usize, StoreError> {
         self.refresh_index_if_stale().await?;
         let ids: Vec<_> = {
             let index = self.inner.index.read().await;

--- a/crates/bazel-mcp-store/src/files.rs
+++ b/crates/bazel-mcp-store/src/files.rs
@@ -18,7 +18,7 @@ use crate::StoreError;
 /// byte provide deterministic, bounded fan-out without a database lookup.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct InvocationPaths {
-    pub directory: PathBuf,
+    pub(crate) directory: PathBuf,
     pub manifest: PathBuf,
     pub details: PathBuf,
     pub stdout: PathBuf,
@@ -62,7 +62,7 @@ impl InvocationPaths {
         }
     }
 
-    pub async fn create(&self) -> Result<(), StoreError> {
+    pub(crate) async fn create(&self) -> Result<(), StoreError> {
         let parent = self
             .directory
             .parent()

--- a/crates/bazel-mcp-store/src/invocation_repository.rs
+++ b/crates/bazel-mcp-store/src/invocation_repository.rs
@@ -31,7 +31,7 @@ impl Store {
 
     /// Read one complete invocation, hydrating target, test, and coverage
     /// collections from the detail sidecar.
-    pub async fn get_hydrated_invocation(
+    pub(crate) async fn get_hydrated_invocation(
         &self,
         id: InvocationId,
     ) -> Result<HydratedInvocation, StoreError> {

--- a/crates/bazel-mcp-store/src/lib.rs
+++ b/crates/bazel-mcp-store/src/lib.rs
@@ -18,12 +18,9 @@ mod retention;
 mod storage;
 mod telemetry;
 
-pub use config::{RawRetentionConfig, RetentionConfig, RetentionConfigError};
+pub use config::{RawRetentionConfig, RetentionConfig};
 pub use files::InvocationPaths;
-pub use record::{
-    CoverageHeader, HydratedInvocation, InvocationDetails, InvocationHeader,
-    InvocationSummaryHeader,
-};
+pub use record::{CoverageHeader, InvocationHeader, InvocationSummaryHeader};
 pub use storage::{InvocationCompletion, Store, StoreError, StoreIoStats, StoreStartupStats};
 
 /// Parser entry point used by adversarial cursor tests and fuzzing.

--- a/crates/bazel-mcp-store/src/query_paging.rs
+++ b/crates/bazel-mcp-store/src/query_paging.rs
@@ -294,7 +294,7 @@ struct BoundedLineReader<R> {
     reader: R,
     offset: u64,
     ordinal: u64,
-    pub(crate) limit: usize,
+    limit: usize,
     value: Vec<u8>,
 }
 

--- a/crates/bazel-mcp-store/src/record.rs
+++ b/crates/bazel-mcp-store/src/record.rs
@@ -16,19 +16,19 @@ use serde::{Deserialize, Deserializer, Serialize, Serializer};
 pub struct InvocationHeader {
     pub request: InvocationRequest,
     pub state: InvocationState,
-    pub started_at_ms: Option<i64>,
+    started_at_ms: Option<i64>,
     pub finished_at_ms: Option<i64>,
     pub termination: Option<Termination>,
     pub summary: Option<InvocationSummaryHeader>,
-    pub run: Option<RunSummary>,
+    run: Option<RunSummary>,
     pub metrics: InvocationMetrics,
-    pub canonical_arguments: Option<Vec<String>>,
-    pub cancellation_reason: Option<String>,
+    canonical_arguments: Option<Vec<String>>,
+    pub(crate) cancellation_reason: Option<String>,
 }
 
 impl InvocationHeader {
     #[must_use]
-    pub fn from_record(record: &InvocationRecord) -> Self {
+    pub(crate) fn from_record(record: &InvocationRecord) -> Self {
         record.clone().into()
     }
 }
@@ -98,22 +98,22 @@ impl<'de> Deserialize<'de> for InvocationHeader {
 /// Summary fields available without loading the detail sidecar.
 #[derive(Clone, Debug, PartialEq)]
 pub struct InvocationSummaryHeader {
-    pub success: bool,
+    success: bool,
     pub headline: String,
     pub target_counts: TargetCounts,
-    pub diagnostics: Vec<Diagnostic>,
+    pub(crate) diagnostics: Vec<Diagnostic>,
     pub test_counts: TestCounts,
-    pub coverage: Option<CoverageHeader>,
-    pub query_sample: Vec<QueryRow>,
-    pub query_result_count: Option<u64>,
-    pub elapsed_ms: u64,
-    pub truncated: bool,
-    pub inspect_hint: Option<InspectHint>,
+    coverage: Option<CoverageHeader>,
+    query_sample: Vec<QueryRow>,
+    pub(crate) query_result_count: Option<u64>,
+    elapsed_ms: u64,
+    truncated: bool,
+    inspect_hint: Option<InspectHint>,
 }
 
 impl InvocationSummaryHeader {
     #[must_use]
-    pub fn into_summary(self) -> InvocationSummary {
+    fn into_summary(self) -> InvocationSummary {
         InvocationSummary {
             success: self.success,
             headline: self.headline,
@@ -159,9 +159,9 @@ impl From<InvocationSummary> for InvocationSummaryHeader {
 /// Aggregate coverage values retained in the compact manifest.
 #[derive(Clone, Debug, PartialEq)]
 pub struct CoverageHeader {
-    pub lines_found: u64,
-    pub lines_hit: u64,
-    pub coverage_percent: f64,
+    lines_found: u64,
+    lines_hit: u64,
+    coverage_percent: f64,
 }
 
 impl CoverageHeader {
@@ -194,14 +194,14 @@ impl From<CoverageSummary> for CoverageHeader {
 /// Large collections stored in `details.json` rather than the manifest.
 #[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize)]
 pub struct InvocationDetails {
-    pub targets: Vec<TargetResult>,
-    pub tests: Vec<TestResult>,
-    pub coverage_files: Vec<CoverageFile>,
+    pub(crate) targets: Vec<TargetResult>,
+    pub(crate) tests: Vec<TestResult>,
+    pub(crate) coverage_files: Vec<CoverageFile>,
 }
 
 impl InvocationDetails {
     #[must_use]
-    pub fn from_record(record: &InvocationRecord) -> Self {
+    pub(crate) fn from_record(record: &InvocationRecord) -> Self {
         let Some(summary) = &record.summary else {
             return Self::default();
         };
@@ -227,7 +227,7 @@ impl InvocationDetails {
     }
 
     #[must_use]
-    pub fn is_empty(&self) -> bool {
+    pub(crate) fn is_empty(&self) -> bool {
         self.targets.is_empty() && self.tests.is_empty() && self.coverage_files.is_empty()
     }
 }
@@ -235,13 +235,14 @@ impl InvocationDetails {
 /// A manifest header combined with its detail sidecar.
 #[derive(Clone, Debug, PartialEq)]
 pub struct HydratedInvocation {
-    pub header: InvocationHeader,
-    pub details: InvocationDetails,
+    pub(crate) header: InvocationHeader,
+    pub(crate) details: InvocationDetails,
 }
 
 impl HydratedInvocation {
     #[must_use]
-    pub fn from_record(record: &InvocationRecord) -> Self {
+    #[cfg(test)]
+    fn from_record(record: &InvocationRecord) -> Self {
         Self {
             header: InvocationHeader::from_record(record),
             details: InvocationDetails::from_record(record),
@@ -249,7 +250,7 @@ impl HydratedInvocation {
     }
 
     #[must_use]
-    pub fn into_record(self) -> InvocationRecord {
+    pub(crate) fn into_record(self) -> InvocationRecord {
         let mut record = self.header.into_record();
         self.details.hydrate(&mut record);
         record

--- a/crates/bazel-mcp-store/src/storage.rs
+++ b/crates/bazel-mcp-store/src/storage.rs
@@ -74,9 +74,9 @@ pub struct Store {
 
 pub(crate) struct StoreInner {
     pub(crate) index: IndexCoordinator,
-    pub(crate) manifests: ManifestRepository,
-    pub(crate) leases: LeaseManager,
-    pub(crate) changes: ChangeCoordinator,
+    manifests: ManifestRepository,
+    leases: LeaseManager,
+    changes: ChangeCoordinator,
     pub(crate) metrics: StoreMetrics,
     startup_stats: StoreStartupStats,
 }
@@ -576,7 +576,8 @@ impl Store {
     /// Page raw query output after applying a caller-supplied text transform.
     /// The transform runs before filtering or returning values, allowing the
     /// runner to redact without persisting a second copy of query results.
-    pub async fn page_query_rows_mapped<F>(
+    #[cfg(test)]
+    async fn page_query_rows_mapped<F>(
         &self,
         id: InvocationId,
         filter: Option<&str>,

--- a/crates/bazel-mcp-types/src/deferred.rs
+++ b/crates/bazel-mcp-types/src/deferred.rs
@@ -29,15 +29,6 @@ impl DeferredRetrieval {
             Self::InlineResult => "inline_result",
         }
     }
-
-    #[must_use]
-    pub fn parse(value: &str) -> Option<Self> {
-        match value {
-            "separate_result" => Some(Self::SeparateResult),
-            "inline_result" => Some(Self::InlineResult),
-            _ => None,
-        }
-    }
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]
@@ -46,50 +37,12 @@ pub enum DeferredTerminalState {
     Cancelled,
 }
 
-impl DeferredTerminalState {
-    #[must_use]
-    pub const fn as_str(self) -> &'static str {
-        match self {
-            Self::Cancelled => "cancelled",
-        }
-    }
-
-    #[must_use]
-    pub fn parse(value: &str) -> Option<Self> {
-        match value {
-            "cancelled" => Some(Self::Cancelled),
-            _ => None,
-        }
-    }
-}
-
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum DeferredFailureKind {
     Queue,
     Execution,
     Internal,
-}
-
-impl DeferredFailureKind {
-    #[must_use]
-    pub const fn as_str(self) -> &'static str {
-        match self {
-            Self::Queue => "queue",
-            Self::Execution => "execution",
-            Self::Internal => "internal",
-        }
-    }
-
-    #[must_use]
-    pub fn parse(value: &str) -> Option<Self> {
-        match value {
-            "queue" => Some(Self::Queue),
-            "execution" => Some(Self::Execution),
-            "internal" => Some(Self::Internal),
-            _ => None,
-        }
-    }
 }
 
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
@@ -131,7 +84,7 @@ impl DeferredResultRecord {
     }
 
     #[must_use]
-    pub fn configured_ttl_ms(&self) -> i64 {
+    fn configured_ttl_ms(&self) -> i64 {
         self.expires_at_ms.saturating_sub(self.updated_at_ms).max(1)
     }
 

--- a/crates/bazel-mcp-types/src/inspection.rs
+++ b/crates/bazel-mcp-types/src/inspection.rs
@@ -21,7 +21,7 @@ pub enum InspectView {
 }
 
 impl InspectView {
-    pub const FOLLOW_UP: [Self; 9] = [
+    const FOLLOW_UP: [Self; 9] = [
         Self::Summary,
         Self::Metrics,
         Self::Diagnostics,
@@ -80,22 +80,6 @@ impl AvailableViews {
     #[must_use]
     pub fn follow_up() -> Self {
         Self(InspectView::FOLLOW_UP.to_vec())
-    }
-
-    #[must_use]
-    pub fn contains(&self, view: InspectView) -> bool {
-        self.0.contains(&view)
-    }
-
-    #[must_use]
-    pub fn has_details(&self) -> bool {
-        self.0
-            .iter()
-            .any(|view| !matches!(view, InspectView::Summary | InspectView::Metrics))
-    }
-
-    pub fn iter(&self) -> impl Iterator<Item = InspectView> + '_ {
-        self.0.iter().copied()
     }
 }
 
@@ -189,7 +173,7 @@ pub enum InspectPayload {
 
 impl InspectPayload {
     #[must_use]
-    pub fn view(&self) -> InspectView {
+    fn view(&self) -> InspectView {
         match self {
             Self::Summary(_) => InspectView::Summary,
             Self::Metrics(_) => InspectView::Metrics,
@@ -224,7 +208,7 @@ impl InspectPayload {
         self.len() == 0
     }
 
-    pub fn truncate(&mut self, len: usize) {
+    fn truncate(&mut self, len: usize) {
         match self {
             Self::Summary(items) => items.truncate(len),
             Self::Metrics(items) => items.truncate(len),
@@ -260,17 +244,17 @@ impl Serialize for InspectPayload {
 
 #[derive(Clone, Debug, PartialEq, Serialize)]
 pub struct InspectResult {
-    pub invocation_id: Option<InvocationId>,
-    pub view: InspectView,
+    invocation_id: Option<InvocationId>,
+    view: InspectView,
     pub items: InspectPayload,
-    pub total_count: Option<u64>,
-    pub filtered_count: Option<u64>,
+    total_count: Option<u64>,
+    filtered_count: Option<u64>,
     pub next_cursor: Option<String>,
     pub truncated: bool,
     #[serde(skip)]
-    pub start_cursor: Option<String>,
+    start_cursor: Option<String>,
     #[serde(skip)]
-    pub item_cursors: Vec<String>,
+    item_cursors: Vec<String>,
 }
 
 impl InspectResult {

--- a/crates/bazel-mcp-types/src/invocation.rs
+++ b/crates/bazel-mcp-types/src/invocation.rs
@@ -126,7 +126,7 @@ impl InvocationState {
         )
     }
 
-    pub fn validate_transition(self, next: Self) -> Result<(), StateTransitionError> {
+    fn validate_transition(self, next: Self) -> Result<(), StateTransitionError> {
         let valid = matches!(
             (self, next),
             (

--- a/hawk.toml
+++ b/hawk.toml
@@ -1,0 +1,57 @@
+[[production]]
+package = "bazel-mcp-server"
+bin = "bazel-mcp"
+reason = "shipped MCP server binary"
+
+[[production]]
+package = "bazel-mcp-reducer-cases"
+bin = "reducer-cases"
+reason = "repository reducer integration harness"
+
+[[production]]
+package = "bazel-mcp-benchmark"
+bin = "bep-spike"
+reason = "BEP decoder benchmark"
+
+[[production]]
+package = "bazel-mcp-benchmark"
+bin = "token-integration"
+reason = "token integration benchmark"
+
+[[production]]
+package = "bazel-mcp-benchmark"
+bin = "agentic-benchmark"
+reason = "agentic integration benchmark"
+
+[[production]]
+package = "bazel-mcp-benchmark"
+bin = "bazel-agentic-shell"
+reason = "agentic shell benchmark adapter"
+
+[[production]]
+package = "bazel-mcp-benchmark"
+bin = "storage-benchmark"
+reason = "storage benchmark"
+
+[[production]]
+package = "bazel-mcp-benchmark"
+bin = "bes-transport-benchmark"
+reason = "BES transport benchmark"
+
+[[exclude]]
+crate = "bazel_mcp_bep"
+module = "proto"
+reason = "generated from the Bazel Build Event Protocol schema"
+
+[[exclude]]
+crate = "bazel_mcp_bes"
+module = "proto"
+reason = "generated from the Build Event Service schema"
+
+[[override]]
+lint = "hawk::dead_public"
+crate = "bazel_mcp_store"
+item = "cursor_is_well_formed"
+kind = "function"
+level = "expect"
+reason = "public entry point for the separate fuzz workspace"

--- a/specs/003-buffa-spike.md
+++ b/specs/003-buffa-spike.md
@@ -171,8 +171,8 @@ user-plus-system CPU time. Do not use a single wall-time result.
   repeated-element memory amplification in owned and view decoding. Existing
   frame, stream, and event limits bound input bytes but not the number of
   repeated elements inside one frame. The current trust boundary is a local
-  BEP file emitted by the Bazel process started by this server; `decode_event`
-  must not be repurposed for arbitrary remote protobuf input. Track the issue
+  BEP file emitted by the Bazel process started by this server; the BEP decode
+  pipeline must not be repurposed for arbitrary remote protobuf input. Track the issue
   and enable an upstream decoded-element budget when one is available.
 - The open reflection/WKT conformance issue is outside this integration: the
   BEP subset uses neither Buffa reflection nor its well-known-type adapters.


### PR DESCRIPTION
## Summary

- configure Hawk across the shipped server and repository utility binaries
- add a checksum-pinned Hawk 0.1.8 CI job using Rust 1.97.0
- remove dead APIs and narrow workspace-internal visibility
- preserve generated protobuf bindings and the separate fuzz-workspace cursor entry point with explicit audited configuration

## Why

Workspace crate boundaries required many declarations to be public even though they were not part of a supported external API. Rust built-in dead-code lints cannot perform closed-world analysis across the workspace, leaving dead helpers and unnecessarily broad visibility undetected.

Hawk now treats the eight intentional binaries as reachability roots and fails CI on new findings.

## Validation

- `make test` (273 tests)
- `make check`
- `make hawk` (0 findings)
- nightly `bep_framing` fuzz smoke
- actionlint 1.7.7
- zizmor 1.25.2
- Release Please configuration check
- pinned Linux Hawk archive checksum and extraction

The Bazel-backed matrix was not run locally because this checkout had no Bazel MCP tool available; the existing CI Bazel jobs remain the gate.