### PR TITLE
fix(fuzz): repair scheduled target coverage

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -8,7 +8,28 @@ concurrency:
   group: fuzz-${{ github.ref }}
   cancel-in-progress: false
 jobs:
+  fuzz-targets:
+    permissions:
+      contents: read
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.targets.outputs.matrix }}
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with: { persist-credentials: false }
+      - name: Discover fuzz targets
+        id: targets
+        shell: bash
+        run: |
+          matrix="$(
+            cargo metadata --no-deps --format-version 1 \
+              --manifest-path fuzz/Cargo.toml |
+              jq -c '[.packages[].targets[] | select(.kind == ["bin"]) | .name]'
+          )"
+          test "$matrix" != "[]"
+          echo "matrix=$matrix" >> "$GITHUB_OUTPUT"
   fuzz:
+    needs: fuzz-targets
     permissions:
       contents: read
     runs-on: ubuntu-latest
@@ -16,7 +37,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        target: [bep_framing, bep_event_stream, named_file_sets, diagnostic_reducer, redaction, cursor_decode, lifecycle_sequence]
+        target: ${{ fromJSON(needs.fuzz-targets.outputs.matrix) }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with: { persist-credentials: false }

--- a/Makefile
+++ b/Makefile
@@ -198,6 +198,7 @@ fuzz-list: fuzz-setup
 	cd fuzz && cargo +nightly fuzz list
 
 fuzz-smoke: fuzz-setup
+	cd fuzz && cargo +nightly check --all-targets
 	cd fuzz && cargo +nightly fuzz run $(FUZZ_TARGET) -- -runs=1
 
 fuzz-run: fuzz-setup

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -176,7 +176,7 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "bazel-mcp-bep"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "buffa",
  "buffa-build",
@@ -186,7 +186,7 @@ dependencies = [
 
 [[package]]
 name = "bazel-mcp-bes"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "bazel-mcp-bep",
  "buffa",
@@ -218,7 +218,7 @@ dependencies = [
 
 [[package]]
 name = "bazel-mcp-policy"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "bazel-mcp-types",
  "regex",
@@ -229,7 +229,7 @@ dependencies = [
 
 [[package]]
 name = "bazel-mcp-reducer"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "bazel-mcp-bep",
@@ -244,7 +244,7 @@ dependencies = [
 
 [[package]]
 name = "bazel-mcp-store"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "base64",
  "bazel-mcp-types",
@@ -259,7 +259,7 @@ dependencies = [
 
 [[package]]
 name = "bazel-mcp-types"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "serde",
  "thiserror",

--- a/fuzz/fuzz_targets/lifecycle_sequence.rs
+++ b/fuzz/fuzz_targets/lifecycle_sequence.rs
@@ -1,21 +1,23 @@
 #![no_main]
-use bazel_mcp_types::InvocationState;
+use std::path::PathBuf;
+
+use bazel_mcp_types::{BazelCommand, InvocationRecord, InvocationRequest, InvocationState};
 use libfuzzer_sys::fuzz_target;
 
 fuzz_target!(|sequence: &[u8]| {
-    let mut state = InvocationState::Queued;
+    let request = InvocationRequest::new(PathBuf::new(), BazelCommand::Build, Vec::new());
+    let mut record = InvocationRecord::queued(request);
     for byte in sequence {
-        let next = match byte % 7 {
+        let next = match byte % 8 {
             0 => InvocationState::Queued,
-            1 => InvocationState::Running,
-            2 => InvocationState::Succeeded,
-            3 => InvocationState::Failed,
-            4 => InvocationState::Cancelled,
-            5 => InvocationState::TimedOut,
+            1 => InvocationState::Starting,
+            2 => InvocationState::Running,
+            3 => InvocationState::Succeeded,
+            4 => InvocationState::Failed,
+            5 => InvocationState::Cancelled,
+            6 => InvocationState::TimedOut,
             _ => InvocationState::Interrupted,
         };
-        if state.validate_transition(next).is_ok() {
-            state = next;
-        }
+        let _ = record.transition(next);
     }
 });

--- a/fuzz/fuzz_targets/named_file_sets.rs
+++ b/fuzz/fuzz_targets/named_file_sets.rs
@@ -2,7 +2,20 @@
 use libfuzzer_sys::fuzz_target;
 
 fuzz_target!(|data: &[u8]| {
-    if let Ok(event) = bazel_mcp_bep::decode_event(data) {
-        let _ = bazel_mcp_reducer::reduce_artifacts(&[event]);
-    }
+    let framed = frame(data);
+    let partial = bazel_mcp_bep::decode_stream_partial(framed.as_slice(), 1024 * 1024);
+    let _ = bazel_mcp_reducer::reduce_artifacts(&partial.events);
 });
+
+fn frame(data: &[u8]) -> Vec<u8> {
+    let mut framed = Vec::with_capacity(data.len().saturating_add(10));
+    let mut remaining = data.len();
+    while remaining >= 0x80 {
+        let byte = u8::try_from(remaining & 0x7f).expect("length byte is masked to seven bits");
+        framed.push(byte | 0x80);
+        remaining >>= 7;
+    }
+    framed.push(u8::try_from(remaining).expect("final length byte fits in seven bits"));
+    framed.extend_from_slice(data);
+    framed
+}


### PR DESCRIPTION
## Summary

- repair the stale `named_file_sets` and `lifecycle_sequence` fuzz harnesses against current public APIs
- derive the scheduled fuzz matrix from the binaries declared in `fuzz/Cargo.toml`
- compile every fuzz target during PR smoke coverage and refresh the standalone fuzz lockfile

## Root cause

The scheduled fuzz run referenced the removed `diagnostic_reducer` target, while two remaining targets still called APIs that had been removed or made private. PR fuzz smoke only compiled the default `bep_framing` target, so the standalone fuzz workspace drift was not detected before the scheduled run.

No crashing input was discovered; all three failures were harness compilation failures.

## Validation

- `make test`
- `make check`
- `cargo check --manifest-path fuzz/Cargo.toml --all-targets --locked`
- one-run ASAN smoke for `lifecycle_sequence`
- one-run ASAN smoke for `bep_framing`

The reducer-backed `named_file_sets` target compiles successfully. Its local ASAN link remains blocked by an existing macOS nightly linker failure in the Starlark/`ctor` dependency stack; the scheduled fuzz workflow runs on Ubuntu.
