### PR TITLE
fix: restore nightly reducer tests across macOS and Windows

### DIFF
--- a/.github/workflows/reducer-integration.yml
+++ b/.github/workflows/reducer-integration.yml
@@ -85,6 +85,10 @@ jobs:
         with:
           persist-credentials: false
           fetch-depth: 0
+      - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
+        with:
+          go-version: "1.26.0"
+          cache: false
       - run: go install github.com/bazelbuild/bazelisk@v1.26.0
       - run: cargo build -p bazel-mcp-server --bin bazel-mcp
       - name: Verify changed examples through MCP
@@ -107,6 +111,10 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with: { persist-credentials: false }
+      - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
+        with:
+          go-version: "1.26.0"
+          cache: false
       - run: go install github.com/bazelbuild/bazelisk@v1.26.0
       - run: cargo build -p bazel-mcp-server --bin bazel-mcp
       - run: >-
@@ -131,6 +139,10 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with: { persist-credentials: false }
+      - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
+        with:
+          go-version: "1.26.0"
+          cache: false
       - run: go install github.com/bazelbuild/bazelisk@v1.26.0
       - run: cargo build -p bazel-mcp-server --bin bazel-mcp
       - name: Locate platform executables
@@ -162,6 +174,10 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with: { persist-credentials: false }
+      - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
+        with:
+          go-version: "1.26.0"
+          cache: false
       - run: go install github.com/bazelbuild/bazelisk@v1.26.0
       - run: cargo build -p bazel-mcp-server --bin bazel-mcp
       - run: >-

--- a/.github/workflows/reducer-integration.yml
+++ b/.github/workflows/reducer-integration.yml
@@ -153,16 +153,19 @@ jobs:
           $installation = & $vswhere -latest -products '*' -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property installationPath
           if (!$installation) { throw "Visual C++ build tools were not found" }
           "BAZEL_VC=$installation\VC" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+          # MSVC cannot open response files beyond MAX_PATH, even when Rust can.
+          "MCP_RUNTIME_PARENT=$env:SystemDrive/bmc" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
       - name: Locate platform executables
         shell: bash
         run: |
           if [[ "$RUNNER_OS" == "Windows" ]]; then
-            echo "BAZELISK_BIN=$HOME/go/bin/bazelisk.exe" >> "$GITHUB_ENV"
-            echo "MCP_SERVER_BIN=$PWD/target/debug/bazel-mcp.exe" >> "$GITHUB_ENV"
+            echo "BAZELISK_BIN=$HOME/go/bin/bazelisk.exe"
+            echo "MCP_SERVER_BIN=$PWD/target/debug/bazel-mcp.exe"
           else
-            echo "BAZELISK_BIN=$HOME/go/bin/bazelisk" >> "$GITHUB_ENV"
-            echo "MCP_SERVER_BIN=$PWD/target/debug/bazel-mcp" >> "$GITHUB_ENV"
-          fi
+            echo "BAZELISK_BIN=$HOME/go/bin/bazelisk"
+            echo "MCP_SERVER_BIN=$PWD/target/debug/bazel-mcp"
+            echo "MCP_RUNTIME_PARENT=$RUNNER_TEMP"
+          fi >> "$GITHUB_ENV"
       - name: Verify all supported fast cases through MCP
         env:
           BAZEL_VERSION: ${{ matrix.bazel }}
@@ -171,6 +174,7 @@ jobs:
           cargo run -p bazel-mcp-reducer-cases -- verify --live
           --tag fast --bazel-version "$BAZEL_VERSION"
           --server "$MCP_SERVER_BIN" --bazel "$BAZELISK_BIN"
+          --runtime-parent "$MCP_RUNTIME_PARENT"
 
   reducer-live-heavy:
     name: Live heavy cases

--- a/.github/workflows/reducer-integration.yml
+++ b/.github/workflows/reducer-integration.yml
@@ -145,6 +145,14 @@ jobs:
           cache: false
       - run: go install github.com/bazelbuild/bazelisk@v1.26.0
       - run: cargo build -p bazel-mcp-server --bin bazel-mcp
+      - name: Locate Windows C++ toolchain
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          $vswhere = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe"
+          $installation = & $vswhere -latest -products '*' -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property installationPath
+          if (!$installation) { throw "Visual C++ build tools were not found" }
+          "BAZEL_VC=$installation\VC" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
       - name: Locate platform executables
         shell: bash
         run: |

--- a/LEARNINGS.md
+++ b/LEARNINGS.md
@@ -26,3 +26,10 @@ MCP efficiency. Do not include secrets or raw sensitive output.
 - Impact: diagnosing the platform failure required another CI run despite an existing reduced diagnostic.
 - Follow-up: include the MCP headline in exit-code mismatch errors and verify the resulting Windows failure is actionable.
 - Codex Thread ID: `01a07230-796a-77d1-9609-55bc1b9e4b4c`.
+
+### Bazel server startup failures lack retained JVM diagnostics
+
+- Symptom: Windows Bazel 9.2.0 returned exit code 37 with no diagnostics; the headline only repeated the exit code. `bazel.inspect` log contained only installation extraction and server-start messages.
+- Impact: neither the run result nor a bounded log inspection explained the failure. Investigating it required extra CI runs and a harness change to inspect `server/jvm.out` before the isolated runtime was deleted.
+- Follow-up: on server-start failures, capture a bounded, redacted JVM startup log from the effective output base into durable evidence and surface its actionable error through the normal inspection flow.
+- Codex Thread ID: `01a07230-796a-77d1-9609-55bc1b9e4b4c`.

--- a/LEARNINGS.md
+++ b/LEARNINGS.md
@@ -19,3 +19,10 @@ MCP efficiency. Do not include secrets or raw sensitive output.
 - Impact: the headline did not identify the cause; the response spent diagnostic entries and model-visible tokens on empty messages, requiring a scan of the remaining diagnostics.
 - Follow-up: discard empty normalized diagnostics before deduplication and select the first nonempty actionable message for the headline. Add a regression fixture for a toolchain-analysis failure with empty BEP failure messages.
 - Codex Thread ID: `01a07230-796a-77d1-9609-55bc1b9e4b4c`.
+
+### Live verification hides the MCP failure headline
+
+- Symptom: a Windows live case failed with exit code 37, but the verifier printed only expected/actual codes and dropped the MCP headline.
+- Impact: diagnosing the platform failure required another CI run despite an existing reduced diagnostic.
+- Follow-up: include the MCP headline in exit-code mismatch errors and verify the resulting Windows failure is actionable.
+- Codex Thread ID: `01a07230-796a-77d1-9609-55bc1b9e4b4c`.

--- a/LEARNINGS.md
+++ b/LEARNINGS.md
@@ -20,13 +20,6 @@ MCP efficiency. Do not include secrets or raw sensitive output.
 - Follow-up: discard empty normalized diagnostics before deduplication and select the first nonempty actionable message for the headline. Add a regression fixture for a toolchain-analysis failure with empty BEP failure messages.
 - Codex Thread ID: `01a07230-796a-77d1-9609-55bc1b9e4b4c`.
 
-### Live verification hides the MCP failure headline
-
-- Symptom: a Windows live case failed with exit code 37, but the verifier printed only expected/actual codes and dropped the MCP headline.
-- Impact: diagnosing the platform failure required another CI run despite an existing reduced diagnostic.
-- Follow-up: include the MCP headline in exit-code mismatch errors and verify the resulting Windows failure is actionable.
-- Codex Thread ID: `01a07230-796a-77d1-9609-55bc1b9e4b4c`.
-
 ### Bazel server startup failures lack retained JVM diagnostics
 
 - Symptom: Windows Bazel 9.2.0 returned exit code 37 with no diagnostics; the headline only repeated the exit code. `bazel.inspect` log contained only installation extraction and server-start messages.

--- a/crates/bazel-mcp-policy/src/environment.rs
+++ b/crates/bazel-mcp-policy/src/environment.rs
@@ -7,8 +7,69 @@ const ALWAYS_ALLOWED: &[&str] = &["HOME", "PATH", "TMPDIR", "TEMP", "TMP", "USER
 #[must_use]
 pub fn filtered_environment(config: &PolicyConfig) -> BTreeMap<String, String> {
     std::env::vars()
-        .filter(|(name, _)| {
-            ALWAYS_ALLOWED.contains(&name.as_str()) || config.environment_allowlist.contains(name)
-        })
+        .filter(|(name, _)| is_allowed(name, config, cfg!(windows)))
         .collect()
+}
+
+fn is_allowed(name: &str, config: &PolicyConfig, windows: bool) -> bool {
+    if windows {
+        // Windows environment names are case-insensitive. SystemRoot is needed
+        // by Windows runtime services, including Winsock name resolution.
+        name.eq_ignore_ascii_case("SystemRoot")
+            || ALWAYS_ALLOWED
+                .iter()
+                .any(|allowed| name.eq_ignore_ascii_case(allowed))
+            || config
+                .environment_allowlist
+                .iter()
+                .any(|allowed| name.eq_ignore_ascii_case(allowed))
+    } else {
+        ALWAYS_ALLOWED.contains(&name) || config.environment_allowlist.contains(name)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn windows_preserves_system_root_and_case_insensitive_names() {
+        let mut config = PolicyConfig::default();
+        config
+            .environment_allowlist
+            .insert("BAZELISK_HOME".to_owned());
+        for name in [
+            "SystemRoot",
+            "SYSTEMROOT",
+            "systemroot",
+            "Path",
+            "TEMP",
+            "Bazelisk_Home",
+        ] {
+            assert!(is_allowed(name, &config, true), "missing {name}");
+        }
+        for name in ["GITHUB_TOKEN", "AWS_SECRET_ACCESS_KEY", "UNLISTED"] {
+            assert!(!is_allowed(name, &config, true), "leaked {name}");
+        }
+    }
+
+    #[test]
+    fn unix_environment_names_remain_case_sensitive() {
+        let mut config = PolicyConfig::default();
+        config
+            .environment_allowlist
+            .insert("BAZELISK_HOME".to_owned());
+        for name in ["PATH", "HOME", "BAZELISK_HOME"] {
+            assert!(is_allowed(name, &config, false));
+        }
+        for name in [
+            "Path",
+            "home",
+            "Bazelisk_Home",
+            "SystemRoot",
+            "GITHUB_TOKEN",
+        ] {
+            assert!(!is_allowed(name, &config, false));
+        }
+    }
 }

--- a/crates/bazel-mcp-reducer-cases/src/mcp.rs
+++ b/crates/bazel-mcp-reducer-cases/src/mcp.rs
@@ -187,13 +187,29 @@ pub fn run_live_case(case: &LoadedCase, options: &LiveOptions) -> Result<LiveRun
             if let Ok(file) = fs::File::open(&path) {
                 let mut bytes = Vec::new();
                 file.take(8192).read_to_end(&mut bytes)?;
-                let runtime_name = runtime.path().to_string_lossy();
-                let workspace_name = workspace.to_string_lossy();
-                let replacements = [
-                    ("RUNTIME", runtime_name.as_bytes()),
-                    ("WORKSPACE", workspace_name.as_bytes()),
+                let normalized = String::from_utf8_lossy(&bytes).replace('\\', "/");
+                let paths = [
+                    (
+                        "RUNTIME",
+                        runtime.path().to_string_lossy().replace('\\', "/"),
+                    ),
+                    ("WORKSPACE", workspace.to_string_lossy().replace('\\', "/")),
+                    (
+                        "HOME",
+                        std::env::var("USERPROFILE")
+                            .unwrap_or_default()
+                            .replace('\\', "/"),
+                    ),
+                    (
+                        "HOME",
+                        std::env::var("HOME").unwrap_or_default().replace('\\', "/"),
+                    ),
                 ];
-                match crate::sanitize_text(&bytes, &replacements) {
+                let replacements: Vec<_> = paths
+                    .iter()
+                    .map(|(label, path)| (*label, path.as_bytes()))
+                    .collect();
+                match crate::sanitize_text(normalized.as_bytes(), &replacements) {
                     Ok(text) => eprintln!(
                         "{}: JVM startup log: {}",
                         case.manifest.id,

--- a/crates/bazel-mcp-reducer-cases/src/mcp.rs
+++ b/crates/bazel-mcp-reducer-cases/src/mcp.rs
@@ -50,7 +50,7 @@ struct HarnessConfig<'a> {
     output_user_root: &'a Path,
     #[serde(skip_serializing_if = "Option::is_none")]
     bazel_executable: Option<&'a Path>,
-    environment_allowlist: [&'static str; 2],
+    environment_allowlist: Vec<&'static str>,
     redaction_patterns: [&'static str; 3],
     result_encoding: &'static str,
     bep_transport: &'static str,
@@ -94,7 +94,23 @@ pub fn run_live_case(case: &LoadedCase, options: &LiveOptions) -> Result<LiveRun
         cache_root: &cache_root,
         output_user_root: &output_user_root,
         bazel_executable: options.bazel_executable.as_deref(),
-        environment_allowlist: ["BAZELISK_HOME", "USE_BAZEL_VERSION"],
+        environment_allowlist: {
+            let mut names = vec!["BAZELISK_HOME", "USE_BAZEL_VERSION"];
+            if cfg!(windows) {
+                // Explicit toolchain location plus the system directories used
+                // by Visual Studio's compiler/SDK setup scripts.
+                names.extend([
+                    "BAZEL_VC",
+                    "ProgramFiles",
+                    "ProgramFiles(x86)",
+                    "ProgramW6432",
+                    "ProgramData",
+                    "COMSPEC",
+                    "SystemDrive",
+                ]);
+            }
+            names
+        },
         redaction_patterns: [
             "(?i)token=[^\\s]+",
             "(?i)(authorization|x-buildbuddy-api-key)=[^\\s]+",

--- a/crates/bazel-mcp-reducer-cases/src/mcp.rs
+++ b/crates/bazel-mcp-reducer-cases/src/mcp.rs
@@ -1,6 +1,6 @@
 use std::{
     fs,
-    io::{BufRead, BufReader, Write},
+    io::{BufRead, BufReader, Read, Write},
     path::{Path, PathBuf},
     process::{Child, ChildStdin, ChildStdout, Command, Stdio},
 };
@@ -182,6 +182,29 @@ pub fn run_live_case(case: &LoadedCase, options: &LiveOptions) -> Result<LiveRun
             }),
         )?;
         eprintln!("{}: unexpected exit code; MCP log: {log}", case.manifest.id);
+        for entry in fs::read_dir(&output_user_root)?.flatten() {
+            let path = entry.path().join("server/jvm.out");
+            if let Ok(file) = fs::File::open(&path) {
+                let mut bytes = Vec::new();
+                file.take(8192).read_to_end(&mut bytes)?;
+                let runtime_name = runtime.path().to_string_lossy();
+                let workspace_name = workspace.to_string_lossy();
+                let replacements = [
+                    ("RUNTIME", runtime_name.as_bytes()),
+                    ("WORKSPACE", workspace_name.as_bytes()),
+                ];
+                match crate::sanitize_text(&bytes, &replacements) {
+                    Ok(text) => eprintln!(
+                        "{}: JVM startup log: {}",
+                        case.manifest.id,
+                        String::from_utf8_lossy(&text)
+                    ),
+                    Err(error) => {
+                        eprintln!("{}: JVM startup log withheld: {error}", case.manifest.id)
+                    }
+                }
+            }
+        }
     }
     client.stop();
 

--- a/crates/bazel-mcp-reducer-cases/src/mcp.rs
+++ b/crates/bazel-mcp-reducer-cases/src/mcp.rs
@@ -169,9 +169,42 @@ pub fn run_live_case(case: &LoadedCase, options: &LiveOptions) -> Result<LiveRun
             }),
         )?;
     }
-    if let Some(expected) = case.manifest.expect.exit_code
-        && run_result.get("exit_code").and_then(Value::as_i64) != Some(i64::from(expected))
-    {
+    let diagnostics = run_result
+        .get("diagnostics")
+        .cloned()
+        .map(serde_json::from_value::<Vec<Diagnostic>>)
+        .transpose()
+        .context("decode live diagnostics")?
+        .unwrap_or_default();
+    let artifacts = artifact_result
+        .get("items")
+        .cloned()
+        .map(serde_json::from_value::<Vec<Artifact>>)
+        .transpose()
+        .context("decode live artifacts")?
+        .unwrap_or_default();
+    let id = InvocationId::from_uuid(
+        Uuid::parse_str(&invocation_id).context("parse live invocation UUID")?,
+    );
+    let invocation_paths = InvocationPaths::new(&cache_root, id);
+    let raw_text = read_retained_text(&invocation_paths)?;
+    let observation = CaseObservation {
+        state: required_string(&run_result, "state")?.to_owned(),
+        exit_code: run_result
+            .get("exit_code")
+            .and_then(Value::as_i64)
+            .and_then(|value| i32::try_from(value).ok()),
+        headline: required_string(&run_result, "headline")?.to_owned(),
+        inspect_hint: run_result
+            .get("inspect_hint")
+            .and_then(Value::as_str)
+            .map(ToOwned::to_owned),
+        diagnostics,
+        artifacts,
+        visible_bytes: serde_json::to_vec(&run_result)?.len(),
+        raw_text,
+    };
+    if crate::verify_expectations(&case.manifest.id, &case.manifest.expect, &observation).is_err() {
         let log = client.call_tool(
             "bazel.inspect",
             json!({
@@ -181,7 +214,10 @@ pub fn run_live_case(case: &LoadedCase, options: &LiveOptions) -> Result<LiveRun
                 "max_bytes": 8192,
             }),
         )?;
-        eprintln!("{}: unexpected exit code; MCP log: {log}", case.manifest.id);
+        eprintln!(
+            "{}: live verification failure; MCP log: {log}",
+            case.manifest.id
+        );
         for entry in fs::read_dir(&output_user_root)?.flatten() {
             let path = entry.path().join("server/jvm.out");
             if let Ok(file) = fs::File::open(&path) {
@@ -221,42 +257,6 @@ pub fn run_live_case(case: &LoadedCase, options: &LiveOptions) -> Result<LiveRun
         }
     }
     client.stop();
-
-    let diagnostics = run_result
-        .get("diagnostics")
-        .cloned()
-        .map(serde_json::from_value::<Vec<Diagnostic>>)
-        .transpose()
-        .context("decode live diagnostics")?
-        .unwrap_or_default();
-    let artifacts = artifact_result
-        .get("items")
-        .cloned()
-        .map(serde_json::from_value::<Vec<Artifact>>)
-        .transpose()
-        .context("decode live artifacts")?
-        .unwrap_or_default();
-    let id = InvocationId::from_uuid(
-        Uuid::parse_str(&invocation_id).context("parse live invocation UUID")?,
-    );
-    let invocation_paths = InvocationPaths::new(&cache_root, id);
-    let raw_text = read_retained_text(&invocation_paths)?;
-    let observation = CaseObservation {
-        state: required_string(&run_result, "state")?.to_owned(),
-        exit_code: run_result
-            .get("exit_code")
-            .and_then(Value::as_i64)
-            .and_then(|value| i32::try_from(value).ok()),
-        headline: required_string(&run_result, "headline")?.to_owned(),
-        inspect_hint: run_result
-            .get("inspect_hint")
-            .and_then(Value::as_str)
-            .map(ToOwned::to_owned),
-        diagnostics,
-        artifacts,
-        visible_bytes: serde_json::to_vec(&run_result)?.len(),
-        raw_text,
-    };
     Ok(LiveRun {
         observation,
         invocation_id,

--- a/crates/bazel-mcp-reducer-cases/src/mcp.rs
+++ b/crates/bazel-mcp-reducer-cases/src/mcp.rs
@@ -187,7 +187,6 @@ pub fn run_live_case(case: &LoadedCase, options: &LiveOptions) -> Result<LiveRun
             if let Ok(file) = fs::File::open(&path) {
                 let mut bytes = Vec::new();
                 file.take(8192).read_to_end(&mut bytes)?;
-                let normalized = String::from_utf8_lossy(&bytes).replace('\\', "/");
                 let paths = [
                     (
                         "RUNTIME",
@@ -205,18 +204,17 @@ pub fn run_live_case(case: &LoadedCase, options: &LiveOptions) -> Result<LiveRun
                         std::env::var("HOME").unwrap_or_default().replace('\\', "/"),
                     ),
                 ];
-                let replacements: Vec<_> = paths
-                    .iter()
-                    .map(|(label, path)| (*label, path.as_bytes()))
-                    .collect();
-                match crate::sanitize_text(normalized.as_bytes(), &replacements) {
+                match sanitize_startup_log(&bytes, &paths) {
                     Ok(text) => eprintln!(
                         "{}: JVM startup log: {}",
                         case.manifest.id,
                         String::from_utf8_lossy(&text)
                     ),
-                    Err(error) => {
-                        eprintln!("{}: JVM startup log withheld: {error}", case.manifest.id)
+                    Err(_) => {
+                        eprintln!(
+                            "{}: JVM startup log withheld because sanitization failed",
+                            case.manifest.id
+                        )
                     }
                 }
             }
@@ -382,5 +380,39 @@ impl McpClient {
 impl Drop for McpClient {
     fn drop(&mut self) {
         self.stop();
+    }
+}
+
+fn sanitize_startup_log(bytes: &[u8], paths: &[(&str, String)]) -> Result<Vec<u8>> {
+    let text = String::from_utf8_lossy(bytes).replace('\\', "/");
+    let normalized_paths: Vec<_> = paths
+        .iter()
+        .map(|(label, path)| (*label, path.replace('\\', "/")))
+        .collect();
+    let replacements: Vec<_> = normalized_paths
+        .iter()
+        .map(|(label, path)| (*label, path.as_bytes()))
+        .collect();
+    crate::sanitize_text(text.as_bytes(), &replacements)
+}
+
+#[cfg(test)]
+mod startup_log_tests {
+    use super::*;
+
+    #[test]
+    fn redacts_both_windows_path_separators_and_rejects_secrets() {
+        let paths = [("HOME", r"C:\Users\runneradmin".to_owned())];
+        for text in [
+            r"fatal: C:\Users\runneradmin\server\jvm.out",
+            "fatal: C:/Users/runneradmin/server/jvm.out",
+        ] {
+            let sanitized = sanitize_startup_log(text.as_bytes(), &paths).unwrap();
+            assert_eq!(
+                String::from_utf8(sanitized).unwrap(),
+                "fatal: <HOME>/server/jvm.out\n"
+            );
+        }
+        assert!(sanitize_startup_log(b"token=SECRET_SENTINEL", &paths).is_err());
     }
 }

--- a/crates/bazel-mcp-reducer-cases/src/mcp.rs
+++ b/crates/bazel-mcp-reducer-cases/src/mcp.rs
@@ -169,6 +169,20 @@ pub fn run_live_case(case: &LoadedCase, options: &LiveOptions) -> Result<LiveRun
             }),
         )?;
     }
+    if let Some(expected) = case.manifest.expect.exit_code
+        && run_result.get("exit_code").and_then(Value::as_i64) != Some(i64::from(expected))
+    {
+        let log = client.call_tool(
+            "bazel.inspect",
+            json!({
+                "invocation_id": &invocation_id,
+                "view": "log",
+                "limit": 100,
+                "max_bytes": 8192,
+            }),
+        )?;
+        eprintln!("{}: unexpected exit code; MCP log: {log}", case.manifest.id);
+    }
     client.stop();
 
     let diagnostics = run_result

--- a/crates/bazel-mcp-reducer-cases/src/semantics.rs
+++ b/crates/bazel-mcp-reducer-cases/src/semantics.rs
@@ -465,6 +465,18 @@ mod tests {
     }
 
     #[test]
+    fn unexpected_exit_reports_the_mcp_headline() {
+        let mut actual = observation();
+        actual.exit_code = Some(37);
+        let error = verify_expectations("cpp/link", &expected(), &actual).unwrap_err();
+        assert!(
+            error
+                .to_string()
+                .contains("observed Some(37): Bazel failed: missing symbol invoice_total")
+        );
+    }
+
+    #[test]
     fn reports_all_semantic_mismatches() {
         let mut actual = observation();
         actual.state = "succeeded".to_owned();

--- a/crates/bazel-mcp-reducer-cases/src/semantics.rs
+++ b/crates/bazel-mcp-reducer-cases/src/semantics.rs
@@ -68,8 +68,8 @@ pub fn verify_expectations(
         && actual.exit_code != Some(exit_code)
     {
         failures.push(format!(
-            "{case_id}: expected exit code {exit_code}, observed {:?}",
-            actual.exit_code
+            "{case_id}: expected exit code {exit_code}, observed {:?}: {}",
+            actual.exit_code, actual.headline
         ));
     }
     if let Some(headline) = &expected.headline_equals

--- a/crates/bazel-mcp-reducer/src/build.rs
+++ b/crates/bazel-mcp-reducer/src/build.rs
@@ -1598,6 +1598,31 @@ TypeError: Cannot read properties of undefined (reading 'lines')
     }
 
     #[test]
+    fn maps_windows_node_stack_frames_from_bazel_bin() {
+        let summary = reduce_invocation(ReductionInput {
+            events: &[],
+            stdout: b"",
+            stderr: br#"C:\cache\execroot\_main\bazel-out\x64_windows-fastbuild\bin\cases\runtime_failure.js:2
+TypeError: Cannot read properties of undefined (reading 'lines')
+    at invoiceTotal (C:\cache\execroot\_main\bazel-out\x64_windows-fastbuild\bin\cases\runtime_failure.js:2:18)
+"#,
+            exit_code: Some(3),
+            elapsed_ms: 1,
+            budget: Budget::result_default(),
+        });
+        let diagnostic = &summary.diagnostics[0];
+        assert_eq!(diagnostic.category, DiagnosticCategory::Test);
+        assert_eq!(
+            diagnostic.location,
+            Some(DiagnosticLocation {
+                path: "cases/runtime_failure.js".into(),
+                line: Some(2),
+                column: Some(18),
+            })
+        );
+    }
+
+    #[test]
     fn pairs_node_syntax_errors_with_the_source_header() {
         let summary = reduce_invocation(ReductionInput {
             events: &[],

--- a/crates/bazel-mcp-reducer/src/diagnostics/bazel.rs
+++ b/crates/bazel-mcp-reducer/src/diagnostics/bazel.rs
@@ -421,12 +421,23 @@ pub(crate) fn compact_bazel_path(path: &str) -> String {
             return relative.to_owned();
         }
     }
-    if let Some((_, after_execroot)) = path.rsplit_once("/execroot/")
+    let path = if let Some((_, after_execroot)) = path.rsplit_once("/execroot/")
         && let Some((_, relative)) = after_execroot.split_once('/')
+    {
+        relative
+    } else {
+        path.strip_prefix("./").unwrap_or(path)
+    };
+    // Rules may execute copied sources from the output tree instead of runfiles
+    // (notably rules_js on Windows). Remove only the known Bazel bin layout.
+    if let Some(output) = path.strip_prefix("bazel-out/")
+        && let Some((configuration, rest)) = output.split_once('/')
+        && !configuration.is_empty()
+        && let Some(relative) = rest.strip_prefix("bin/")
     {
         return relative.to_owned();
     }
-    path.strip_prefix("./").unwrap_or(path).to_owned()
+    path.to_owned()
 }
 
 #[cfg(test)]
@@ -443,7 +454,14 @@ mod tests {
             compact_bazel_path("/tmp/test.runfiles/_main/pkg/test.py"),
             "pkg/test.py"
         );
-        assert_eq!(compact_bazel_path("/opt/src/main.go"), "/opt/src/main.go");
+        for path in [
+            "/opt/src/main.go",
+            "/opt/bazel-out/config/bin/main.js",
+            "bazel-out/config/testlogs/pkg/test.log",
+            "bazel-out/config/genfiles/pkg/generated.h",
+        ] {
+            assert_eq!(compact_bazel_path(path), path);
+        }
     }
 
     #[test]

--- a/crates/bazel-mcp-runner/src/artifacts.rs
+++ b/crates/bazel-mcp-runner/src/artifacts.rs
@@ -72,7 +72,7 @@ pub(crate) fn local_artifact_path(artifact: &bazel_mcp_types::Artifact) -> Optio
         return None;
     }
     if let Some(path) = artifact.uri.strip_prefix("file://") {
-        return Some(PathBuf::from(path));
+        return Some(local_file_uri_path(path, cfg!(windows)));
     }
     let path = PathBuf::from(&artifact.uri);
     path.is_absolute().then_some(path)
@@ -101,4 +101,58 @@ fn bazel_test_log_output_base(path: &Path) -> Option<PathBuf> {
         return None;
     }
     Some(components[..execroot].iter().collect())
+}
+
+fn local_file_uri_path(path: &str, windows: bool) -> PathBuf {
+    // A file URI adds a slash before a Windows drive (file:///C:/...).
+    // Keeping it makes canonicalization look for a different, invalid path.
+    let bytes = path.as_bytes();
+    if windows
+        && bytes.len() >= 4
+        && bytes[0] == b'/'
+        && bytes[1].is_ascii_alphabetic()
+        && bytes[2..4] == *b":/"
+    {
+        PathBuf::from(&path[1..])
+    } else {
+        PathBuf::from(path)
+    }
+}
+
+#[cfg(test)]
+mod file_uri_tests {
+    use super::*;
+
+    #[test]
+    fn windows_drive_uri_drops_the_uri_root_slash() {
+        assert_eq!(
+            local_file_uri_path("/C:/cache/test.log", true),
+            PathBuf::from("C:/cache/test.log")
+        );
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn resolves_a_real_windows_test_log_uri() {
+        let root = tempfile::tempdir().unwrap();
+        let path = root.path().join("test.log");
+        std::fs::write(&path, "test evidence").unwrap();
+        let artifact = bazel_mcp_types::Artifact {
+            name: "test.log".to_owned(),
+            kind: ArtifactKind::TestLog,
+            uri: format!("file:///{}", path.to_string_lossy().replace('\\', "/")),
+            size_bytes: None,
+            locally_available: true,
+        };
+        let resolved = local_artifact_path(&artifact).unwrap();
+        assert_eq!(std::fs::read_to_string(resolved).unwrap(), "test evidence");
+    }
+
+    #[test]
+    fn unix_uri_keeps_the_root_slash() {
+        assert_eq!(
+            local_file_uri_path("/tmp/test.log", false),
+            PathBuf::from("/tmp/test.log")
+        );
+    }
 }

--- a/crates/bazel-mcp-runner/src/execution.rs
+++ b/crates/bazel-mcp-runner/src/execution.rs
@@ -1215,7 +1215,11 @@ impl InvocationService {
         for diagnostic in &mut summary.diagnostics {
             diagnostic.message = sanitize(&diagnostic.message, 1_000);
             if let Some(location) = &mut diagnostic.location {
-                let path = location.path.replace(workspace.as_ref(), "<workspace>");
+                let path = crate::path_args::workspace_relative_path(
+                    &location.path,
+                    workspace.as_ref(),
+                    cfg!(windows),
+                );
                 let path = path
                     .strip_prefix("<workspace>/")
                     .or_else(|| path.strip_prefix("<workspace>\\"))

--- a/crates/bazel-mcp-runner/src/execution.rs
+++ b/crates/bazel-mcp-runner/src/execution.rs
@@ -423,7 +423,10 @@ impl InvocationService {
             ExecutionDriver::Bazel { .. } => {
                 if let Some(output_user_root) = &self.config.output_user_root {
                     command
-                        .arg(format!("--output_user_root={}", output_user_root.display()))
+                        .arg(format!(
+                            "--output_user_root={}",
+                            crate::path_args::bazel_path(output_user_root)
+                        ))
                         .arg(format!(
                             "--max_idle_secs={}",
                             self.config.isolated_bazel_server_idle_timeout.as_secs()
@@ -437,7 +440,10 @@ impl InvocationService {
                     match bep_transport {
                         BepTransport::Tail => {
                             command
-                                .arg(format!("--build_event_binary_file={}", paths.bep.display()))
+                                .arg(format!(
+                                    "--build_event_binary_file={}",
+                                    crate::path_args::bazel_path(&paths.bep)
+                                ))
                                 .arg("--build_event_binary_file_path_conversion=false");
                         }
                         BepTransport::Fifo => {
@@ -448,7 +454,10 @@ impl InvocationService {
                             #[cfg(not(unix))]
                             let output = paths.bep.as_path();
                             command
-                                .arg(format!("--build_event_binary_file={}", output.display()))
+                                .arg(format!(
+                                    "--build_event_binary_file={}",
+                                    crate::path_args::bazel_path(output)
+                                ))
                                 .arg("--build_event_binary_file_path_conversion=false");
                         }
                         BepTransport::Bes => {
@@ -514,7 +523,7 @@ impl InvocationService {
                     command
                         .arg(format!(
                             "--bazel-startup-flag=--output_user_root={}",
-                            output_user_root.display()
+                            crate::path_args::bazel_path(output_user_root)
                         ))
                         .arg(format!(
                             "--bazel-startup-flag=--max_idle_secs={}",
@@ -1444,7 +1453,10 @@ async fn probe_bazel_server_pid(
         .envs(filtered_environment(&config.policy));
     if let Some(output_user_root) = &config.output_user_root {
         command
-            .arg(format!("--output_user_root={}", output_user_root.display()))
+            .arg(format!(
+                "--output_user_root={}",
+                crate::path_args::bazel_path(output_user_root)
+            ))
             .arg(format!(
                 "--max_idle_secs={}",
                 config.isolated_bazel_server_idle_timeout.as_secs()

--- a/crates/bazel-mcp-runner/src/lib.rs
+++ b/crates/bazel-mcp-runner/src/lib.rs
@@ -8,6 +8,7 @@ mod evidence;
 mod execution;
 mod inspection;
 mod output_base_lock;
+mod path_args;
 mod scheduler;
 mod service;
 mod test_evidence;

--- a/crates/bazel-mcp-runner/src/path_args.rs
+++ b/crates/bazel-mcp-runner/src/path_args.rs
@@ -24,6 +24,29 @@ fn windows_bazel_path(path: &str) -> String {
     path.to_owned()
 }
 
+pub(crate) fn workspace_relative_path(path: &str, workspace: &str, windows: bool) -> String {
+    let (path, workspace) = if windows {
+        (
+            windows_bazel_path(path).replace('\\', "/"),
+            windows_bazel_path(workspace).replace('\\', "/"),
+        )
+    } else {
+        (path.to_owned(), workspace.to_owned())
+    };
+    let workspace = workspace.trim_end_matches('/');
+    let matches = path.get(..workspace.len()).is_some_and(|prefix| {
+        if windows {
+            prefix.eq_ignore_ascii_case(workspace)
+        } else {
+            prefix == workspace
+        }
+    });
+    if matches && let Some(relative) = path[workspace.len()..].strip_prefix('/') {
+        return relative.to_owned();
+    }
+    path
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -41,6 +64,34 @@ mod tests {
         assert_eq!(
             windows_bazel_path(r"\\?\UNC\server\share\events.bep"),
             r"\\server\share\events.bep"
+        );
+    }
+
+    #[test]
+    fn windows_workspace_paths_match_bazel_spelling_and_case() {
+        let workspace = r"\\?\D:\a\bazel-mcp\examples\starlark";
+        for path in [
+            "D:/a/bazel-mcp/examples/starlark/cases/analysis/defs.bzl",
+            r"d:\a\BAZEL-MCP\examples\starlark\cases\analysis\defs.bzl",
+        ] {
+            assert_eq!(
+                workspace_relative_path(path, workspace, true),
+                "cases/analysis/defs.bzl"
+            );
+        }
+        let sibling = "D:/a/bazel-mcp/examples/starlark-other/defs.bzl";
+        assert_eq!(workspace_relative_path(sibling, workspace, true), sibling);
+    }
+
+    #[test]
+    fn unix_workspace_paths_remain_case_sensitive() {
+        assert_eq!(
+            workspace_relative_path("/repo/pkg/main.go", "/repo", false),
+            "pkg/main.go"
+        );
+        assert_eq!(
+            workspace_relative_path("/REPO/pkg/main.go", "/repo", false),
+            "/REPO/pkg/main.go"
         );
     }
 

--- a/crates/bazel-mcp-runner/src/path_args.rs
+++ b/crates/bazel-mcp-runner/src/path_args.rs
@@ -1,0 +1,58 @@
+use std::path::Path;
+
+pub(crate) fn bazel_path(path: &Path) -> String {
+    let path = path.to_string_lossy();
+    if cfg!(windows) {
+        windows_bazel_path(&path)
+    } else {
+        path.into_owned()
+    }
+}
+
+fn windows_bazel_path(path: &str) -> String {
+    // Canonical Windows filesystem paths use the verbatim prefix, but Bazel's
+    // Java filesystem rejects it in file-valued command-line flags.
+    if let Some(unc) = path.strip_prefix(r"\\?\UNC\") {
+        return format!(r"\\{unc}");
+    }
+    if let Some(drive) = path.strip_prefix(r"\\?\") {
+        let bytes = drive.as_bytes();
+        if bytes.len() >= 3 && bytes[0].is_ascii_alphabetic() && bytes[1..3] == *b":\\" {
+            return drive.to_owned();
+        }
+    }
+    path.to_owned()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn canonical_drive_path_is_compatible_with_bazels_java_parser() {
+        assert_eq!(
+            windows_bazel_path(r"\\?\C:\Users\runner\cache space\events.bep"),
+            r"C:\Users\runner\cache space\events.bep"
+        );
+    }
+
+    #[test]
+    fn canonical_unc_path_keeps_its_network_root() {
+        assert_eq!(
+            windows_bazel_path(r"\\?\UNC\server\share\events.bep"),
+            r"\\server\share\events.bep"
+        );
+    }
+
+    #[test]
+    fn ordinary_paths_and_device_names_are_unchanged() {
+        for path in [
+            r"C:\cache\events.bep",
+            r"\\server\share\events.bep",
+            r"\\?\Volume{abc}\file",
+            "/tmp/events.bep",
+        ] {
+            assert_eq!(windows_bazel_path(path), path);
+        }
+    }
+}

--- a/scripts/test-mcp-smoke.py
+++ b/scripts/test-mcp-smoke.py
@@ -171,7 +171,7 @@ def main():
         ("build_success", "build", ["//:ok"], 0, "succeeded", 60),
         ("loading_failure", "build", ["//:missing"], 1, "failed", 60),
         ("action_failure", "build", ["//:action_failure"], 1, "failed", 60),
-        ("test_success", "test", ["//:test_success"], 0, "succeeded", 60),
+        ("test_success", "test", ["//:test_success"], 0, "succeeded", 180),
         ("test_failure", "test", ["//:test_failure"], 3, "failed", 60),
         ("coverage", "coverage", ["//:test_success"], 0, "succeeded", 60),
         ("query", "query", ["//..."], 0, "succeeded", 60),
@@ -194,7 +194,8 @@ def main():
     for request_id, (name, command, command_args, exit_code, state, timeout) in enumerate(cases, 2):
         result = call(process, request_id, args.workspace, command, command_args, timeout)
         if result["state"] != state or result.get("exit_code") != exit_code:
-            raise RuntimeError(f"{name} mismatch: {result}")
+            log = inspect(process, request_id + 1000, result["invocation_id"], "log")
+            raise RuntimeError(f"{name} mismatch: {result}; MCP log: {log}")
         print(f"{name}\t{result['state']}\t{result.get('exit_code')}")
     query_result = call(
         process, 100, args.workspace, "query", ["filter('^//:large_', //:*)"], 60


### PR DESCRIPTION
## Summary

Restore the scheduled reducer platform matrix on macOS and Windows. macOS lacked Go for installing Bazelisk. Windows failures exposed missing runtime/toolchain environment, incompatible or overlong file paths, unavailable test logs, and diagnostic paths that did not match the source workspace. The fixes let every supported live case reach and verify its intended failure on both Bazel versions.

## Changes

- Install pinned Go before Bazelisk in reducer integration jobs, discover the Windows Visual C++ installation with vswhere, and explicitly allow its location and system-directory variables in the live harness.
- Preserve `SystemRoot` and match environment allowlists case-insensitively on Windows; keep Unix behavior unchanged.
- Convert internally generated Bazel file arguments from verbatim Windows drive/UNC paths to ordinary paths, retaining canonical paths for filesystem access.
- Resolve Windows `file:///C:/...` test-log URIs to the native drive path so failed-test evidence remains available.
- Normalize stack frames from Bazel bin outputs, including Windows rules_js copied sources, to configuration-independent paths. Match Windows workspace prefixes across canonical/verbatim spelling, slash styles, and letter case without matching sibling directories.
- Use a short Windows runtime root to keep native compiler response-file paths below MAX_PATH (the failing Abseil path was 263 characters).
- Include the MCP headline, bounded inspected log, and sanitized JVM startup excerpt when live contracts fail. Cover Windows path normalization and secret rejection.
- Give the first successful smoke test 180 seconds for cold test setup after repeated 60-second CI timeouts; preserve the dedicated one-second timeout case.
- Record the remaining MCP startup-diagnostic gap in `LEARNINGS.md`.

## Test plan

- Environment regression failed before the fix and passed afterward, including Unix and secret-filtering cases.
- Drive/UNC path regressions failed before conversion and passed afterward; ordinary paths and device names stay unchanged.
- Startup-log sanitization and diagnostic-reporting tests passed.
- `make check`, full `make test`, and `make hawk` passed on the current head (zero Hawk findings).
- Windows workspace path regressions cover slash/case differences and sibling boundaries; Unix remains case-sensitive.
- Windows Node stack-frame regression failed before the fix and passed afterward.
- File-URI regression failed before the fix and passed afterward; a native Windows test opens a real test-log file through its URI.
- All six live platform jobs passed on commit `9530946`: Linux, macOS, and Windows with Bazel 8.4.2 and 9.2.0. All three replay jobs also passed: [full scheduled matrix](https://github.com/ewhauser/bazel-mcp/actions/runs/34275583377).
- All 21 applicable PR checks passed on the same commit, including fuzz smoke and Windows release smoke.

## Risks

Environment filtering and native-path conversion changes are Windows-specific. Diagnostic compaction recognizes Bazel output layouts on every platform. No fixtures are blessed or skipped, and the three-tool MCP surface stays unchanged. Startup-log excerpts are bounded to 8 KiB and withheld if sanitization fails.
